### PR TITLE
Fixing MessageKit XCFramework

### DIFF
--- a/swift/Cartfile
+++ b/swift/Cartfile
@@ -1,3 +1,3 @@
-github "MessageKit/MessageKit" "3.7.0"
+github "MessageKit/MessageKit" "3.4.2"
 github "nathantannar4/InputBarAccessoryView" "5.4.0"
 github "zeroc-ice/ice" "v3.7.7"

--- a/swift/Cartfile.resolved
+++ b/swift/Cartfile.resolved
@@ -1,4 +1,4 @@
-github "MessageKit/MessageKit" "3.7.0"
+github "MessageKit/MessageKit" "3.4.2"
 github "mxcl/PromiseKit" "6.15.3"
 github "nathantannar4/InputBarAccessoryView" "5.4.0"
 github "zeroc-ice/ice" "v3.7.7"

--- a/swift/Chat/Info.plist
+++ b/swift/Chat/Info.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>Chat</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -22,8 +24,6 @@
 	<true/>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreenBackground</string>
-	<key>UIMainStoryboardFile</key>
-	<string>Main</string>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>armv7</string>

--- a/swift/demos.xcodeproj/project.pbxproj
+++ b/swift/demos.xcodeproj/project.pbxproj
@@ -7,329 +7,323 @@
 	objects = {
 
 /* Begin PBXAggregateTarget section */
-		31999E35AD68722C990CAFDD /* allDemos macOS */ = {
+		22B9E10BE8EB9E6CF5B5DDDC /* allDemos iOS */ = {
 			isa = PBXAggregateTarget;
-			buildConfigurationList = 91CFEFF5E725F23A39F19AD3 /* Build configuration list for PBXAggregateTarget "allDemos macOS" */;
+			buildConfigurationList = 6AD851E6F69695DE19EA2C94 /* Build configuration list for PBXAggregateTarget "allDemos iOS" */;
 			buildPhases = (
 			);
 			dependencies = (
-				8642B58056EEFCDE51A7487C /* PBXTargetDependency */,
-				CDE843D008407AFEA297381C /* PBXTargetDependency */,
-				B7D276A5B0AB292D9C39BC99 /* PBXTargetDependency */,
-				9B478DA634B9080BB3BF17B8 /* PBXTargetDependency */,
-				4B11F505145FD07325AE4D3B /* PBXTargetDependency */,
-				3A4EC9DEF376C8A2C2E2457A /* PBXTargetDependency */,
-				39FECAC6848FBBB8781C14DB /* PBXTargetDependency */,
-				97C1AE5BB572FAC6FA23652C /* PBXTargetDependency */,
-				B422DFAA60337F3CD152DCC1 /* PBXTargetDependency */,
-				24AACACA2C3C1F5D5A6CF027 /* PBXTargetDependency */,
-				00B75381BE2E52F48EBC5140 /* PBXTargetDependency */,
-				B971437E6D70C55A12E1FDBC /* PBXTargetDependency */,
-				250E3F02C2BE3DB314C33E9D /* PBXTargetDependency */,
-				D55DF6A601457DF20F0C0C0C /* PBXTargetDependency */,
-				038ED7F75A5BCFF70973AF20 /* PBXTargetDependency */,
-				29C15E18FACE12B826CC602A /* PBXTargetDependency */,
-				51FFF76CF4FAAF2BD34E6C32 /* PBXTargetDependency */,
-				612164092DAD6EE1D0AB8B85 /* PBXTargetDependency */,
-				23D414EA07E1AFD5004D88D6 /* PBXTargetDependency */,
-				FD5858CA3B99530B41B9A412 /* PBXTargetDependency */,
-				08AEF213CAED9BF2856DEFB4 /* PBXTargetDependency */,
-				274B653A9DCD88E484951978 /* PBXTargetDependency */,
-				E9F172792E6793986D995EFF /* PBXTargetDependency */,
-				50BB4A971C2479A9227AE981 /* PBXTargetDependency */,
-				8F0AA37B537B93BE444DD675 /* PBXTargetDependency */,
-				18347D6FA0FECAC333A54628 /* PBXTargetDependency */,
-				8C1BBD9E0AB1286274578416 /* PBXTargetDependency */,
-				4359A7D36CEC11510E4E18D3 /* PBXTargetDependency */,
-				C61207F300A72A690664152B /* PBXTargetDependency */,
-				3E8863DF944743A87E76EB2C /* PBXTargetDependency */,
-				1BD6BCFE0865FBFFD3BCCD7E /* PBXTargetDependency */,
-				F91F7471A68B14B4E740FE87 /* PBXTargetDependency */,
-				C08105BB25A45067CAB1DE1B /* PBXTargetDependency */,
-				0FCDFFCC3FAF47DE74413225 /* PBXTargetDependency */,
-				F31F06743418391112B9156A /* PBXTargetDependency */,
-				1577F9299978B3890A54E257 /* PBXTargetDependency */,
-			);
-			name = "allDemos macOS";
-			productName = "allDemos macOS";
-		};
-		50404C35B730F02C93AF4914 /* allDemos iOS */ = {
-			isa = PBXAggregateTarget;
-			buildConfigurationList = 2B1D739A5ABDFE7403B6979A /* Build configuration list for PBXAggregateTarget "allDemos iOS" */;
-			buildPhases = (
-			);
-			dependencies = (
-				AC0ED34772EFEE4878163911 /* PBXTargetDependency */,
-				E6AAA4689E95C4E7FEF48CE9 /* PBXTargetDependency */,
-				6EEE960E0AF569D8D84BF275 /* PBXTargetDependency */,
+				FA71B179D01BD4D9F0637DE8 /* PBXTargetDependency */,
+				F9F8D085703B8CAC45BF9243 /* PBXTargetDependency */,
+				32D404291A138CBF7445457D /* PBXTargetDependency */,
 			);
 			name = "allDemos iOS";
 			productName = "allDemos iOS";
 		};
+		659409F48B20801489DA468F /* allDemos macOS */ = {
+			isa = PBXAggregateTarget;
+			buildConfigurationList = B59022905C78425FE7C63286 /* Build configuration list for PBXAggregateTarget "allDemos macOS" */;
+			buildPhases = (
+			);
+			dependencies = (
+				7089618FD8A699A719F28D5F /* PBXTargetDependency */,
+				EA5671547B692482337FD413 /* PBXTargetDependency */,
+				793754CF654E1426BD7E66FB /* PBXTargetDependency */,
+				8B44D35DB33B5415B29E52A3 /* PBXTargetDependency */,
+				C4DEF31513B56972675327B8 /* PBXTargetDependency */,
+				57BAB662204CF9021499D0F3 /* PBXTargetDependency */,
+				BF8CF25EA66E3620D7053049 /* PBXTargetDependency */,
+				FE3B17ECCECE2198CF0A6A3C /* PBXTargetDependency */,
+				579022A6C784181BEA957D2F /* PBXTargetDependency */,
+				D22999AB39F8CDC111B6000A /* PBXTargetDependency */,
+				B8E6F4C7424A84ED74B88335 /* PBXTargetDependency */,
+				4082A1D396FDAC8BF191CBDE /* PBXTargetDependency */,
+				5E9EBDF97052E70FC2CCEC1B /* PBXTargetDependency */,
+				637E05839E642841783A90D3 /* PBXTargetDependency */,
+				98D3E2467E544C3CDCCBD2BE /* PBXTargetDependency */,
+				0E9C60E366FA1091486E9FB9 /* PBXTargetDependency */,
+				42F7418347052AC796518BE4 /* PBXTargetDependency */,
+				582F0A2D6DE95524F1F3D962 /* PBXTargetDependency */,
+				D8C278C6C249D8CD61E50127 /* PBXTargetDependency */,
+				01DD30D29654DEED9C4A7C89 /* PBXTargetDependency */,
+				2ACFC4CA2E9E4A7818C42288 /* PBXTargetDependency */,
+				D7DC377DE69F289B38B05FB5 /* PBXTargetDependency */,
+				C3CAB674ECB6C48279B430AB /* PBXTargetDependency */,
+				0B15DF218F143DA698BB5B4C /* PBXTargetDependency */,
+				6560E1FBF39DB646E9AB8B3E /* PBXTargetDependency */,
+				A5F2B36B1AE7D7B006420AA1 /* PBXTargetDependency */,
+				1732FC86934641DD7C82ED54 /* PBXTargetDependency */,
+				F9CA7967F0940009623A811F /* PBXTargetDependency */,
+				7247F613DE578A0B4069F821 /* PBXTargetDependency */,
+				037B66B1DF156544A0C981E2 /* PBXTargetDependency */,
+				DA25943E0D914247B65BA4A1 /* PBXTargetDependency */,
+				951D1991CEAC4320B6D10942 /* PBXTargetDependency */,
+				689CE6F4DF1663CB744F9ACA /* PBXTargetDependency */,
+				49EF65C7366CE4013C26ACB2 /* PBXTargetDependency */,
+				168B9AF410BA123F0331368B /* PBXTargetDependency */,
+				EA8278621D3263AB19531A65 /* PBXTargetDependency */,
+			);
+			name = "allDemos macOS";
+			productName = "allDemos macOS";
+		};
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
-		010D85C5494670D31D3847FF /* IceImpl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = DC44E9365BDEFE5223CA9AC7 /* IceImpl.xcframework */; };
-		012744D82CE3F807640D2CFB /* Latency.ice in Sources */ = {isa = PBXBuildFile; fileRef = AE6F2AD2D3EF1EAE5E359219 /* Latency.ice */; };
-		04A0558D9FC21428ADDEB063 /* IceImpl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 44E2EF3378D9F7C7F0D447C2 /* IceImpl.xcframework */; };
-		04B7C8E052A627FA98A73090 /* AuthenticatorI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86E08919DF7384C8501E200E /* AuthenticatorI.swift */; };
-		04BFD2897CE795156CA4484F /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63215B9BDD9CB595E01658F8 /* main.swift */; };
-		072AE5C5B9D219C970838CF3 /* IceStorm.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = C1C7EFC80BA45C6FAB2C053C /* IceStorm.xcframework */; };
-		0980C8A0AF7B12D75EDBCE00 /* PromiseKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = E33F8EBD6359013AE72CB2C7 /* PromiseKit.xcframework */; };
-		0A83DFF290810DDE023BCA4B /* IceImpl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 44E2EF3378D9F7C7F0D447C2 /* IceImpl.xcframework */; };
-		0B042FABD01D18992298159D /* IceImpl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 44E2EF3378D9F7C7F0D447C2 /* IceImpl.xcframework */; };
-		0E1ED2CEBFCDFB533DEB0740 /* PromiseKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = E33F8EBD6359013AE72CB2C7 /* PromiseKit.xcframework */; };
-		0EE2A7BC3A329D5940D3DEDD /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564EEE78D51984E4FC201895 /* main.swift */; };
-		0EE72299D3E516D8DD28FA12 /* Glacier2.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F40534B11EFC9339CC9F490 /* Glacier2.xcframework */; };
-		0F0E266C863347E471DF073D /* Callback.ice in Sources */ = {isa = PBXBuildFile; fileRef = 6827D0D0191C586EC4231BA4 /* Callback.ice */; };
-		0F86E98A896E81691C4D51A1 /* PromiseKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = E33F8EBD6359013AE72CB2C7 /* PromiseKit.xcframework */; };
-		112E3B4FF1F871DBBCC5DF1B /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 062D4FF632571C9B1EE57EDA /* main.swift */; };
-		13C6818DF564007890DB1402 /* InputBarAccessoryView.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 6D76908AFC77A69CC01C4A45 /* InputBarAccessoryView.xcframework */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
-		13D9F98A3C5D4DBDBB0CAE9E /* IceImpl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 44E2EF3378D9F7C7F0D447C2 /* IceImpl.xcframework */; };
-		1424ADB885E8084865CCE88E /* IceImpl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 44E2EF3378D9F7C7F0D447C2 /* IceImpl.xcframework */; };
-		1515090A8F460C2A8D4143CB /* IceImpl.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = DC44E9365BDEFE5223CA9AC7 /* IceImpl.xcframework */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
-		15901BA8CE490342871BB691 /* Clock.ice in Sources */ = {isa = PBXBuildFile; fileRef = 8328076C5A54A89E5C1C6A77 /* Clock.ice */; };
-		15BFCF206A9046ED582E38A5 /* Ice.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 28C558DB55A446508E4FF509 /* Ice.xcframework */; };
-		15CA12B9AFA3979AD3405EE1 /* Main.storyboard in Sources */ = {isa = PBXBuildFile; fileRef = 4DCF7B3212E070F32DE5D06F /* Main.storyboard */; };
-		16841EEC752AE669FF860A28 /* IceImpl.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = DC44E9365BDEFE5223CA9AC7 /* IceImpl.xcframework */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
-		16D343280A66EDF32939167D /* PromiseKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = E33F8EBD6359013AE72CB2C7 /* PromiseKit.xcframework */; };
-		17B436C46CBC6530BEEDC9CC /* IceImpl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 44E2EF3378D9F7C7F0D447C2 /* IceImpl.xcframework */; };
-		189CC8E44C24B682E5B73B74 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EA465016479DB7783F7D599 /* main.swift */; };
-		1A81751D6FC13419374B6429 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE4AC0DC09B8774590AF2DDF /* main.swift */; };
-		1B94DF311587E4C491B9C4B5 /* EditController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6643D756BFA7EEC23DC768D2 /* EditController.swift */; };
-		1B9C9E0C4DB51B04A6A3F136 /* PrinterI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7141F96B9E1438EE1FD9324B /* PrinterI.swift */; };
-		1BAE8F95CB7C6BEFED6CE195 /* Ice.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 28C558DB55A446508E4FF509 /* Ice.xcframework */; };
-		1C78C756E2DA1373D19BAEF6 /* IceGrid.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = FA3BF90C0656239819A25831 /* IceGrid.xcframework */; };
-		1CBA9A8CACDC460BD2BAA1F4 /* PromiseKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = E33F8EBD6359013AE72CB2C7 /* PromiseKit.xcframework */; };
-		1E25458997C9E03CC9D1F3DF /* Ice.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 28C558DB55A446508E4FF509 /* Ice.xcframework */; };
-		1E45A049C3A91106DB101B7F /* Ice.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 28C558DB55A446508E4FF509 /* Ice.xcframework */; };
-		1F2551E5A9356F2454BA465D /* Ice.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 28C558DB55A446508E4FF509 /* Ice.xcframework */; };
-		1F3517AEDC557C489BCDF1DF /* Hello.ice in Sources */ = {isa = PBXBuildFile; fileRef = 8D28BE3CE7F6D7DFC1075304 /* Hello.ice */; };
-		1F3B340EF766BA61F0B08CD2 /* Calculator.ice in Sources */ = {isa = PBXBuildFile; fileRef = 16DBCF84A11CA84DB546F2A8 /* Calculator.ice */; };
-		21FC9E3C3F7CE1ED1AD557EE /* LoadingButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17C01B6B96D318BD91BCCED7 /* LoadingButton.swift */; };
-		234635F2E2E0A92EF117F799 /* Ice.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 28C558DB55A446508E4FF509 /* Ice.xcframework */; };
-		23BB952CB080EB7669E7CA4B /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB86282C2355E1B10F369CC5 /* main.swift */; };
-		273F47D0B153EC4DDC78EDD3 /* Calculator.ice in Sources */ = {isa = PBXBuildFile; fileRef = 16DBCF84A11CA84DB546F2A8 /* Calculator.ice */; };
-		27495FC8BBD356C1986E5C9C /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7011BF01BCEDBFABCB6AAB74 /* main.swift */; };
-		28015B80AD567473CB9BD951 /* Ice.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 28C558DB55A446508E4FF509 /* Ice.xcframework */; };
-		2B9B3A87867530BD576120D0 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA3625DECE4A1AD3E1926870 /* AppDelegate.swift */; };
-		2C9DA92045119442FC6B8234 /* Context.ice in Sources */ = {isa = PBXBuildFile; fileRef = 38D692F7A1A59D07B3A84D38 /* Context.ice */; };
-		2DEFBEAAEB28F486953FFCEA /* PromiseKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = E33F8EBD6359013AE72CB2C7 /* PromiseKit.xcframework */; };
-		2EAFB94822311181E29CA8F7 /* IceImpl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 44E2EF3378D9F7C7F0D447C2 /* IceImpl.xcframework */; };
-		2EDB13AC30D1B2BAB8486797 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAB0E574877C807BE5637963 /* main.swift */; };
-		2EE0B1D1A32AFC2ED595953E /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE06C1F13EC4D1CDBC4FBC70 /* AppDelegate.swift */; };
-		2F186674718752E7EA886C86 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFABB932D97DA909193B1439 /* main.swift */; };
-		2F68EBF269EFB214472DED67 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 452D5F978671BA38A3F94EB3 /* main.swift */; };
-		2F7C8F68BFC15C852834A877 /* Ice.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 28C558DB55A446508E4FF509 /* Ice.xcframework */; };
-		2FA106B4CD04CEBA8699EBFB /* IceImpl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 44E2EF3378D9F7C7F0D447C2 /* IceImpl.xcframework */; };
-		31E1105448CF166A2CF40272 /* IceImpl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 44E2EF3378D9F7C7F0D447C2 /* IceImpl.xcframework */; };
-		32FCFBF7FF2F3B3C0630438C /* PromiseKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = E33F8EBD6359013AE72CB2C7 /* PromiseKit.xcframework */; };
-		339D867D3A90AC35F69F9A14 /* Glacier2.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6A9CC980FC134C230BC7EF63 /* Glacier2.xcframework */; };
-		3498E8508C2A552C7FF1638C /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CA1965D308C6B95B2D02B01 /* main.swift */; };
-		3680F02DE13628156E750A59 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00E639D7AAB89720BD2AF551 /* main.swift */; };
-		372E84B694977688A6DA39E9 /* IceImpl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 44E2EF3378D9F7C7F0D447C2 /* IceImpl.xcframework */; };
-		37C24239D197F413D4ECF065 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD67B4FA75F306DC428A91EC /* main.swift */; };
-		3A0DC095BA2E9C7244937739 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A2F7EE4FA803841AEE05E6 /* main.swift */; };
-		3B02135314675381F031D66D /* Hello.ice in Sources */ = {isa = PBXBuildFile; fileRef = 0BF7011B044009FEDA7643A3 /* Hello.ice */; };
-		3BDB6BCD538D6558C0A3C2B6 /* Hello.ice in Sources */ = {isa = PBXBuildFile; fileRef = F845036D52ADEC64757D9E9E /* Hello.ice */; };
-		3D14CB80099CE2B13789175C /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF3CBA7BB3733BC3DFB8B8F3 /* main.swift */; };
-		3D95FB75CC06B9E689D22056 /* PromiseKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = E33F8EBD6359013AE72CB2C7 /* PromiseKit.xcframework */; };
-		3E9E4613BD8A3E2323C541D1 /* Hello.ice in Sources */ = {isa = PBXBuildFile; fileRef = F59BA32210DDA4AF9E06A751 /* Hello.ice */; };
-		3EDD9E4DE42C8D14C9FB73FD /* ChatMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9169D28F09D967F0B93C7D8A /* ChatMessage.swift */; };
-		400676150E41886CDC538B15 /* Hello.ice in Sources */ = {isa = PBXBuildFile; fileRef = 0BF7011B044009FEDA7643A3 /* Hello.ice */; };
-		402F87AC13D27D7F50EEB2C5 /* Ice.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D79B76AFF6799725A4428FD2 /* Ice.xcframework */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
-		4092F0E6F262FDBCF7BE4D3B /* Ice.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D79B76AFF6799725A4428FD2 /* Ice.xcframework */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
-		420E92FAB38094109B605E30 /* Library.ice in Sources */ = {isa = PBXBuildFile; fileRef = 48B5E1B84C2F4810AF3BE092 /* Library.ice */; };
-		429DA72EB010FE720D6C742B /* IceImpl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 44E2EF3378D9F7C7F0D447C2 /* IceImpl.xcframework */; };
-		439A5E7ECBB679919168E539 /* Hello.ice in Sources */ = {isa = PBXBuildFile; fileRef = 401F230285604E1ADBEA9689 /* Hello.ice */; };
-		453B1346DCC826C7D38743FE /* PromiseKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = E33F8EBD6359013AE72CB2C7 /* PromiseKit.xcframework */; };
-		4545A79BFD233609A902A7FA /* Ice.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = D79B76AFF6799725A4428FD2 /* Ice.xcframework */; };
-		468989FA8DFC289779572BA4 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1417615123189DBFB739754 /* main.swift */; };
-		47898C1018717BA2AC5717B0 /* PromiseKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = E33F8EBD6359013AE72CB2C7 /* PromiseKit.xcframework */; };
-		483D5387F14E39E25E350437 /* PromiseKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = E33F8EBD6359013AE72CB2C7 /* PromiseKit.xcframework */; };
-		4A845BF3450D904C2282B13B /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE183346DF16C34D553A5778 /* main.swift */; };
-		4ACBAC8E58E91869B15ED860 /* Hello.ice in Sources */ = {isa = PBXBuildFile; fileRef = E766A925498F62424246E54C /* Hello.ice */; };
-		4AEC65F139DDB25046B451B1 /* PromiseKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = E33F8EBD6359013AE72CB2C7 /* PromiseKit.xcframework */; };
-		4C6010C454D09DAE9709BD29 /* IceImpl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 44E2EF3378D9F7C7F0D447C2 /* IceImpl.xcframework */; };
-		4CFE45787F5217A9950FA6A6 /* IceImpl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 44E2EF3378D9F7C7F0D447C2 /* IceImpl.xcframework */; };
-		4D5EEB90EA6B18683BE01774 /* IceImpl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 44E2EF3378D9F7C7F0D447C2 /* IceImpl.xcframework */; };
-		4D7FC87F7E92C427A0E2138E /* LaunchScreen.storyboard in Sources */ = {isa = PBXBuildFile; fileRef = 560295E3FB26C30FE4279071 /* LaunchScreen.storyboard */; };
-		4E3A78D8A36A5671A7457522 /* Session.ice in Sources */ = {isa = PBXBuildFile; fileRef = A488AF4C5BBD8776F8442C44 /* Session.ice */; };
-		4E3E21C843024411503857E0 /* MessageKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 32029539794EF0F1BBB97D18 /* MessageKit.xcframework */; };
-		4E74FA37692914846608E9B3 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 962F08EBB1AD8F2EDDCA79C2 /* main.swift */; };
-		4F5D7905876A913D13DD1DBF /* Hello.ice in Sources */ = {isa = PBXBuildFile; fileRef = E766A925498F62424246E54C /* Hello.ice */; };
-		50AE3EC343B91A0E47763DC8 /* PromiseKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = E33F8EBD6359013AE72CB2C7 /* PromiseKit.xcframework */; };
-		50DA129B13907FCF6A5F813A /* Contact.ice in Sources */ = {isa = PBXBuildFile; fileRef = 0942CEA562FE56F14AE24E39 /* Contact.ice */; };
-		526E06AF28894ACB154AAFA5 /* Glacier2.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9F40534B11EFC9339CC9F490 /* Glacier2.xcframework */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
-		532F3CD26CB44774FFF3D9D9 /* LaunchScreen.storyboard in Sources */ = {isa = PBXBuildFile; fileRef = 7451971287B9F34894391172 /* LaunchScreen.storyboard */; };
-		542EAE25A13DA2240AF9C95E /* ChatUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 115E221C6424603632377848 /* ChatUser.swift */; };
-		568C45B6E3CCDC02B17E3995 /* PromiseKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = E33F8EBD6359013AE72CB2C7 /* PromiseKit.xcframework */; };
-		58071923E4C69FFB2574B507 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA4598F4AC7F620B4079E250 /* main.swift */; };
-		5B4D9A6E5418BF3F5F650D18 /* IceGrid.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = FA3BF90C0656239819A25831 /* IceGrid.xcframework */; };
-		5C5F43408464276C03A402FA /* PromiseKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = E33F8EBD6359013AE72CB2C7 /* PromiseKit.xcframework */; };
-		5E29756E2FF8DCD9F3375442 /* Clock.ice in Sources */ = {isa = PBXBuildFile; fileRef = 8328076C5A54A89E5C1C6A77 /* Clock.ice */; };
-		5F4BCCD1C1597091894D5087 /* Ice.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 28C558DB55A446508E4FF509 /* Ice.xcframework */; };
-		628C34FA5FB884EF359DECEA /* Images.xcassets in Sources */ = {isa = PBXBuildFile; fileRef = 4D8C4A502C81A17810483EAC /* Images.xcassets */; };
-		6318FEB5B6183174B6497494 /* Ice.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 28C558DB55A446508E4FF509 /* Ice.xcframework */; };
-		653C099B7C3B794B537D571E /* CalculatorI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CC9437BF449759BC05DF17E /* CalculatorI.swift */; };
-		658346FE10B77C5117F52905 /* MainController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9C206C3CF068A0923D1B6BE /* MainController.swift */; };
-		65B3E44AA5FA99BAF02DF56C /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5300F0985211B122CE67D3DE /* main.swift */; };
-		65CF4660E805EB5C1CA542A3 /* Ice.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 28C558DB55A446508E4FF509 /* Ice.xcframework */; };
-		667423DCF8AE97EBE57B7FA4 /* PromiseKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = E33F8EBD6359013AE72CB2C7 /* PromiseKit.xcframework */; };
-		66B6C551108EBF774A13EC3E /* Ice.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 28C558DB55A446508E4FF509 /* Ice.xcframework */; };
-		681C86B6B39F63097347A465 /* IceImpl.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = DC44E9365BDEFE5223CA9AC7 /* IceImpl.xcframework */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
-		687B1ADE5368310A18CB30E0 /* Interceptor.ice in Sources */ = {isa = PBXBuildFile; fileRef = BA319441718A4B4410187238 /* Interceptor.ice */; };
-		68A0A99C32C90CD022686DE6 /* IceImpl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 44E2EF3378D9F7C7F0D447C2 /* IceImpl.xcframework */; };
-		696DF9C8A7E0EE94DA879672 /* Main.storyboard in Sources */ = {isa = PBXBuildFile; fileRef = 89D4B0BEAB0413B93B185EA9 /* Main.storyboard */; };
-		6ABE0273F66CD4180A22CA27 /* Hello.ice in Sources */ = {isa = PBXBuildFile; fileRef = 401F230285604E1ADBEA9689 /* Hello.ice */; };
-		6B3CA6C95C71045A113D4802 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0EFBEDB18F101F76F3B4348 /* main.swift */; };
-		6B83E8CE89C9E0716F63A044 /* InputBarAccessoryView.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6D76908AFC77A69CC01C4A45 /* InputBarAccessoryView.xcframework */; };
-		6BA65EC1FAFDE73352940A0A /* IceImpl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 44E2EF3378D9F7C7F0D447C2 /* IceImpl.xcframework */; };
-		6BEEBD2460B239E93E6D09FB /* Ice.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 28C558DB55A446508E4FF509 /* Ice.xcframework */; };
-		6BF4EAEBF2B2FB8FD273696D /* config.client in Resources */ = {isa = PBXBuildFile; fileRef = 1E17322B9B3129F67236C598 /* config.client */; };
-		6C53160CE7218F20A786DD2E /* Ice.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 28C558DB55A446508E4FF509 /* Ice.xcframework */; };
-		6DB02A868A938C084D3C4B8F /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 196EF0A3C8C45D4604C52011 /* main.swift */; };
-		6E55D812FAB3E318566807FC /* Hello.ice in Sources */ = {isa = PBXBuildFile; fileRef = F59BA32210DDA4AF9E06A751 /* Hello.ice */; };
-		705CDAD2418B540A39EC6A61 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33A4936D644169FE316E54E1 /* main.swift */; };
-		7353A648ECE4170F2E3982DB /* Throughput.ice in Sources */ = {isa = PBXBuildFile; fileRef = 62889D9BEFF1DD78E140F388 /* Throughput.ice */; };
-		73A546C9013D7EFDFD47B962 /* Glacier2.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6A9CC980FC134C230BC7EF63 /* Glacier2.xcframework */; };
-		75AE6402086F569488A13C01 /* Printer.ice in Sources */ = {isa = PBXBuildFile; fileRef = 393A11CCE8A9AF5886257EB1 /* Printer.ice */; };
-		75B464E1B3CA4554A6836318 /* Ice.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 28C558DB55A446508E4FF509 /* Ice.xcframework */; };
-		76B0CC9749A0FD2086659FC3 /* Images.xcassets in Sources */ = {isa = PBXBuildFile; fileRef = A1ED884AD886A6DEBBC3C728 /* Images.xcassets */; };
-		76D0B73E375DD04ED854E004 /* IceImpl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 44E2EF3378D9F7C7F0D447C2 /* IceImpl.xcframework */; };
-		76E7A2569C1B8B0AEC4DA78A /* Ice.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 28C558DB55A446508E4FF509 /* Ice.xcframework */; };
-		76FAE53B0DCB8497E129C238 /* Filesystem.ice in Sources */ = {isa = PBXBuildFile; fileRef = CBE746FB0E45B94FB26DBC9A /* Filesystem.ice */; };
-		773CD9BD405602CC4D9E75EB /* UserController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0CEA765E2311A5EA908CCF7 /* UserController.swift */; };
-		775A2A6D3389024DA1261280 /* Hello.ice in Sources */ = {isa = PBXBuildFile; fileRef = 78FB10F066D761AF1A24DB94 /* Hello.ice */; };
-		782096ED290E9F9300FF7B35 /* PromiseKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = E33F8EBD6359013AE72CB2C7 /* PromiseKit.xcframework */; };
-		79FC71B6C00515F6554F4D00 /* ChatController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04B294665F8365C4660E5293 /* ChatController.swift */; };
-		7A53D6E070682728768127C0 /* Ice.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 28C558DB55A446508E4FF509 /* Ice.xcframework */; };
-		7BAEFD2E4CE634061DB81263 /* MessageKit.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 32029539794EF0F1BBB97D18 /* MessageKit.xcframework */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
-		7CB3535DD7D6FA84A89D1C95 /* ThermostatI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22F9E0B5646525E4BCDD65DB /* ThermostatI.swift */; };
-		7D3AD9F611E8CD7F0AE861C7 /* config.client in Resources */ = {isa = PBXBuildFile; fileRef = 94A052DBBD69CB6C57BB5E82 /* config.client */; };
-		7D3D5CD70EE4ADE2A22FFB55 /* Printer.ice in Sources */ = {isa = PBXBuildFile; fileRef = C5AB75CEB64242F131C9C4BA /* Printer.ice */; };
-		7FC979D748B84D20966A7183 /* IceImpl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 44E2EF3378D9F7C7F0D447C2 /* IceImpl.xcframework */; };
-		7FD9709EA9A851FE1CDAADA3 /* IceImpl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 44E2EF3378D9F7C7F0D447C2 /* IceImpl.xcframework */; };
-		816026404829D5A35EACCAB0 /* Main.storyboard in Sources */ = {isa = PBXBuildFile; fileRef = 2DA6A62EE8B96C49196C6104 /* Main.storyboard */; };
-		84336C703029A580102A9363 /* Ice.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 28C558DB55A446508E4FF509 /* Ice.xcframework */; };
-		8960A62086805B535DC69B00 /* PromiseKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = E33F8EBD6359013AE72CB2C7 /* PromiseKit.xcframework */; };
-		8A73156BB0693578CFC70CD6 /* Ice.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D79B76AFF6799725A4428FD2 /* Ice.xcframework */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
-		8F6FA82CEBDE0485B1D5A1D0 /* AddController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE172FAF992BE42BF38A733D /* AddController.swift */; };
-		931292E4DD8EB0D276FF9AE4 /* Ice.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 28C558DB55A446508E4FF509 /* Ice.xcframework */; };
-		93A93C754F7560DA90E3349E /* Hello.ice in Sources */ = {isa = PBXBuildFile; fileRef = F845036D52ADEC64757D9E9E /* Hello.ice */; };
-		93D50216C1EC663D1BD56766 /* Ice.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 28C558DB55A446508E4FF509 /* Ice.xcframework */; };
-		940C388D748943FE416FE1C9 /* IceImpl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 44E2EF3378D9F7C7F0D447C2 /* IceImpl.xcframework */; };
-		958EA4E64A27BCD12FCBBC11 /* PromiseKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 55A37C8DED853A4C0C0212D7 /* PromiseKit.xcframework */; };
-		96663A86E8947C50DE6CDA5F /* IceImpl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 44E2EF3378D9F7C7F0D447C2 /* IceImpl.xcframework */; };
-		96B5842FACA240F8DEBC9DD6 /* Ice.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = D79B76AFF6799725A4428FD2 /* Ice.xcframework */; };
-		96D4B6C4488BCA084AF4F6E8 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3DFA602DEC55A1DE82BBF9F /* main.swift */; };
-		971C57C680EAC169FC02EB07 /* ChatApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DA9D65FCBB43921AE081B19 /* ChatApp.swift */; };
-		98FD99B2F95B728BABE886F2 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28DADE4A9B6DA1704649740D /* main.swift */; };
-		995DA1E74797D464FE505707 /* Ice.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 28C558DB55A446508E4FF509 /* Ice.xcframework */; };
-		9AE8AEC03E8536793AB11110 /* IceImpl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 44E2EF3378D9F7C7F0D447C2 /* IceImpl.xcframework */; };
-		9D3951C8429C655F8628FA42 /* PromiseKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = E33F8EBD6359013AE72CB2C7 /* PromiseKit.xcframework */; };
-		9E0CEBD3EC2175F0DE047F22 /* Glacier2.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6A9CC980FC134C230BC7EF63 /* Glacier2.xcframework */; };
-		9EF25EF302D1ABC9E3BAB900 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BE3E92C43F1D4A3709F9319 /* main.swift */; };
-		A04A73365BE3993CF823B9A6 /* DetailController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4B9142B71C331252B9ABD6C /* DetailController.swift */; };
-		A086446B70993F4A71A8EC42 /* IceImpl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 44E2EF3378D9F7C7F0D447C2 /* IceImpl.xcframework */; };
-		A0F390FFD28C816316318200 /* Glacier2.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9F40534B11EFC9339CC9F490 /* Glacier2.xcframework */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
-		A1F28213EC586464006A8F3D /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62F56BC2E31623E888EE6519 /* main.swift */; };
-		A22582AC862B7043984455EB /* Printer.ice in Sources */ = {isa = PBXBuildFile; fileRef = 393A11CCE8A9AF5886257EB1 /* Printer.ice */; };
-		A2CB957E6B2B58561810243D /* IceImpl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 44E2EF3378D9F7C7F0D447C2 /* IceImpl.xcframework */; };
-		A3B2B498D40D1C15E5AD0CF1 /* IceImpl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 44E2EF3378D9F7C7F0D447C2 /* IceImpl.xcframework */; };
-		A5BA6CBA3AE407A039BD77E7 /* Ice.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 28C558DB55A446508E4FF509 /* Ice.xcframework */; };
-		A768655B27B30C1400E41232 /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A768655A27B30C1400E41232 /* LoginView.swift */; };
-		A768655D27B3134D00E41232 /* LoginViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A768655C27B3134D00E41232 /* LoginViewModel.swift */; };
-		A79DD7D200CA7A5B2F70B027 /* Images.xcassets in Sources */ = {isa = PBXBuildFile; fileRef = 45F2D35942591858FBD901DD /* Images.xcassets */; };
-		A89B2946882429C77330E49E /* IceImpl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 44E2EF3378D9F7C7F0D447C2 /* IceImpl.xcframework */; };
-		A8C98CD18E36973FE4CE89DC /* PromiseKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = E33F8EBD6359013AE72CB2C7 /* PromiseKit.xcframework */; };
-		A95DCB64A518D3228970C287 /* PromiseKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = E33F8EBD6359013AE72CB2C7 /* PromiseKit.xcframework */; };
-		AAC6E3279A6CB6E2EDABF7F3 /* PromiseKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = E33F8EBD6359013AE72CB2C7 /* PromiseKit.xcframework */; };
-		AB2D1B182CC0FF6975FF862E /* certs in Resources */ = {isa = PBXBuildFile; fileRef = 734F7EBAF5DD523F69E07AEA /* certs */; };
-		AB415AA349C41D7262B0151B /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6F51134D874C51E8A43C60F /* ViewController.swift */; };
-		AC5F83FFA8B64959FAE9B929 /* Ice.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 28C558DB55A446508E4FF509 /* Ice.xcframework */; };
-		AC921078F74F097A83C382A1 /* Callback.ice in Sources */ = {isa = PBXBuildFile; fileRef = 6827D0D0191C586EC4231BA4 /* Callback.ice */; };
-		AEE551DA1FA05F73A61D4DCF /* Context.ice in Sources */ = {isa = PBXBuildFile; fileRef = 38D692F7A1A59D07B3A84D38 /* Context.ice */; };
-		AFA10FE5E010813B1E91834F /* Glacier2.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6A9CC980FC134C230BC7EF63 /* Glacier2.xcframework */; };
-		B06D18012CA6C84AE560F0EF /* InterceptorI.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9225308B90D05589A4A6BDF /* InterceptorI.swift */; };
-		B424D557AC8D811DEE249812 /* ContextI.swift in Sources */ = {isa = PBXBuildFile; fileRef = A848D5911477BACC1B9C18C8 /* ContextI.swift */; };
-		B48BED02CF9B848D55509544 /* LoginController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F5252E6DE7462352320FB7A /* LoginController.swift */; };
-		B48CA0948BD515FC09B1E9E1 /* Callback.ice in Sources */ = {isa = PBXBuildFile; fileRef = 10A521847822A38F221AF2AF /* Callback.ice */; };
-		B4F1A77FF6A2B0189C2AFB2F /* IceImpl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = DC44E9365BDEFE5223CA9AC7 /* IceImpl.xcframework */; };
-		B5374557598A8C7A3C7E1627 /* Ice.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 28C558DB55A446508E4FF509 /* Ice.xcframework */; };
-		B60E1F70B46C71B3C682A36B /* Contact.ice in Sources */ = {isa = PBXBuildFile; fileRef = 0942CEA562FE56F14AE24E39 /* Contact.ice */; };
-		B6D0A2F25DFF702C5198C6AD /* IceImpl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 44E2EF3378D9F7C7F0D447C2 /* IceImpl.xcframework */; };
-		B7E26932B35B732187F2FB37 /* PromiseKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = E33F8EBD6359013AE72CB2C7 /* PromiseKit.xcframework */; };
-		B9970D1C9424B23C56F7D0BD /* PromiseKit.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 55A37C8DED853A4C0C0212D7 /* PromiseKit.xcframework */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
-		BAC92AB7609E9A9402DCC9E6 /* LaunchScreen.storyboard in Sources */ = {isa = PBXBuildFile; fileRef = ACA7351C60E3801D9AB14CB1 /* LaunchScreen.storyboard */; };
-		BAFDDAE70A67570D6435453D /* PromiseKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = E33F8EBD6359013AE72CB2C7 /* PromiseKit.xcframework */; };
-		BB28C11F53882B35B5315BC4 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E73A8039907731FCD618C1F /* main.swift */; };
-		BB88916B303AC04F8755E9E0 /* Ice.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = D79B76AFF6799725A4428FD2 /* Ice.xcframework */; };
-		BC4CF78E8F723B0E01F92570 /* Ice.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 28C558DB55A446508E4FF509 /* Ice.xcframework */; };
-		BFE19108A71379FBD40D4015 /* PromiseKit.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 55A37C8DED853A4C0C0212D7 /* PromiseKit.xcframework */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
-		C377BA1A96FF04FCEA92B469 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 626DF7CBBBF14EA0C5B37ADA /* main.swift */; };
-		C39DBF43BD06A1A1A21C1881 /* IceImpl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 44E2EF3378D9F7C7F0D447C2 /* IceImpl.xcframework */; };
-		C576A5F1BD07620DC606EBCF /* Ice.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 28C558DB55A446508E4FF509 /* Ice.xcframework */; };
-		C5DCDAEE14456FE153F06F05 /* IceStorm.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = C1C7EFC80BA45C6FAB2C053C /* IceStorm.xcframework */; };
-		C9A677BF7ACF228CCA534082 /* Ice.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 28C558DB55A446508E4FF509 /* Ice.xcframework */; };
-		CB34AF9E2101F496F93EAC79 /* IceImpl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 44E2EF3378D9F7C7F0D447C2 /* IceImpl.xcframework */; };
-		CC52D560764B23BBFE53BAE8 /* PromiseKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = E33F8EBD6359013AE72CB2C7 /* PromiseKit.xcframework */; };
-		CCC535ADF4FF4699BAEEF779 /* PromiseKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = E33F8EBD6359013AE72CB2C7 /* PromiseKit.xcframework */; };
-		CDE548AEDBCF0DA5F5B3E769 /* PromiseKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = E33F8EBD6359013AE72CB2C7 /* PromiseKit.xcframework */; };
-		CDFF62B96CE03E0C7AE44018 /* Ice.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 28C558DB55A446508E4FF509 /* Ice.xcframework */; };
-		CEE51D32579534BF1F9A174A /* PromiseKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 55A37C8DED853A4C0C0212D7 /* PromiseKit.xcframework */; };
-		CF5D1035546F54AA16508EC7 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01DCB1638386E8F076C4527F /* main.swift */; };
-		D064B5105E23783C956801CD /* IceImpl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 44E2EF3378D9F7C7F0D447C2 /* IceImpl.xcframework */; };
-		D1B981738EDC4A5E05085E5B /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 412158B51D090DBE79E8588C /* main.swift */; };
-		D308E560C7FA78CFF18EC210 /* PromiseKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = E33F8EBD6359013AE72CB2C7 /* PromiseKit.xcframework */; };
-		D376E2BA2DD9DAA1782D5C39 /* IceImpl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 44E2EF3378D9F7C7F0D447C2 /* IceImpl.xcframework */; };
-		D3A577BC7CEF918650C61888 /* Filesystem.ice in Sources */ = {isa = PBXBuildFile; fileRef = CBE746FB0E45B94FB26DBC9A /* Filesystem.ice */; };
-		D4B44BF1C728EE01D7B5342D /* Ice.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 28C558DB55A446508E4FF509 /* Ice.xcframework */; };
-		D4B4718F09D2E67404EA5926 /* PromiseKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = E33F8EBD6359013AE72CB2C7 /* PromiseKit.xcframework */; };
-		D520CD53A7272E3F76CFDEF8 /* ChatLayoutController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FE03B5CC4924485E04FC7BA /* ChatLayoutController.swift */; };
-		D5B38FD0965B231BFCA35FAC /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C4552F3A57E06F1FE087CA3 /* main.swift */; };
-		D67A37BECDC2ACB03B220642 /* Interceptor.ice in Sources */ = {isa = PBXBuildFile; fileRef = BA319441718A4B4410187238 /* Interceptor.ice */; };
-		D713022205E0AC521BA9B069 /* IceImpl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = DC44E9365BDEFE5223CA9AC7 /* IceImpl.xcframework */; };
-		D77927F9976C69F799AFE7ED /* Ice.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 28C558DB55A446508E4FF509 /* Ice.xcframework */; };
-		D85AC2902178B3AC1FC299D1 /* Callback.ice in Sources */ = {isa = PBXBuildFile; fileRef = 10A521847822A38F221AF2AF /* Callback.ice */; };
-		DAB863F961828C6E952AE8C5 /* Throughput.ice in Sources */ = {isa = PBXBuildFile; fileRef = 62889D9BEFF1DD78E140F388 /* Throughput.ice */; };
-		DB2F920F9FDAB86BA37816DF /* Ice.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 28C558DB55A446508E4FF509 /* Ice.xcframework */; };
-		DB4C136A042C43441582BE38 /* LoginController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 572B6823AAC759EDC9E19B71 /* LoginController.swift */; };
-		DB8AFFBC433A4672D3587C96 /* IceImpl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 44E2EF3378D9F7C7F0D447C2 /* IceImpl.xcframework */; };
-		DCC2AD3D30FCB77C095AC740 /* Ice.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 28C558DB55A446508E4FF509 /* Ice.xcframework */; };
-		DE086E95B3B5B371B1775916 /* PromiseKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = E33F8EBD6359013AE72CB2C7 /* PromiseKit.xcframework */; };
-		DEBA1B0114909800D239CA25 /* Ice.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 28C558DB55A446508E4FF509 /* Ice.xcframework */; };
-		DF08480B7D2D2F3DAD99C17D /* Printer.ice in Sources */ = {isa = PBXBuildFile; fileRef = C5AB75CEB64242F131C9C4BA /* Printer.ice */; };
-		DF710555BF41835553B71071 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06BE5622AC513229E4D8C1DA /* main.swift */; };
-		E10589D62D38D85C70649931 /* Latency.ice in Sources */ = {isa = PBXBuildFile; fileRef = AE6F2AD2D3EF1EAE5E359219 /* Latency.ice */; };
-		E19E5D5DD7E8770858F5E040 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D135994048263BF1FDD1606 /* main.swift */; };
-		E299A77DAD60E8DFCBAA9187 /* PromiseKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = E33F8EBD6359013AE72CB2C7 /* PromiseKit.xcframework */; };
-		E40AAF9ECDB1DC1BD3038324 /* ChatSession.ice in Sources */ = {isa = PBXBuildFile; fileRef = 176C6FB865C900ACDE99E192 /* ChatSession.ice */; };
-		E4240F0FF2585E4D04CBE537 /* PromiseKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = E33F8EBD6359013AE72CB2C7 /* PromiseKit.xcframework */; };
-		E43CB6F98E3727A066B2C691 /* Ice.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 28C558DB55A446508E4FF509 /* Ice.xcframework */; };
-		E5573B13B5795295AC3DF847 /* Hello.ice in Sources */ = {isa = PBXBuildFile; fileRef = 78FB10F066D761AF1A24DB94 /* Hello.ice */; };
-		E5F5F06DB4680E55E199E88A /* PromiseKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = E33F8EBD6359013AE72CB2C7 /* PromiseKit.xcframework */; };
-		E5FAFFC9E536912F25AB23A8 /* Ice.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 28C558DB55A446508E4FF509 /* Ice.xcframework */; };
-		E82FD8E9EE1C503CABD75119 /* PromiseKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = E33F8EBD6359013AE72CB2C7 /* PromiseKit.xcframework */; };
-		E891BB777495872C66903573 /* IceImpl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 44E2EF3378D9F7C7F0D447C2 /* IceImpl.xcframework */; };
-		ED179FD60AA178A51FEEA3E3 /* PromiseKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = E33F8EBD6359013AE72CB2C7 /* PromiseKit.xcframework */; };
-		ED72F5559FA208C51D4189B6 /* PromiseKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 55A37C8DED853A4C0C0212D7 /* PromiseKit.xcframework */; };
-		EFE942394337C84255AD3659 /* ContactDBI.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4ED404F16F47126CD654B7B /* ContactDBI.swift */; };
-		F34601BEDBF2C941FBC2CB7C /* Glacier2.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F40534B11EFC9339CC9F490 /* Glacier2.xcframework */; };
-		F7997B16ED2FC36A4E5978B7 /* IceImpl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 44E2EF3378D9F7C7F0D447C2 /* IceImpl.xcframework */; };
-		F864B4DFE6BC8FF86450C43F /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CA52058B78D6D362BFE4799 /* main.swift */; };
-		F87C03A2BC97530D3A01D6E0 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 344F81939D64CD391A3B64BA /* main.swift */; };
-		F98852227C27AA09BEF4DEBA /* IceImpl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 44E2EF3378D9F7C7F0D447C2 /* IceImpl.xcframework */; };
-		FA0054A3FA0195F08D029C2E /* Glacier2Session.ice in Sources */ = {isa = PBXBuildFile; fileRef = E7394F43D1595EA0A782488C /* Glacier2Session.ice */; };
-		FA1626A3A90FEAA304867F45 /* IceImpl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 44E2EF3378D9F7C7F0D447C2 /* IceImpl.xcframework */; };
-		FABB8B99C0CC31F983A710BC /* PromiseKit.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 55A37C8DED853A4C0C0212D7 /* PromiseKit.xcframework */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
-		FB81BBB83D81E4A0E15445F6 /* Ice.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 28C558DB55A446508E4FF509 /* Ice.xcframework */; };
-		FB921140FE895DE8FB13DA62 /* PromiseKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = E33F8EBD6359013AE72CB2C7 /* PromiseKit.xcframework */; };
-		FBFDD84EB23AAB23A4EA92B3 /* Chat.ice in Sources */ = {isa = PBXBuildFile; fileRef = 664BB7725F3CE5BF2D6D1362 /* Chat.ice */; };
+		00F3CF5A0B1DD007F8592D19 /* LoginViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A66943ED723AF6633F4BA99 /* LoginViewModel.swift */; };
+		00F554D0DB7E35ACC7EF56CA /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B072E97D7C8C6712C74FA65 /* main.swift */; };
+		01BBF3B7DAB8FBABEC3405C4 /* MessageKit.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 72532D6611FFCB3AEA584CF2 /* MessageKit.xcframework */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		0380BEC4FE089A774CC52CBA /* PromiseKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A3283875DC46723DD0292377 /* PromiseKit.xcframework */; };
+		039B3FF67AB6BFCD9DA2AD97 /* Ice.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = F6D5ADFEDCEA37390E6306AB /* Ice.xcframework */; };
+		046C9EB84A64E2A0B1F7CA60 /* Hello.ice in Sources */ = {isa = PBXBuildFile; fileRef = 1CAF9B5AB8BE58FA0EB10620 /* Hello.ice */; };
+		04980A1E0970588D5763A589 /* Ice.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = F6D5ADFEDCEA37390E6306AB /* Ice.xcframework */; };
+		06A3340BA611E5DD9C53FFDA /* IceImpl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A17DB692E0895FE387DAE12A /* IceImpl.xcframework */; };
+		08BF2C23CA0AA8F48E1C198F /* Glacier2.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6090A77E36453AEE0FBD5067 /* Glacier2.xcframework */; };
+		09677A5BB6AAF49CCE67966E /* Glacier2.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6090A77E36453AEE0FBD5067 /* Glacier2.xcframework */; };
+		0A40FFCCB7DBAE729612D6E0 /* PromiseKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A3283875DC46723DD0292377 /* PromiseKit.xcframework */; };
+		0B6AE54965581C2B95345EF9 /* InputBarAccessoryView.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 14A6541C9B56301D61D6617B /* InputBarAccessoryView.xcframework */; };
+		0B76A141FA70978EAE7EBE32 /* PromiseKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A3283875DC46723DD0292377 /* PromiseKit.xcframework */; };
+		0B84FC7A1DBD12395CD05704 /* Images.xcassets in Sources */ = {isa = PBXBuildFile; fileRef = D9B1A389A4EC6F245A2A60A0 /* Images.xcassets */; };
+		0CA8906D84EFF888131ED416 /* PromiseKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A3283875DC46723DD0292377 /* PromiseKit.xcframework */; };
+		0F792206AC740C57490859DD /* PromiseKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8D1F93F5EAFFF88BD6AF411C /* PromiseKit.xcframework */; };
+		10B4B2BE1EBC093751D0B008 /* PromiseKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A3283875DC46723DD0292377 /* PromiseKit.xcframework */; };
+		11A60946CA831F4071077227 /* IceImpl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A17DB692E0895FE387DAE12A /* IceImpl.xcframework */; };
+		1265ECC72E822B50E61E6F04 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A1D640865F913073C70C4FF /* main.swift */; };
+		12A1FA954A65D9D4B3E938D3 /* Ice.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = F6D5ADFEDCEA37390E6306AB /* Ice.xcframework */; };
+		13B0C3F042D348005E3D46A5 /* Callback.ice in Sources */ = {isa = PBXBuildFile; fileRef = 5243222A3CC5BEAF68C60F71 /* Callback.ice */; };
+		14140038F90E29CBE7B4A05C /* IceImpl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5E747475333ADF987F603E6C /* IceImpl.xcframework */; };
+		14B11A164CCEA52D10510215 /* Ice.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = F6D5ADFEDCEA37390E6306AB /* Ice.xcframework */; };
+		16C1995FFBFE5A81D1268DD0 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6156419DB27240E87FC12AD3 /* main.swift */; };
+		1729EFFCB0FE273A9B3B8951 /* Chat.ice in Sources */ = {isa = PBXBuildFile; fileRef = 80E8C4DFE7FAAD51C145CF29 /* Chat.ice */; };
+		175365065B824E1063E7047F /* ProxySettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DE4BC8D3B1AC40589A0F47C /* ProxySettings.swift */; };
+		18DAC98BD68252339393FE67 /* IceImpl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A17DB692E0895FE387DAE12A /* IceImpl.xcframework */; };
+		19E00BFF583537AEFBC88424 /* Ice.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = F6D5ADFEDCEA37390E6306AB /* Ice.xcframework */; };
+		1B6371D511B784A96940484F /* Contact.ice in Sources */ = {isa = PBXBuildFile; fileRef = 1159DF4CC0FC9B954A10D812 /* Contact.ice */; };
+		1B9AFFD56EF14588A01CC414 /* IceImpl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A17DB692E0895FE387DAE12A /* IceImpl.xcframework */; };
+		1BF3DBD92C453B8986C593A3 /* Ice.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = F6D5ADFEDCEA37390E6306AB /* Ice.xcframework */; };
+		1C0050361F80EBD3F7DFC289 /* PrinterI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07CBA324F6759CF66AD9F78A /* PrinterI.swift */; };
+		1CFE8DDAAAF53CA1BFBA8443 /* Ice.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = F6D5ADFEDCEA37390E6306AB /* Ice.xcframework */; };
+		1DBC1DC65F6FF8ED943B3DC8 /* Hello.ice in Sources */ = {isa = PBXBuildFile; fileRef = 297A3C05FC7C5D646BFC71B3 /* Hello.ice */; };
+		1DD2C03CA0B4DCECD5AD630E /* FormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D41183ED7AF99A5F55B1E8E8 /* FormView.swift */; };
+		1E189C038023357CA0C911A3 /* PromiseKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A3283875DC46723DD0292377 /* PromiseKit.xcframework */; };
+		1F649784C620C36705938E3B /* Ice.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = F6D5ADFEDCEA37390E6306AB /* Ice.xcframework */; };
+		1FA334AB2BDDA68C3D415B03 /* ButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D09298A13696CB8450955D26 /* ButtonView.swift */; };
+		214B68CB2F063337F09799A7 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 182D38D880F51066DF80DA36 /* main.swift */; };
+		21B0948AE347809A0EC55033 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 119DF9A2E1B9A44EAA8D3A12 /* main.swift */; };
+		2256B421133B6750CABDFBDC /* Ice.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = F6D5ADFEDCEA37390E6306AB /* Ice.xcframework */; };
+		23FF46B15DBF2E068AAB8A93 /* PromiseKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A3283875DC46723DD0292377 /* PromiseKit.xcframework */; };
+		25AB0F41B9780AF4856116EA /* IceImpl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A17DB692E0895FE387DAE12A /* IceImpl.xcframework */; };
+		2969FB85B2BB4833CBA7A297 /* Ice.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = BC03557C145BF03816F95E71 /* Ice.xcframework */; };
+		2CA203928AFA063EBBA9F85D /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AE01E8009BD5112F86F3EE7 /* main.swift */; };
+		2E36354DF6812EF628C19038 /* Hello.ice in Sources */ = {isa = PBXBuildFile; fileRef = FDCC5878BE3F1BDFBDC416C1 /* Hello.ice */; };
+		2E4485260D42FA41E777A160 /* IceImpl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A17DB692E0895FE387DAE12A /* IceImpl.xcframework */; };
+		31CEB0D30C795E4FD3251110 /* IceImpl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A17DB692E0895FE387DAE12A /* IceImpl.xcframework */; };
+		32A399636483721E49F83D5A /* Ice.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = BC03557C145BF03816F95E71 /* Ice.xcframework */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		334A046B330AA03FB846FCFB /* PromiseKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A3283875DC46723DD0292377 /* PromiseKit.xcframework */; };
+		3410071CF783E96E226E9738 /* IceImpl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A17DB692E0895FE387DAE12A /* IceImpl.xcframework */; };
+		35E3216EFC48E52EE773A716 /* Ice.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = F6D5ADFEDCEA37390E6306AB /* Ice.xcframework */; };
+		36004CB4D5B856B14A3E889A /* Calculator.ice in Sources */ = {isa = PBXBuildFile; fileRef = 2B8323ADB0E2AAFB22A11C1F /* Calculator.ice */; };
+		3666EDE056135C2DE0579617 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7155FDE58250E9D19CA3131E /* main.swift */; };
+		36A86037702C43808CD49AF5 /* IceImpl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A17DB692E0895FE387DAE12A /* IceImpl.xcframework */; };
+		373B2557C8FE352364046452 /* PromiseKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A3283875DC46723DD0292377 /* PromiseKit.xcframework */; };
+		391F30BFAF0DBBF645D2F2DC /* PromiseKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8D1F93F5EAFFF88BD6AF411C /* PromiseKit.xcframework */; };
+		3963BE94336190EC4C1D1573 /* Ice.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = F6D5ADFEDCEA37390E6306AB /* Ice.xcframework */; };
+		3A59CA7F50DD777AE22D07C7 /* IceImpl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5E747475333ADF987F603E6C /* IceImpl.xcframework */; };
+		3A6D45ED3489FB897963352C /* Hello.ice in Sources */ = {isa = PBXBuildFile; fileRef = FDCC5878BE3F1BDFBDC416C1 /* Hello.ice */; };
+		3A75E0D04D58A5CF1250C4FC /* Ice.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = F6D5ADFEDCEA37390E6306AB /* Ice.xcframework */; };
+		3B4FA933F8E43155C7EF0107 /* IceImpl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A17DB692E0895FE387DAE12A /* IceImpl.xcframework */; };
+		3BC2B4393E9F8BDA5AA3A77E /* IceImpl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A17DB692E0895FE387DAE12A /* IceImpl.xcframework */; };
+		3BDBFECA833B5E4400654632 /* IceImpl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A17DB692E0895FE387DAE12A /* IceImpl.xcframework */; };
+		3C1A28F7E5FC5394E9ABEC8F /* ContactDBI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88C5026755B2F338489AFBE9 /* ContactDBI.swift */; };
+		3CC84245E2B1F7F824D2EA74 /* Interceptor.ice in Sources */ = {isa = PBXBuildFile; fileRef = 66C79E9BF61C66A55F891C76 /* Interceptor.ice */; };
+		3D4BB6ADC54B7D0112414BD0 /* PromiseKit.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8D1F93F5EAFFF88BD6AF411C /* PromiseKit.xcframework */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		3EA8580090524C6DB1F1A8AC /* Ice.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = F6D5ADFEDCEA37390E6306AB /* Ice.xcframework */; };
+		3F53D8B1536AFC4B8E11E485 /* IceImpl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A17DB692E0895FE387DAE12A /* IceImpl.xcframework */; };
+		3FAA6C67375BCD6B55453C12 /* Hello.ice in Sources */ = {isa = PBXBuildFile; fileRef = 1CAF9B5AB8BE58FA0EB10620 /* Hello.ice */; };
+		40A958490377D6241B518073 /* Hello.ice in Sources */ = {isa = PBXBuildFile; fileRef = 297A3C05FC7C5D646BFC71B3 /* Hello.ice */; };
+		413C0BC8E402F3BF09259E7E /* IceImpl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A17DB692E0895FE387DAE12A /* IceImpl.xcframework */; };
+		42ACE6B72FBE7209C2B5EB7C /* IceGrid.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = ADCEEBFF3D6FE9745DBC0F12 /* IceGrid.xcframework */; };
+		45F0A5D99C59FCD2ED89B4D2 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89958C96902E761791FB2A36 /* main.swift */; };
+		4621C84EF2908DB9445D3DD1 /* IceGrid.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = ADCEEBFF3D6FE9745DBC0F12 /* IceGrid.xcframework */; };
+		4834E56B747F47DB3DCAA453 /* Client.swift in Sources */ = {isa = PBXBuildFile; fileRef = 682FF469D6A1C7F0B187FCFB /* Client.swift */; };
+		483D42A25BD4EC198EEA0528 /* config.client in Resources */ = {isa = PBXBuildFile; fileRef = 0BF2D8AF1D0F9CBA492FFFA0 /* config.client */; };
+		49677CFB031726757DCDF84D /* Callback.ice in Sources */ = {isa = PBXBuildFile; fileRef = C11ECF49C07B3F0D8D24D4CE /* Callback.ice */; };
+		4AAA416EF1039BD4331C0771 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7FFECC1E9A92EB99DB45189 /* main.swift */; };
+		4BBB7D0D7A2F512CB5E64149 /* Clock.ice in Sources */ = {isa = PBXBuildFile; fileRef = 659807E1F731370BB23B7547 /* Clock.ice */; };
+		4C1638EFA9335DFC212FB19B /* PromiseKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A3283875DC46723DD0292377 /* PromiseKit.xcframework */; };
+		4C62A4D89471B0E78F97AE08 /* IceImpl.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5E747475333ADF987F603E6C /* IceImpl.xcframework */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		4CE7763D1C1A092AF35459D8 /* PromiseKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A3283875DC46723DD0292377 /* PromiseKit.xcframework */; };
+		51AD6E2F4D69B5481868F1F0 /* PromiseKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A3283875DC46723DD0292377 /* PromiseKit.xcframework */; };
+		528848BAB8C2AC1CA4500E65 /* Ice.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = F6D5ADFEDCEA37390E6306AB /* Ice.xcframework */; };
+		52C1F8712856FD48EFEBE872 /* PromiseKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A3283875DC46723DD0292377 /* PromiseKit.xcframework */; };
+		558DEDB163066F9D8C84E61C /* ChatUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5BF957583E207844EF3D17D /* ChatUser.swift */; };
+		575D4A471155DCC43F0AF05C /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14E30ECC6FC00347408358AC /* main.swift */; };
+		5947EF25FEF1852AFFA67C54 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B80F9BF7F22E83B6E50198 /* main.swift */; };
+		59E7175B2F77E2CC6BE9E3EC /* ButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC612259AECEB8BAFD75B122 /* ButtonView.swift */; };
+		5A66EC165731718CF499A31C /* MessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3419BF2F5BA87FBBEAA600E2 /* MessageView.swift */; };
+		5B5BB2ECFB48B1B9373960A8 /* PromiseKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A3283875DC46723DD0292377 /* PromiseKit.xcframework */; };
+		5B7CD1C62895A8B7FE94573A /* IceImpl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A17DB692E0895FE387DAE12A /* IceImpl.xcframework */; };
+		5C3097B6D1B70FFB10073BFB /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC3E97FBD168151BE75FFABC /* main.swift */; };
+		5E1F30DC3ACBB682C3B35B39 /* PromiseKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A3283875DC46723DD0292377 /* PromiseKit.xcframework */; };
+		5E2F18583109C2BD7BD1A9C6 /* Hello.ice in Sources */ = {isa = PBXBuildFile; fileRef = FA61DA58008B4C300C53DBBA /* Hello.ice */; };
+		60AB6E4A0349D347225A13AA /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE553DAEFFB91D14B2F1E095 /* main.swift */; };
+		60CCC075B62A54A01A9D63D9 /* Hello.ice in Sources */ = {isa = PBXBuildFile; fileRef = 433CCEA38EC899FF3573DA55 /* Hello.ice */; };
+		6121241C8714AF7E773741E4 /* CalculatorI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D8A0252E35287420AD6F9C4 /* CalculatorI.swift */; };
+		61991B598153D81AD07F2AEF /* IceImpl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A17DB692E0895FE387DAE12A /* IceImpl.xcframework */; };
+		627515A621F1BA62F1CD6ECF /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BE94C38DB2165FDFF7288A4 /* main.swift */; };
+		62EBFB243C7838D2175D4869 /* Throughput.ice in Sources */ = {isa = PBXBuildFile; fileRef = BAFF519269261E59BCD1EC19 /* Throughput.ice */; };
+		63267968AB45EEE7A7FDF389 /* Ice.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = F6D5ADFEDCEA37390E6306AB /* Ice.xcframework */; };
+		66C86D41B853871F236B5499 /* IceImpl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A17DB692E0895FE387DAE12A /* IceImpl.xcframework */; };
+		68AB3DC5A5A2230F0F748AFA /* ProxySettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4CAEB24950021156B12C284 /* ProxySettingsView.swift */; };
+		69A5830532752C7732817336 /* Hello.ice in Sources */ = {isa = PBXBuildFile; fileRef = FDFE811E43D3912A799A2927 /* Hello.ice */; };
+		69B3A9BAF94BF1D751AE173E /* Printer.ice in Sources */ = {isa = PBXBuildFile; fileRef = 38744134BEAD371CB759721B /* Printer.ice */; };
+		6BC648C12CD0269FBD8D86EB /* Ice.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = F6D5ADFEDCEA37390E6306AB /* Ice.xcframework */; };
+		6CC0B49DB9B252989721D2D6 /* PromiseKit.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8D1F93F5EAFFF88BD6AF411C /* PromiseKit.xcframework */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		6D8B027CA77AC684AB3FF403 /* Images.xcassets in Sources */ = {isa = PBXBuildFile; fileRef = 91493EA2D9B868513FFDC930 /* Images.xcassets */; };
+		7012BE8703C2C3CC6CB35F4C /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AE3EE1D56DB116DB064D5AD /* LoginView.swift */; };
+		7025C0AA1DB299B090FB7093 /* HelloApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89CF71983E611003BE227C55 /* HelloApp.swift */; };
+		703DC4B712010A7123A4861B /* IceImpl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A17DB692E0895FE387DAE12A /* IceImpl.xcframework */; };
+		7070D4F0AC60F543926475B3 /* Ice.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = F6D5ADFEDCEA37390E6306AB /* Ice.xcframework */; };
+		73CEAFEE072FC6BEF2E1F5C7 /* Ice.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = F6D5ADFEDCEA37390E6306AB /* Ice.xcframework */; };
+		73F304B30AE907FD03C6717E /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4F1FB2AB678C69D651C799C /* main.swift */; };
+		76B1ECD89A0E609F061CFCCC /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0E6A06FE6652B7B68DF2300 /* main.swift */; };
+		76C3E5FEFEFF0C38B8F5D81E /* IceImpl.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5E747475333ADF987F603E6C /* IceImpl.xcframework */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		76E3A938B1A497F53231DF62 /* certs in Resources */ = {isa = PBXBuildFile; fileRef = B6425B00666CF3BCC4321F5E /* certs */; };
+		7C361A3F11FEE415AC4AA1E1 /* PromiseKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A3283875DC46723DD0292377 /* PromiseKit.xcframework */; };
+		7C4035897CE368F0DF488028 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B7264AB55E8A3106AC51A36 /* main.swift */; };
+		7E4AF05B39992CDFC83F7009 /* ChatSession.ice in Sources */ = {isa = PBXBuildFile; fileRef = 890485C2DE8A237A4F7E6FEF /* ChatSession.ice */; };
+		7EA8FB037E3B6C3AED9E901D /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DD46FB9CCAF0938A7F7A020 /* main.swift */; };
+		7F52C550F5ABE139771A840A /* PromiseKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A3283875DC46723DD0292377 /* PromiseKit.xcframework */; };
+		7F8FEEE3CCDC5AE0F310D404 /* PromiseKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A3283875DC46723DD0292377 /* PromiseKit.xcframework */; };
+		80DD4A627CF5B052161612E3 /* IceImpl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A17DB692E0895FE387DAE12A /* IceImpl.xcframework */; };
+		81BD1214FC530CEA78E43021 /* IceImpl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A17DB692E0895FE387DAE12A /* IceImpl.xcframework */; };
+		82504D9F15C0C04135019869 /* Glacier2.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6090A77E36453AEE0FBD5067 /* Glacier2.xcframework */; };
+		82A76BD99F4C717CC5C8D845 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01659268489EEC0398AE6547 /* main.swift */; };
+		853B4420854A636C48B4AA05 /* Hello.ice in Sources */ = {isa = PBXBuildFile; fileRef = EB096EB42E87282807FE0D9D /* Hello.ice */; };
+		8548885819F0240D677BB3C6 /* Glacier2.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6090A77E36453AEE0FBD5067 /* Glacier2.xcframework */; };
+		86331B876DDB5CA43E43D758 /* certs in Resources */ = {isa = PBXBuildFile; fileRef = 558F42A0EB85C995C0501E62 /* certs */; };
+		863F9515405B1038F1572097 /* PromiseKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A3283875DC46723DD0292377 /* PromiseKit.xcframework */; };
+		868133D320E6ED4DD57D984D /* Ice.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = F6D5ADFEDCEA37390E6306AB /* Ice.xcframework */; };
+		86DD836836F8AAB208932965 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3095385D6D4C977E3A5FFE0B /* main.swift */; };
+		8728ED93B0D9016298D5AF74 /* Interceptor.ice in Sources */ = {isa = PBXBuildFile; fileRef = 66C79E9BF61C66A55F891C76 /* Interceptor.ice */; };
+		882DF5C30256B2D4B981A8E8 /* Ice.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = BC03557C145BF03816F95E71 /* Ice.xcframework */; };
+		88C95645A9DC43D0B71F25FF /* Callback.ice in Sources */ = {isa = PBXBuildFile; fileRef = 5243222A3CC5BEAF68C60F71 /* Callback.ice */; };
+		8AA22853F429537AA8B18DCB /* PromiseKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A3283875DC46723DD0292377 /* PromiseKit.xcframework */; };
+		8BB24CCAE7DFDB35FEA9FA33 /* IceImpl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A17DB692E0895FE387DAE12A /* IceImpl.xcframework */; };
+		8C85ECCAFC9D6EEA763F5050 /* Ice.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = F6D5ADFEDCEA37390E6306AB /* Ice.xcframework */; };
+		8CA95FBC0E4F686B42102558 /* Calculator.ice in Sources */ = {isa = PBXBuildFile; fileRef = 2B8323ADB0E2AAFB22A11C1F /* Calculator.ice */; };
+		8E1C8D210C07D4CA5DE948DC /* ChatApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0BA1758D46D25B723354B2A /* ChatApp.swift */; };
+		910C48BF6007222BB5045854 /* Ice.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = F6D5ADFEDCEA37390E6306AB /* Ice.xcframework */; };
+		91CDC2168F770FEED8E0FBB2 /* Context.ice in Sources */ = {isa = PBXBuildFile; fileRef = 9C03ACE9054F79C85364DCEE /* Context.ice */; };
+		922A8900A3C17A8E69A22FB9 /* IceImpl.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5E747475333ADF987F603E6C /* IceImpl.xcframework */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		939CA4225665DBDB3B860B94 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 796351E195A29AF6D4C56C50 /* main.swift */; };
+		93B345B674B6E7A8B517390F /* IceImpl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A17DB692E0895FE387DAE12A /* IceImpl.xcframework */; };
+		93EAB484E4D93F1005F9BF78 /* Ice.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = F6D5ADFEDCEA37390E6306AB /* Ice.xcframework */; };
+		9516D35BFFE6F2D66C6FCCE1 /* IceImpl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A17DB692E0895FE387DAE12A /* IceImpl.xcframework */; };
+		9540FFBFAFE9D0F115F84D9C /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 471F66A6A5B0313A7FCC8103 /* main.swift */; };
+		95545ACAD037E4111F97F7FF /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = B98DB4BE5FC6124CD188185D /* main.swift */; };
+		961F7B866A9C98232B527C7F /* Images.xcassets in Sources */ = {isa = PBXBuildFile; fileRef = 47DF638C1F0FE8FDDF32230E /* Images.xcassets */; };
+		96612D9F85C656B2F2878365 /* PromiseKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A3283875DC46723DD0292377 /* PromiseKit.xcframework */; };
+		97B9D82129370E6B55AA6112 /* MessageKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 72532D6611FFCB3AEA584CF2 /* MessageKit.xcframework */; };
+		9915F1DB77481091A31A5290 /* PromiseKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A3283875DC46723DD0292377 /* PromiseKit.xcframework */; };
+		9966CAF7B2CC58AEB0AEC923 /* Printer.ice in Sources */ = {isa = PBXBuildFile; fileRef = 9D6E4AD2F25CC4A4A74FD31B /* Printer.ice */; };
+		99AA98F0EEDE91ACCADADBAF /* PromiseKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A3283875DC46723DD0292377 /* PromiseKit.xcframework */; };
+		9A225E418433F86974FECD0D /* ChatMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E01850376B12840A28C24DD /* ChatMessage.swift */; };
+		9A8FA35CE6DF40B6D09916EF /* Throughput.ice in Sources */ = {isa = PBXBuildFile; fileRef = BAFF519269261E59BCD1EC19 /* Throughput.ice */; };
+		9A93844AD18C53965BFAA34A /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 865C9B290A4F6B73C770716D /* main.swift */; };
+		9ABF363532F6F07CB0E7D281 /* PromiseKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A3283875DC46723DD0292377 /* PromiseKit.xcframework */; };
+		9CE0C99C1ADA5C3C7D3CEC5D /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0983D2DC20F667ECE804DBCE /* main.swift */; };
+		9D481B706A909E0DE19D7046 /* PromiseKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A3283875DC46723DD0292377 /* PromiseKit.xcframework */; };
+		9DB00450AF2291C85FF81FE1 /* IceImpl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A17DB692E0895FE387DAE12A /* IceImpl.xcframework */; };
+		9E587A7C05E39504A02E2A3F /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 753391F556A5F8C93ABC6ABD /* main.swift */; };
+		9EF0C7C9DB7B4DB15F63FB9D /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E0E12A86B874F17FAEF5FD2 /* main.swift */; };
+		A137DFB1CDBF6482313A817F /* Ice.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = F6D5ADFEDCEA37390E6306AB /* Ice.xcframework */; };
+		A38EB238A9D3EBCDABB4D8AC /* PromiseKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A3283875DC46723DD0292377 /* PromiseKit.xcframework */; };
+		A46BFCFFB91188D689710288 /* IceImpl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A17DB692E0895FE387DAE12A /* IceImpl.xcframework */; };
+		A4756E4023590AC7DC20A31E /* IceImpl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5E747475333ADF987F603E6C /* IceImpl.xcframework */; };
+		A4A84A7AF129A92CFEA02EFE /* Hello.ice in Sources */ = {isa = PBXBuildFile; fileRef = FA61DA58008B4C300C53DBBA /* Hello.ice */; };
+		A50FC99DCD0E318ADEC33AD6 /* IceImpl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A17DB692E0895FE387DAE12A /* IceImpl.xcframework */; };
+		A63243EE764ACC994C5691EC /* ProxySettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E03CE17EC29CC0EB9F65C25 /* ProxySettings.swift */; };
+		A75BFB3CAC44EEF135CDE8F8 /* AuthenticatorI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8392CA466DE82E34967ED739 /* AuthenticatorI.swift */; };
+		A8CBAC043CB08646045BF12C /* IceImpl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A17DB692E0895FE387DAE12A /* IceImpl.xcframework */; };
+		AA7E5435E00604C6A6ADD429 /* InterceptorI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03164D5D43273B40ACC16B18 /* InterceptorI.swift */; };
+		AB7AE64DF5B723C3EB950CBA /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68FDCA36F2E359A95EFBD5FA /* main.swift */; };
+		AC3CEFCA72DCB8B57BC9BE12 /* Glacier2.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 97F0299BB374A87174167DC2 /* Glacier2.xcframework */; };
+		ACB3DB2EA2DBE16322DC2C66 /* IceImpl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A17DB692E0895FE387DAE12A /* IceImpl.xcframework */; };
+		AD7388526BEBF9F5BEE1241D /* Ice.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = F6D5ADFEDCEA37390E6306AB /* Ice.xcframework */; };
+		AD93E10D5C99E2E8F57E6E63 /* PromiseKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A3283875DC46723DD0292377 /* PromiseKit.xcframework */; };
+		AE12B6685B006CF9F842809A /* Context.ice in Sources */ = {isa = PBXBuildFile; fileRef = 9C03ACE9054F79C85364DCEE /* Context.ice */; };
+		AF3368D5FEC2DE720FCD8DCC /* HelloApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = E36C6AFB2056519590EB40BC /* HelloApp.swift */; };
+		AF4A20E5FB735EA8FBA5C53C /* IceImpl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A17DB692E0895FE387DAE12A /* IceImpl.xcframework */; };
+		B03E35F981104CA48E54E19F /* Client.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30AEEE77443915F4B5275267 /* Client.swift */; };
+		B09CDEB3C1A22B93296E6358 /* Ice.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = F6D5ADFEDCEA37390E6306AB /* Ice.xcframework */; };
+		B27D463C308D2C1CF5184D1C /* IceStorm.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3066738A6A797BC7554D7EA6 /* IceStorm.xcframework */; };
+		B42AD43E65B9B5DFB6D8CFA6 /* Latency.ice in Sources */ = {isa = PBXBuildFile; fileRef = 0C3898D57712FCD59D25EE7F /* Latency.ice */; };
+		B6022CC6E3B960DFAC24466C /* IceImpl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A17DB692E0895FE387DAE12A /* IceImpl.xcframework */; };
+		B9044FEB14C2A7B255978C93 /* ProxySettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E26BF8F0915B9A9A8A575229 /* ProxySettingsView.swift */; };
+		B96EE41312E856DC5672E7D8 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71FA03B36793A98FE0D86D99 /* main.swift */; };
+		BB1512D30C5971A05445631E /* Filesystem.ice in Sources */ = {isa = PBXBuildFile; fileRef = 27F63A2026D6BA776427CA0E /* Filesystem.ice */; };
+		BC3C94B01121223DA9B98199 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = E729B07F7DF1A13054A6B6CD /* main.swift */; };
+		BD29E4F73D90A28F709C1207 /* Filesystem.ice in Sources */ = {isa = PBXBuildFile; fileRef = 27F63A2026D6BA776427CA0E /* Filesystem.ice */; };
+		BFE8E78DF08D391D3811E620 /* InputBarAccessoryView.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 14A6541C9B56301D61D6617B /* InputBarAccessoryView.xcframework */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		C0008F417272E71FDD109C76 /* Contact.ice in Sources */ = {isa = PBXBuildFile; fileRef = 1159DF4CC0FC9B954A10D812 /* Contact.ice */; };
+		C2EE59133B5533F2251A576A /* PromiseKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A3283875DC46723DD0292377 /* PromiseKit.xcframework */; };
+		C326729084F3BDF2B89032EB /* Printer.ice in Sources */ = {isa = PBXBuildFile; fileRef = 38744134BEAD371CB759721B /* Printer.ice */; };
+		C59B1D4E7732E0B02EB5CBC0 /* PromiseKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A3283875DC46723DD0292377 /* PromiseKit.xcframework */; };
+		C886FF78467BC2F5F19AB456 /* PromiseKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A3283875DC46723DD0292377 /* PromiseKit.xcframework */; };
+		CB3A3D25696BC9C46EB1520D /* ThermostatI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 017302CFB001ED3B8B8E4C99 /* ThermostatI.swift */; };
+		CBA480D5C95A81417D89A2FD /* Ice.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = F6D5ADFEDCEA37390E6306AB /* Ice.xcframework */; };
+		CBF42967279717F602F0090A /* IceImpl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A17DB692E0895FE387DAE12A /* IceImpl.xcframework */; };
+		CBF4A3C4E604E944E41A0833 /* Ice.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = F6D5ADFEDCEA37390E6306AB /* Ice.xcframework */; };
+		CC84EF4225A42C39840D22BB /* Hello.ice in Sources */ = {isa = PBXBuildFile; fileRef = ABFD6BCBCC983EA843AD4D2D /* Hello.ice */; };
+		CD65DE4519703EE25E0C3730 /* IceImpl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A17DB692E0895FE387DAE12A /* IceImpl.xcframework */; };
+		CE02BBCF94F3B566F58CF1BE /* IceImpl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A17DB692E0895FE387DAE12A /* IceImpl.xcframework */; };
+		D11BCF36EDE21E3AF23EC0C2 /* Ice.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = F6D5ADFEDCEA37390E6306AB /* Ice.xcframework */; };
+		D3DAECABBB46132BC75329B5 /* PromiseKit.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8D1F93F5EAFFF88BD6AF411C /* PromiseKit.xcframework */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		D52C1CE0AF793528DFB3A0CD /* Hello.ice in Sources */ = {isa = PBXBuildFile; fileRef = 433CCEA38EC899FF3573DA55 /* Hello.ice */; };
+		D52C330B43A43B65D9C5C088 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54E37D3065FF48B94BA98BA4 /* main.swift */; };
+		D54E5AFEFAB0CB099A26A53B /* PromiseKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A3283875DC46723DD0292377 /* PromiseKit.xcframework */; };
+		D6E3611B9225F83EEC96DC0A /* PromiseKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A3283875DC46723DD0292377 /* PromiseKit.xcframework */; };
+		D7B518045A8118EF63C0227F /* Printer.ice in Sources */ = {isa = PBXBuildFile; fileRef = 9D6E4AD2F25CC4A4A74FD31B /* Printer.ice */; };
+		D7CE3D7E9236A5A16BA7FF37 /* PromiseKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8D1F93F5EAFFF88BD6AF411C /* PromiseKit.xcframework */; };
+		D8A7D9E653DC8E1508751F8E /* PromiseKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A3283875DC46723DD0292377 /* PromiseKit.xcframework */; };
+		D8DB6D20ABCA1F56E41E6581 /* Ice.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = F6D5ADFEDCEA37390E6306AB /* Ice.xcframework */; };
+		D9AD135AF860DF831FB6A69E /* StatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30111B4320FFB91EA0136E0D /* StatusView.swift */; };
+		DCDA989B93B9E71959050276 /* IceImpl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A17DB692E0895FE387DAE12A /* IceImpl.xcframework */; };
+		DCF636456F36001A6EA7C34A /* Hello.ice in Sources */ = {isa = PBXBuildFile; fileRef = ABFD6BCBCC983EA843AD4D2D /* Hello.ice */; };
+		DE385A628CDEFE3388CF037F /* PromiseKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A3283875DC46723DD0292377 /* PromiseKit.xcframework */; };
+		DE870E0875BDCD3589DD81B9 /* Ice.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = BC03557C145BF03816F95E71 /* Ice.xcframework */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		DEAD603C28B5B937A7C9FE52 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FB6F066F7A0E28AD17B8E2B /* main.swift */; };
+		DF027AEF7E29C994AB363061 /* Ice.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = F6D5ADFEDCEA37390E6306AB /* Ice.xcframework */; };
+		DF57179F6952B1AF8C6268A7 /* ContextI.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEFC33ED9950620998C6D44C /* ContextI.swift */; };
+		DFC8E28F9F2F3B953C3E1256 /* PromiseKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A3283875DC46723DD0292377 /* PromiseKit.xcframework */; };
+		E0188129EA84B88DF496A38C /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59F54B9F7348F848EADE4E3B /* main.swift */; };
+		E21E9807B2E9F06409851025 /* Clock.ice in Sources */ = {isa = PBXBuildFile; fileRef = 659807E1F731370BB23B7547 /* Clock.ice */; };
+		E2AD5885F69F89D79B003D07 /* FormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 767E6BD4CF76BB3960550B1B /* FormView.swift */; };
+		E5A59CA6972B19A66BC38E1C /* Glacier2.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 97F0299BB374A87174167DC2 /* Glacier2.xcframework */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		E5B55A70045ABFC26AA2764D /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E94589557E60F855FCFD732 /* main.swift */; };
+		E66479ECA0F7DC4E53E48105 /* Ice.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = F6D5ADFEDCEA37390E6306AB /* Ice.xcframework */; };
+		EB2A988F21E2CBD5DF74E4A5 /* Ice.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = BC03557C145BF03816F95E71 /* Ice.xcframework */; };
+		ECB248D9655461DC0DB1CEDA /* Ice.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = F6D5ADFEDCEA37390E6306AB /* Ice.xcframework */; };
+		EE60A1DF0940F76B5285093E /* Ice.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = F6D5ADFEDCEA37390E6306AB /* Ice.xcframework */; };
+		EF7F03E90E0B5B7A2E708BFB /* Latency.ice in Sources */ = {isa = PBXBuildFile; fileRef = 0C3898D57712FCD59D25EE7F /* Latency.ice */; };
+		EFA669665A876BC4B9C17125 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8046165D06F6EE72D935DFD6 /* main.swift */; };
+		EFCF553DDB0ECE9ACD2B0E51 /* Ice.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = F6D5ADFEDCEA37390E6306AB /* Ice.xcframework */; };
+		F09D7787C66048B4DCF64FE5 /* Ice.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = F6D5ADFEDCEA37390E6306AB /* Ice.xcframework */; };
+		F1334E31F424EA6490643ACD /* IceImpl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A17DB692E0895FE387DAE12A /* IceImpl.xcframework */; };
+		F224573363F1E92C07784182 /* UsersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2471051F59F384D06E073851 /* UsersView.swift */; };
+		F36A09BF4F2AF56A3651178A /* IceStorm.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3066738A6A797BC7554D7EA6 /* IceStorm.xcframework */; };
+		F4587C50C2B3904121616A4C /* Callback.ice in Sources */ = {isa = PBXBuildFile; fileRef = C11ECF49C07B3F0D8D24D4CE /* Callback.ice */; };
+		F5F1CFCC4C702340C63F5FD5 /* PromiseKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A3283875DC46723DD0292377 /* PromiseKit.xcframework */; };
+		F6B146D65A2114694C15A26C /* Ice.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = BC03557C145BF03816F95E71 /* Ice.xcframework */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		F74460AE1424465DA89A2CE9 /* IceImpl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A17DB692E0895FE387DAE12A /* IceImpl.xcframework */; };
+		F89948908CC42B7B4F1FD3AC /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = F21FD317F3E42BD9EE4574FF /* main.swift */; };
+		F9E7DF7B873E4735C1DBBAB4 /* Ice.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = F6D5ADFEDCEA37390E6306AB /* Ice.xcframework */; };
+		FB6D97DE5F0214392DC5CDEE /* Client.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9390FFE79FD9D646D574DC1F /* Client.swift */; };
+		FEBDEBCF5F945337164FE811 /* StatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53305CC3053FB53A008BE291 /* StatusView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXBuildRule section */
-		0E06F531F9FFA91015B0E888 /* PBXBuildRule */ = {
+		09FA64871309C790F4915829 /* PBXBuildRule */ = {
 			isa = PBXBuildRule;
 			compilerSpec = com.apple.compilers.proxy.script;
 			filePatterns = "*.ice";
@@ -344,7 +338,7 @@
 			runOncePerArchitecture = 0;
 			script = "if [ -f \"${ICE_HOME-unset}/bin/slice2swift\" ]; then\n    SLICE2SWIFT=\"$ICE_HOME/bin/slice2swift\"\n    SLICEDIR=\"$ICE_HOME/slice\"\nelif [ -f /usr/local/bin/slice2swift ]; then\n    SLICE2SWIFT=/usr/local/bin/slice2swift\n    SLICEDIR=/usr/local/share/ice/slice\nelse\n    echo \"Failed to locate slice2swift compiler\"\n    exit 1\nfi\n\n\"$SLICE2SWIFT\" -I\"$SLICEDIR\" -I\"$INPUT_FILE_DIR\" --output-dir \"$DERIVED_FILE_DIR\" \"$INPUT_FILE_PATH\"\n";
 		};
-		1CFE4A43AA960CF8FD6431C2 /* PBXBuildRule */ = {
+		173B6DA731F8A6A3C1BB752C /* PBXBuildRule */ = {
 			isa = PBXBuildRule;
 			compilerSpec = com.apple.compilers.proxy.script;
 			filePatterns = "*.ice";
@@ -359,7 +353,7 @@
 			runOncePerArchitecture = 0;
 			script = "if [ -f \"${ICE_HOME-unset}/bin/slice2swift\" ]; then\n    SLICE2SWIFT=\"$ICE_HOME/bin/slice2swift\"\n    SLICEDIR=\"$ICE_HOME/slice\"\nelif [ -f /usr/local/bin/slice2swift ]; then\n    SLICE2SWIFT=/usr/local/bin/slice2swift\n    SLICEDIR=/usr/local/share/ice/slice\nelse\n    echo \"Failed to locate slice2swift compiler\"\n    exit 1\nfi\n\n\"$SLICE2SWIFT\" -I\"$SLICEDIR\" -I\"$INPUT_FILE_DIR\" --output-dir \"$DERIVED_FILE_DIR\" \"$INPUT_FILE_PATH\"\n";
 		};
-		1FD0F9896E0C0A8E941A61BE /* PBXBuildRule */ = {
+		19B1F356D43A751A68A31FA0 /* PBXBuildRule */ = {
 			isa = PBXBuildRule;
 			compilerSpec = com.apple.compilers.proxy.script;
 			filePatterns = "*.ice";
@@ -374,7 +368,7 @@
 			runOncePerArchitecture = 0;
 			script = "if [ -f \"${ICE_HOME-unset}/bin/slice2swift\" ]; then\n    SLICE2SWIFT=\"$ICE_HOME/bin/slice2swift\"\n    SLICEDIR=\"$ICE_HOME/slice\"\nelif [ -f /usr/local/bin/slice2swift ]; then\n    SLICE2SWIFT=/usr/local/bin/slice2swift\n    SLICEDIR=/usr/local/share/ice/slice\nelse\n    echo \"Failed to locate slice2swift compiler\"\n    exit 1\nfi\n\n\"$SLICE2SWIFT\" -I\"$SLICEDIR\" -I\"$INPUT_FILE_DIR\" --output-dir \"$DERIVED_FILE_DIR\" \"$INPUT_FILE_PATH\"\n";
 		};
-		32983ED06FB64B16AC6747A5 /* PBXBuildRule */ = {
+		1A523D52193A5779418E5077 /* PBXBuildRule */ = {
 			isa = PBXBuildRule;
 			compilerSpec = com.apple.compilers.proxy.script;
 			filePatterns = "*.ice";
@@ -389,7 +383,7 @@
 			runOncePerArchitecture = 0;
 			script = "if [ -f \"${ICE_HOME-unset}/bin/slice2swift\" ]; then\n    SLICE2SWIFT=\"$ICE_HOME/bin/slice2swift\"\n    SLICEDIR=\"$ICE_HOME/slice\"\nelif [ -f /usr/local/bin/slice2swift ]; then\n    SLICE2SWIFT=/usr/local/bin/slice2swift\n    SLICEDIR=/usr/local/share/ice/slice\nelse\n    echo \"Failed to locate slice2swift compiler\"\n    exit 1\nfi\n\n\"$SLICE2SWIFT\" -I\"$SLICEDIR\" -I\"$INPUT_FILE_DIR\" --output-dir \"$DERIVED_FILE_DIR\" \"$INPUT_FILE_PATH\"\n";
 		};
-		3719C432F43D3FAEF5A07132 /* PBXBuildRule */ = {
+		1B49080C136F32951D92F4ED /* PBXBuildRule */ = {
 			isa = PBXBuildRule;
 			compilerSpec = com.apple.compilers.proxy.script;
 			filePatterns = "*.ice";
@@ -404,7 +398,7 @@
 			runOncePerArchitecture = 0;
 			script = "if [ -f \"${ICE_HOME-unset}/bin/slice2swift\" ]; then\n    SLICE2SWIFT=\"$ICE_HOME/bin/slice2swift\"\n    SLICEDIR=\"$ICE_HOME/slice\"\nelif [ -f /usr/local/bin/slice2swift ]; then\n    SLICE2SWIFT=/usr/local/bin/slice2swift\n    SLICEDIR=/usr/local/share/ice/slice\nelse\n    echo \"Failed to locate slice2swift compiler\"\n    exit 1\nfi\n\n\"$SLICE2SWIFT\" -I\"$SLICEDIR\" -I\"$INPUT_FILE_DIR\" --output-dir \"$DERIVED_FILE_DIR\" \"$INPUT_FILE_PATH\"\n";
 		};
-		3D3ADFD2AF40F1BAE040430B /* PBXBuildRule */ = {
+		278092AC96609633F23F3170 /* PBXBuildRule */ = {
 			isa = PBXBuildRule;
 			compilerSpec = com.apple.compilers.proxy.script;
 			filePatterns = "*.ice";
@@ -419,7 +413,7 @@
 			runOncePerArchitecture = 0;
 			script = "if [ -f \"${ICE_HOME-unset}/bin/slice2swift\" ]; then\n    SLICE2SWIFT=\"$ICE_HOME/bin/slice2swift\"\n    SLICEDIR=\"$ICE_HOME/slice\"\nelif [ -f /usr/local/bin/slice2swift ]; then\n    SLICE2SWIFT=/usr/local/bin/slice2swift\n    SLICEDIR=/usr/local/share/ice/slice\nelse\n    echo \"Failed to locate slice2swift compiler\"\n    exit 1\nfi\n\n\"$SLICE2SWIFT\" -I\"$SLICEDIR\" -I\"$INPUT_FILE_DIR\" --output-dir \"$DERIVED_FILE_DIR\" \"$INPUT_FILE_PATH\"\n";
 		};
-		406F45E9E963EED4233296A3 /* PBXBuildRule */ = {
+		27ADB387DD96190E8368149F /* PBXBuildRule */ = {
 			isa = PBXBuildRule;
 			compilerSpec = com.apple.compilers.proxy.script;
 			filePatterns = "*.ice";
@@ -434,7 +428,7 @@
 			runOncePerArchitecture = 0;
 			script = "if [ -f \"${ICE_HOME-unset}/bin/slice2swift\" ]; then\n    SLICE2SWIFT=\"$ICE_HOME/bin/slice2swift\"\n    SLICEDIR=\"$ICE_HOME/slice\"\nelif [ -f /usr/local/bin/slice2swift ]; then\n    SLICE2SWIFT=/usr/local/bin/slice2swift\n    SLICEDIR=/usr/local/share/ice/slice\nelse\n    echo \"Failed to locate slice2swift compiler\"\n    exit 1\nfi\n\n\"$SLICE2SWIFT\" -I\"$SLICEDIR\" -I\"$INPUT_FILE_DIR\" --output-dir \"$DERIVED_FILE_DIR\" \"$INPUT_FILE_PATH\"\n";
 		};
-		41C4A8D3BE8CF66A8FADAF00 /* PBXBuildRule */ = {
+		334E503AA663C149C61B5779 /* PBXBuildRule */ = {
 			isa = PBXBuildRule;
 			compilerSpec = com.apple.compilers.proxy.script;
 			filePatterns = "*.ice";
@@ -449,7 +443,7 @@
 			runOncePerArchitecture = 0;
 			script = "if [ -f \"${ICE_HOME-unset}/bin/slice2swift\" ]; then\n    SLICE2SWIFT=\"$ICE_HOME/bin/slice2swift\"\n    SLICEDIR=\"$ICE_HOME/slice\"\nelif [ -f /usr/local/bin/slice2swift ]; then\n    SLICE2SWIFT=/usr/local/bin/slice2swift\n    SLICEDIR=/usr/local/share/ice/slice\nelse\n    echo \"Failed to locate slice2swift compiler\"\n    exit 1\nfi\n\n\"$SLICE2SWIFT\" -I\"$SLICEDIR\" -I\"$INPUT_FILE_DIR\" --output-dir \"$DERIVED_FILE_DIR\" \"$INPUT_FILE_PATH\"\n";
 		};
-		421C8FEC21D23626888A39F8 /* PBXBuildRule */ = {
+		3FA52435382FDEC0BA851B9F /* PBXBuildRule */ = {
 			isa = PBXBuildRule;
 			compilerSpec = com.apple.compilers.proxy.script;
 			filePatterns = "*.ice";
@@ -464,7 +458,7 @@
 			runOncePerArchitecture = 0;
 			script = "if [ -f \"${ICE_HOME-unset}/bin/slice2swift\" ]; then\n    SLICE2SWIFT=\"$ICE_HOME/bin/slice2swift\"\n    SLICEDIR=\"$ICE_HOME/slice\"\nelif [ -f /usr/local/bin/slice2swift ]; then\n    SLICE2SWIFT=/usr/local/bin/slice2swift\n    SLICEDIR=/usr/local/share/ice/slice\nelse\n    echo \"Failed to locate slice2swift compiler\"\n    exit 1\nfi\n\n\"$SLICE2SWIFT\" -I\"$SLICEDIR\" -I\"$INPUT_FILE_DIR\" --output-dir \"$DERIVED_FILE_DIR\" \"$INPUT_FILE_PATH\"\n";
 		};
-		4299ACAFB66C19199BCAB016 /* PBXBuildRule */ = {
+		4B8F1E606B26D31B0A872B9C /* PBXBuildRule */ = {
 			isa = PBXBuildRule;
 			compilerSpec = com.apple.compilers.proxy.script;
 			filePatterns = "*.ice";
@@ -479,7 +473,7 @@
 			runOncePerArchitecture = 0;
 			script = "if [ -f \"${ICE_HOME-unset}/bin/slice2swift\" ]; then\n    SLICE2SWIFT=\"$ICE_HOME/bin/slice2swift\"\n    SLICEDIR=\"$ICE_HOME/slice\"\nelif [ -f /usr/local/bin/slice2swift ]; then\n    SLICE2SWIFT=/usr/local/bin/slice2swift\n    SLICEDIR=/usr/local/share/ice/slice\nelse\n    echo \"Failed to locate slice2swift compiler\"\n    exit 1\nfi\n\n\"$SLICE2SWIFT\" -I\"$SLICEDIR\" -I\"$INPUT_FILE_DIR\" --output-dir \"$DERIVED_FILE_DIR\" \"$INPUT_FILE_PATH\"\n";
 		};
-		4585E5EB3CA7339430A627B7 /* PBXBuildRule */ = {
+		4EFA8054DAC43541B5D8A6B1 /* PBXBuildRule */ = {
 			isa = PBXBuildRule;
 			compilerSpec = com.apple.compilers.proxy.script;
 			filePatterns = "*.ice";
@@ -494,7 +488,7 @@
 			runOncePerArchitecture = 0;
 			script = "if [ -f \"${ICE_HOME-unset}/bin/slice2swift\" ]; then\n    SLICE2SWIFT=\"$ICE_HOME/bin/slice2swift\"\n    SLICEDIR=\"$ICE_HOME/slice\"\nelif [ -f /usr/local/bin/slice2swift ]; then\n    SLICE2SWIFT=/usr/local/bin/slice2swift\n    SLICEDIR=/usr/local/share/ice/slice\nelse\n    echo \"Failed to locate slice2swift compiler\"\n    exit 1\nfi\n\n\"$SLICE2SWIFT\" -I\"$SLICEDIR\" -I\"$INPUT_FILE_DIR\" --output-dir \"$DERIVED_FILE_DIR\" \"$INPUT_FILE_PATH\"\n";
 		};
-		4CDFB47EF0E9A0B3CA8C9B0E /* PBXBuildRule */ = {
+		51807347603BF086887A412D /* PBXBuildRule */ = {
 			isa = PBXBuildRule;
 			compilerSpec = com.apple.compilers.proxy.script;
 			filePatterns = "*.ice";
@@ -509,7 +503,7 @@
 			runOncePerArchitecture = 0;
 			script = "if [ -f \"${ICE_HOME-unset}/bin/slice2swift\" ]; then\n    SLICE2SWIFT=\"$ICE_HOME/bin/slice2swift\"\n    SLICEDIR=\"$ICE_HOME/slice\"\nelif [ -f /usr/local/bin/slice2swift ]; then\n    SLICE2SWIFT=/usr/local/bin/slice2swift\n    SLICEDIR=/usr/local/share/ice/slice\nelse\n    echo \"Failed to locate slice2swift compiler\"\n    exit 1\nfi\n\n\"$SLICE2SWIFT\" -I\"$SLICEDIR\" -I\"$INPUT_FILE_DIR\" --output-dir \"$DERIVED_FILE_DIR\" \"$INPUT_FILE_PATH\"\n";
 		};
-		56A42DF76C566BFA9FFDEF6E /* PBXBuildRule */ = {
+		59B8BA36CEA2A1C02A6646C0 /* PBXBuildRule */ = {
 			isa = PBXBuildRule;
 			compilerSpec = com.apple.compilers.proxy.script;
 			filePatterns = "*.ice";
@@ -524,7 +518,7 @@
 			runOncePerArchitecture = 0;
 			script = "if [ -f \"${ICE_HOME-unset}/bin/slice2swift\" ]; then\n    SLICE2SWIFT=\"$ICE_HOME/bin/slice2swift\"\n    SLICEDIR=\"$ICE_HOME/slice\"\nelif [ -f /usr/local/bin/slice2swift ]; then\n    SLICE2SWIFT=/usr/local/bin/slice2swift\n    SLICEDIR=/usr/local/share/ice/slice\nelse\n    echo \"Failed to locate slice2swift compiler\"\n    exit 1\nfi\n\n\"$SLICE2SWIFT\" -I\"$SLICEDIR\" -I\"$INPUT_FILE_DIR\" --output-dir \"$DERIVED_FILE_DIR\" \"$INPUT_FILE_PATH\"\n";
 		};
-		66A4E283D5F13032BD2C9B9B /* PBXBuildRule */ = {
+		6592CAD54A0B4EAE3690334B /* PBXBuildRule */ = {
 			isa = PBXBuildRule;
 			compilerSpec = com.apple.compilers.proxy.script;
 			filePatterns = "*.ice";
@@ -539,7 +533,7 @@
 			runOncePerArchitecture = 0;
 			script = "if [ -f \"${ICE_HOME-unset}/bin/slice2swift\" ]; then\n    SLICE2SWIFT=\"$ICE_HOME/bin/slice2swift\"\n    SLICEDIR=\"$ICE_HOME/slice\"\nelif [ -f /usr/local/bin/slice2swift ]; then\n    SLICE2SWIFT=/usr/local/bin/slice2swift\n    SLICEDIR=/usr/local/share/ice/slice\nelse\n    echo \"Failed to locate slice2swift compiler\"\n    exit 1\nfi\n\n\"$SLICE2SWIFT\" -I\"$SLICEDIR\" -I\"$INPUT_FILE_DIR\" --output-dir \"$DERIVED_FILE_DIR\" \"$INPUT_FILE_PATH\"\n";
 		};
-		6F1821E03518B1E82C60F750 /* PBXBuildRule */ = {
+		6683676801DC5340F7461EB3 /* PBXBuildRule */ = {
 			isa = PBXBuildRule;
 			compilerSpec = com.apple.compilers.proxy.script;
 			filePatterns = "*.ice";
@@ -554,7 +548,7 @@
 			runOncePerArchitecture = 0;
 			script = "if [ -f \"${ICE_HOME-unset}/bin/slice2swift\" ]; then\n    SLICE2SWIFT=\"$ICE_HOME/bin/slice2swift\"\n    SLICEDIR=\"$ICE_HOME/slice\"\nelif [ -f /usr/local/bin/slice2swift ]; then\n    SLICE2SWIFT=/usr/local/bin/slice2swift\n    SLICEDIR=/usr/local/share/ice/slice\nelse\n    echo \"Failed to locate slice2swift compiler\"\n    exit 1\nfi\n\n\"$SLICE2SWIFT\" -I\"$SLICEDIR\" -I\"$INPUT_FILE_DIR\" --output-dir \"$DERIVED_FILE_DIR\" \"$INPUT_FILE_PATH\"\n";
 		};
-		70254A2FFE981A7314224F2C /* PBXBuildRule */ = {
+		6969C041D92817702DDD3E05 /* PBXBuildRule */ = {
 			isa = PBXBuildRule;
 			compilerSpec = com.apple.compilers.proxy.script;
 			filePatterns = "*.ice";
@@ -569,7 +563,7 @@
 			runOncePerArchitecture = 0;
 			script = "if [ -f \"${ICE_HOME-unset}/bin/slice2swift\" ]; then\n    SLICE2SWIFT=\"$ICE_HOME/bin/slice2swift\"\n    SLICEDIR=\"$ICE_HOME/slice\"\nelif [ -f /usr/local/bin/slice2swift ]; then\n    SLICE2SWIFT=/usr/local/bin/slice2swift\n    SLICEDIR=/usr/local/share/ice/slice\nelse\n    echo \"Failed to locate slice2swift compiler\"\n    exit 1\nfi\n\n\"$SLICE2SWIFT\" -I\"$SLICEDIR\" -I\"$INPUT_FILE_DIR\" --output-dir \"$DERIVED_FILE_DIR\" \"$INPUT_FILE_PATH\"\n";
 		};
-		7527A13F00BAC0CF95F59030 /* PBXBuildRule */ = {
+		6E8BEFB904F45A399EF18CFF /* PBXBuildRule */ = {
 			isa = PBXBuildRule;
 			compilerSpec = com.apple.compilers.proxy.script;
 			filePatterns = "*.ice";
@@ -584,7 +578,7 @@
 			runOncePerArchitecture = 0;
 			script = "if [ -f \"${ICE_HOME-unset}/bin/slice2swift\" ]; then\n    SLICE2SWIFT=\"$ICE_HOME/bin/slice2swift\"\n    SLICEDIR=\"$ICE_HOME/slice\"\nelif [ -f /usr/local/bin/slice2swift ]; then\n    SLICE2SWIFT=/usr/local/bin/slice2swift\n    SLICEDIR=/usr/local/share/ice/slice\nelse\n    echo \"Failed to locate slice2swift compiler\"\n    exit 1\nfi\n\n\"$SLICE2SWIFT\" -I\"$SLICEDIR\" -I\"$INPUT_FILE_DIR\" --output-dir \"$DERIVED_FILE_DIR\" \"$INPUT_FILE_PATH\"\n";
 		};
-		7D8737FD3499AE4DACC5B7F5 /* PBXBuildRule */ = {
+		7BBDFAFB105F20244737212C /* PBXBuildRule */ = {
 			isa = PBXBuildRule;
 			compilerSpec = com.apple.compilers.proxy.script;
 			filePatterns = "*.ice";
@@ -599,7 +593,7 @@
 			runOncePerArchitecture = 0;
 			script = "if [ -f \"${ICE_HOME-unset}/bin/slice2swift\" ]; then\n    SLICE2SWIFT=\"$ICE_HOME/bin/slice2swift\"\n    SLICEDIR=\"$ICE_HOME/slice\"\nelif [ -f /usr/local/bin/slice2swift ]; then\n    SLICE2SWIFT=/usr/local/bin/slice2swift\n    SLICEDIR=/usr/local/share/ice/slice\nelse\n    echo \"Failed to locate slice2swift compiler\"\n    exit 1\nfi\n\n\"$SLICE2SWIFT\" -I\"$SLICEDIR\" -I\"$INPUT_FILE_DIR\" --output-dir \"$DERIVED_FILE_DIR\" \"$INPUT_FILE_PATH\"\n";
 		};
-		7E193C93AA1D3754DA045CF7 /* PBXBuildRule */ = {
+		8373C509512D2258C99A88DF /* PBXBuildRule */ = {
 			isa = PBXBuildRule;
 			compilerSpec = com.apple.compilers.proxy.script;
 			filePatterns = "*.ice";
@@ -614,7 +608,7 @@
 			runOncePerArchitecture = 0;
 			script = "if [ -f \"${ICE_HOME-unset}/bin/slice2swift\" ]; then\n    SLICE2SWIFT=\"$ICE_HOME/bin/slice2swift\"\n    SLICEDIR=\"$ICE_HOME/slice\"\nelif [ -f /usr/local/bin/slice2swift ]; then\n    SLICE2SWIFT=/usr/local/bin/slice2swift\n    SLICEDIR=/usr/local/share/ice/slice\nelse\n    echo \"Failed to locate slice2swift compiler\"\n    exit 1\nfi\n\n\"$SLICE2SWIFT\" -I\"$SLICEDIR\" -I\"$INPUT_FILE_DIR\" --output-dir \"$DERIVED_FILE_DIR\" \"$INPUT_FILE_PATH\"\n";
 		};
-		819889159CBDC04DFA75199F /* PBXBuildRule */ = {
+		853DDA973B06366CBD4924E0 /* PBXBuildRule */ = {
 			isa = PBXBuildRule;
 			compilerSpec = com.apple.compilers.proxy.script;
 			filePatterns = "*.ice";
@@ -629,7 +623,7 @@
 			runOncePerArchitecture = 0;
 			script = "if [ -f \"${ICE_HOME-unset}/bin/slice2swift\" ]; then\n    SLICE2SWIFT=\"$ICE_HOME/bin/slice2swift\"\n    SLICEDIR=\"$ICE_HOME/slice\"\nelif [ -f /usr/local/bin/slice2swift ]; then\n    SLICE2SWIFT=/usr/local/bin/slice2swift\n    SLICEDIR=/usr/local/share/ice/slice\nelse\n    echo \"Failed to locate slice2swift compiler\"\n    exit 1\nfi\n\n\"$SLICE2SWIFT\" -I\"$SLICEDIR\" -I\"$INPUT_FILE_DIR\" --output-dir \"$DERIVED_FILE_DIR\" \"$INPUT_FILE_PATH\"\n";
 		};
-		851736E0B6157559A3C74F87 /* PBXBuildRule */ = {
+		857B547C99E563D5F0561D21 /* PBXBuildRule */ = {
 			isa = PBXBuildRule;
 			compilerSpec = com.apple.compilers.proxy.script;
 			filePatterns = "*.ice";
@@ -644,7 +638,7 @@
 			runOncePerArchitecture = 0;
 			script = "if [ -f \"${ICE_HOME-unset}/bin/slice2swift\" ]; then\n    SLICE2SWIFT=\"$ICE_HOME/bin/slice2swift\"\n    SLICEDIR=\"$ICE_HOME/slice\"\nelif [ -f /usr/local/bin/slice2swift ]; then\n    SLICE2SWIFT=/usr/local/bin/slice2swift\n    SLICEDIR=/usr/local/share/ice/slice\nelse\n    echo \"Failed to locate slice2swift compiler\"\n    exit 1\nfi\n\n\"$SLICE2SWIFT\" -I\"$SLICEDIR\" -I\"$INPUT_FILE_DIR\" --output-dir \"$DERIVED_FILE_DIR\" \"$INPUT_FILE_PATH\"\n";
 		};
-		8C00F1B419F603FE73EE85A3 /* PBXBuildRule */ = {
+		87469216BECB3530AAE040D1 /* PBXBuildRule */ = {
 			isa = PBXBuildRule;
 			compilerSpec = com.apple.compilers.proxy.script;
 			filePatterns = "*.ice";
@@ -659,7 +653,7 @@
 			runOncePerArchitecture = 0;
 			script = "if [ -f \"${ICE_HOME-unset}/bin/slice2swift\" ]; then\n    SLICE2SWIFT=\"$ICE_HOME/bin/slice2swift\"\n    SLICEDIR=\"$ICE_HOME/slice\"\nelif [ -f /usr/local/bin/slice2swift ]; then\n    SLICE2SWIFT=/usr/local/bin/slice2swift\n    SLICEDIR=/usr/local/share/ice/slice\nelse\n    echo \"Failed to locate slice2swift compiler\"\n    exit 1\nfi\n\n\"$SLICE2SWIFT\" -I\"$SLICEDIR\" -I\"$INPUT_FILE_DIR\" --output-dir \"$DERIVED_FILE_DIR\" \"$INPUT_FILE_PATH\"\n";
 		};
-		8EF4AD55275B1DBDF9B9A43E /* PBXBuildRule */ = {
+		88780369B9F230397EF5C066 /* PBXBuildRule */ = {
 			isa = PBXBuildRule;
 			compilerSpec = com.apple.compilers.proxy.script;
 			filePatterns = "*.ice";
@@ -674,7 +668,7 @@
 			runOncePerArchitecture = 0;
 			script = "if [ -f \"${ICE_HOME-unset}/bin/slice2swift\" ]; then\n    SLICE2SWIFT=\"$ICE_HOME/bin/slice2swift\"\n    SLICEDIR=\"$ICE_HOME/slice\"\nelif [ -f /usr/local/bin/slice2swift ]; then\n    SLICE2SWIFT=/usr/local/bin/slice2swift\n    SLICEDIR=/usr/local/share/ice/slice\nelse\n    echo \"Failed to locate slice2swift compiler\"\n    exit 1\nfi\n\n\"$SLICE2SWIFT\" -I\"$SLICEDIR\" -I\"$INPUT_FILE_DIR\" --output-dir \"$DERIVED_FILE_DIR\" \"$INPUT_FILE_PATH\"\n";
 		};
-		9B76F1C4D8A7A0F002D98D9F /* PBXBuildRule */ = {
+		928486546746E8F5486B4AF3 /* PBXBuildRule */ = {
 			isa = PBXBuildRule;
 			compilerSpec = com.apple.compilers.proxy.script;
 			filePatterns = "*.ice";
@@ -689,7 +683,7 @@
 			runOncePerArchitecture = 0;
 			script = "if [ -f \"${ICE_HOME-unset}/bin/slice2swift\" ]; then\n    SLICE2SWIFT=\"$ICE_HOME/bin/slice2swift\"\n    SLICEDIR=\"$ICE_HOME/slice\"\nelif [ -f /usr/local/bin/slice2swift ]; then\n    SLICE2SWIFT=/usr/local/bin/slice2swift\n    SLICEDIR=/usr/local/share/ice/slice\nelse\n    echo \"Failed to locate slice2swift compiler\"\n    exit 1\nfi\n\n\"$SLICE2SWIFT\" -I\"$SLICEDIR\" -I\"$INPUT_FILE_DIR\" --output-dir \"$DERIVED_FILE_DIR\" \"$INPUT_FILE_PATH\"\n";
 		};
-		9FCC1FCFC7A3D808D523097C /* PBXBuildRule */ = {
+		9E3E75B18CDD6930E072CF5A /* PBXBuildRule */ = {
 			isa = PBXBuildRule;
 			compilerSpec = com.apple.compilers.proxy.script;
 			filePatterns = "*.ice";
@@ -704,7 +698,7 @@
 			runOncePerArchitecture = 0;
 			script = "if [ -f \"${ICE_HOME-unset}/bin/slice2swift\" ]; then\n    SLICE2SWIFT=\"$ICE_HOME/bin/slice2swift\"\n    SLICEDIR=\"$ICE_HOME/slice\"\nelif [ -f /usr/local/bin/slice2swift ]; then\n    SLICE2SWIFT=/usr/local/bin/slice2swift\n    SLICEDIR=/usr/local/share/ice/slice\nelse\n    echo \"Failed to locate slice2swift compiler\"\n    exit 1\nfi\n\n\"$SLICE2SWIFT\" -I\"$SLICEDIR\" -I\"$INPUT_FILE_DIR\" --output-dir \"$DERIVED_FILE_DIR\" \"$INPUT_FILE_PATH\"\n";
 		};
-		A218157A7BC216EBAE82D348 /* PBXBuildRule */ = {
+		A09A3CBFC6D99459D28FCC7A /* PBXBuildRule */ = {
 			isa = PBXBuildRule;
 			compilerSpec = com.apple.compilers.proxy.script;
 			filePatterns = "*.ice";
@@ -719,7 +713,7 @@
 			runOncePerArchitecture = 0;
 			script = "if [ -f \"${ICE_HOME-unset}/bin/slice2swift\" ]; then\n    SLICE2SWIFT=\"$ICE_HOME/bin/slice2swift\"\n    SLICEDIR=\"$ICE_HOME/slice\"\nelif [ -f /usr/local/bin/slice2swift ]; then\n    SLICE2SWIFT=/usr/local/bin/slice2swift\n    SLICEDIR=/usr/local/share/ice/slice\nelse\n    echo \"Failed to locate slice2swift compiler\"\n    exit 1\nfi\n\n\"$SLICE2SWIFT\" -I\"$SLICEDIR\" -I\"$INPUT_FILE_DIR\" --output-dir \"$DERIVED_FILE_DIR\" \"$INPUT_FILE_PATH\"\n";
 		};
-		A228580E1A43A248CA4AA122 /* PBXBuildRule */ = {
+		ADBC0D864075F574B4CEE6CE /* PBXBuildRule */ = {
 			isa = PBXBuildRule;
 			compilerSpec = com.apple.compilers.proxy.script;
 			filePatterns = "*.ice";
@@ -734,7 +728,7 @@
 			runOncePerArchitecture = 0;
 			script = "if [ -f \"${ICE_HOME-unset}/bin/slice2swift\" ]; then\n    SLICE2SWIFT=\"$ICE_HOME/bin/slice2swift\"\n    SLICEDIR=\"$ICE_HOME/slice\"\nelif [ -f /usr/local/bin/slice2swift ]; then\n    SLICE2SWIFT=/usr/local/bin/slice2swift\n    SLICEDIR=/usr/local/share/ice/slice\nelse\n    echo \"Failed to locate slice2swift compiler\"\n    exit 1\nfi\n\n\"$SLICE2SWIFT\" -I\"$SLICEDIR\" -I\"$INPUT_FILE_DIR\" --output-dir \"$DERIVED_FILE_DIR\" \"$INPUT_FILE_PATH\"\n";
 		};
-		A9B74F9AFB4557E7DBD6800B /* PBXBuildRule */ = {
+		B0CF47206A6E02FF52F70D63 /* PBXBuildRule */ = {
 			isa = PBXBuildRule;
 			compilerSpec = com.apple.compilers.proxy.script;
 			filePatterns = "*.ice";
@@ -749,7 +743,7 @@
 			runOncePerArchitecture = 0;
 			script = "if [ -f \"${ICE_HOME-unset}/bin/slice2swift\" ]; then\n    SLICE2SWIFT=\"$ICE_HOME/bin/slice2swift\"\n    SLICEDIR=\"$ICE_HOME/slice\"\nelif [ -f /usr/local/bin/slice2swift ]; then\n    SLICE2SWIFT=/usr/local/bin/slice2swift\n    SLICEDIR=/usr/local/share/ice/slice\nelse\n    echo \"Failed to locate slice2swift compiler\"\n    exit 1\nfi\n\n\"$SLICE2SWIFT\" -I\"$SLICEDIR\" -I\"$INPUT_FILE_DIR\" --output-dir \"$DERIVED_FILE_DIR\" \"$INPUT_FILE_PATH\"\n";
 		};
-		B36FFF764B7EF2F513C9AD7B /* PBXBuildRule */ = {
+		B73312EDBC1AF0035D53A4CF /* PBXBuildRule */ = {
 			isa = PBXBuildRule;
 			compilerSpec = com.apple.compilers.proxy.script;
 			filePatterns = "*.ice";
@@ -764,7 +758,7 @@
 			runOncePerArchitecture = 0;
 			script = "if [ -f \"${ICE_HOME-unset}/bin/slice2swift\" ]; then\n    SLICE2SWIFT=\"$ICE_HOME/bin/slice2swift\"\n    SLICEDIR=\"$ICE_HOME/slice\"\nelif [ -f /usr/local/bin/slice2swift ]; then\n    SLICE2SWIFT=/usr/local/bin/slice2swift\n    SLICEDIR=/usr/local/share/ice/slice\nelse\n    echo \"Failed to locate slice2swift compiler\"\n    exit 1\nfi\n\n\"$SLICE2SWIFT\" -I\"$SLICEDIR\" -I\"$INPUT_FILE_DIR\" --output-dir \"$DERIVED_FILE_DIR\" \"$INPUT_FILE_PATH\"\n";
 		};
-		B402161F82F03A5286729412 /* PBXBuildRule */ = {
+		BFD3A71AF9B9141C7003A969 /* PBXBuildRule */ = {
 			isa = PBXBuildRule;
 			compilerSpec = com.apple.compilers.proxy.script;
 			filePatterns = "*.ice";
@@ -779,7 +773,7 @@
 			runOncePerArchitecture = 0;
 			script = "if [ -f \"${ICE_HOME-unset}/bin/slice2swift\" ]; then\n    SLICE2SWIFT=\"$ICE_HOME/bin/slice2swift\"\n    SLICEDIR=\"$ICE_HOME/slice\"\nelif [ -f /usr/local/bin/slice2swift ]; then\n    SLICE2SWIFT=/usr/local/bin/slice2swift\n    SLICEDIR=/usr/local/share/ice/slice\nelse\n    echo \"Failed to locate slice2swift compiler\"\n    exit 1\nfi\n\n\"$SLICE2SWIFT\" -I\"$SLICEDIR\" -I\"$INPUT_FILE_DIR\" --output-dir \"$DERIVED_FILE_DIR\" \"$INPUT_FILE_PATH\"\n";
 		};
-		B634FC0262466B3FAD8D65EC /* PBXBuildRule */ = {
+		C05844AFC4473A58B91C8D3E /* PBXBuildRule */ = {
 			isa = PBXBuildRule;
 			compilerSpec = com.apple.compilers.proxy.script;
 			filePatterns = "*.ice";
@@ -794,7 +788,7 @@
 			runOncePerArchitecture = 0;
 			script = "if [ -f \"${ICE_HOME-unset}/bin/slice2swift\" ]; then\n    SLICE2SWIFT=\"$ICE_HOME/bin/slice2swift\"\n    SLICEDIR=\"$ICE_HOME/slice\"\nelif [ -f /usr/local/bin/slice2swift ]; then\n    SLICE2SWIFT=/usr/local/bin/slice2swift\n    SLICEDIR=/usr/local/share/ice/slice\nelse\n    echo \"Failed to locate slice2swift compiler\"\n    exit 1\nfi\n\n\"$SLICE2SWIFT\" -I\"$SLICEDIR\" -I\"$INPUT_FILE_DIR\" --output-dir \"$DERIVED_FILE_DIR\" \"$INPUT_FILE_PATH\"\n";
 		};
-		C24C58A904C5A31E6267936A /* PBXBuildRule */ = {
+		C6348C017141B2AC009D7B20 /* PBXBuildRule */ = {
 			isa = PBXBuildRule;
 			compilerSpec = com.apple.compilers.proxy.script;
 			filePatterns = "*.ice";
@@ -809,7 +803,7 @@
 			runOncePerArchitecture = 0;
 			script = "if [ -f \"${ICE_HOME-unset}/bin/slice2swift\" ]; then\n    SLICE2SWIFT=\"$ICE_HOME/bin/slice2swift\"\n    SLICEDIR=\"$ICE_HOME/slice\"\nelif [ -f /usr/local/bin/slice2swift ]; then\n    SLICE2SWIFT=/usr/local/bin/slice2swift\n    SLICEDIR=/usr/local/share/ice/slice\nelse\n    echo \"Failed to locate slice2swift compiler\"\n    exit 1\nfi\n\n\"$SLICE2SWIFT\" -I\"$SLICEDIR\" -I\"$INPUT_FILE_DIR\" --output-dir \"$DERIVED_FILE_DIR\" \"$INPUT_FILE_PATH\"\n";
 		};
-		C3C9DF19F1223F72D2085A2C /* PBXBuildRule */ = {
+		D2C1B0C447C447F9EB9CC359 /* PBXBuildRule */ = {
 			isa = PBXBuildRule;
 			compilerSpec = com.apple.compilers.proxy.script;
 			filePatterns = "*.ice";
@@ -824,7 +818,7 @@
 			runOncePerArchitecture = 0;
 			script = "if [ -f \"${ICE_HOME-unset}/bin/slice2swift\" ]; then\n    SLICE2SWIFT=\"$ICE_HOME/bin/slice2swift\"\n    SLICEDIR=\"$ICE_HOME/slice\"\nelif [ -f /usr/local/bin/slice2swift ]; then\n    SLICE2SWIFT=/usr/local/bin/slice2swift\n    SLICEDIR=/usr/local/share/ice/slice\nelse\n    echo \"Failed to locate slice2swift compiler\"\n    exit 1\nfi\n\n\"$SLICE2SWIFT\" -I\"$SLICEDIR\" -I\"$INPUT_FILE_DIR\" --output-dir \"$DERIVED_FILE_DIR\" \"$INPUT_FILE_PATH\"\n";
 		};
-		C4F3C5561F9031CA3D26999E /* PBXBuildRule */ = {
+		D64BD7B7854DD9B0DAE6DB3D /* PBXBuildRule */ = {
 			isa = PBXBuildRule;
 			compilerSpec = com.apple.compilers.proxy.script;
 			filePatterns = "*.ice";
@@ -839,7 +833,7 @@
 			runOncePerArchitecture = 0;
 			script = "if [ -f \"${ICE_HOME-unset}/bin/slice2swift\" ]; then\n    SLICE2SWIFT=\"$ICE_HOME/bin/slice2swift\"\n    SLICEDIR=\"$ICE_HOME/slice\"\nelif [ -f /usr/local/bin/slice2swift ]; then\n    SLICE2SWIFT=/usr/local/bin/slice2swift\n    SLICEDIR=/usr/local/share/ice/slice\nelse\n    echo \"Failed to locate slice2swift compiler\"\n    exit 1\nfi\n\n\"$SLICE2SWIFT\" -I\"$SLICEDIR\" -I\"$INPUT_FILE_DIR\" --output-dir \"$DERIVED_FILE_DIR\" \"$INPUT_FILE_PATH\"\n";
 		};
-		CF57CC737724508D9B3D9334 /* PBXBuildRule */ = {
+		DFBF4F5E260F24C2A49DB36C /* PBXBuildRule */ = {
 			isa = PBXBuildRule;
 			compilerSpec = com.apple.compilers.proxy.script;
 			filePatterns = "*.ice";
@@ -854,7 +848,7 @@
 			runOncePerArchitecture = 0;
 			script = "if [ -f \"${ICE_HOME-unset}/bin/slice2swift\" ]; then\n    SLICE2SWIFT=\"$ICE_HOME/bin/slice2swift\"\n    SLICEDIR=\"$ICE_HOME/slice\"\nelif [ -f /usr/local/bin/slice2swift ]; then\n    SLICE2SWIFT=/usr/local/bin/slice2swift\n    SLICEDIR=/usr/local/share/ice/slice\nelse\n    echo \"Failed to locate slice2swift compiler\"\n    exit 1\nfi\n\n\"$SLICE2SWIFT\" -I\"$SLICEDIR\" -I\"$INPUT_FILE_DIR\" --output-dir \"$DERIVED_FILE_DIR\" \"$INPUT_FILE_PATH\"\n";
 		};
-		E27F3AD87BAAA937B31B3F71 /* PBXBuildRule */ = {
+		E04266D5EFC8A13C1653471F /* PBXBuildRule */ = {
 			isa = PBXBuildRule;
 			compilerSpec = com.apple.compilers.proxy.script;
 			filePatterns = "*.ice";
@@ -869,7 +863,7 @@
 			runOncePerArchitecture = 0;
 			script = "if [ -f \"${ICE_HOME-unset}/bin/slice2swift\" ]; then\n    SLICE2SWIFT=\"$ICE_HOME/bin/slice2swift\"\n    SLICEDIR=\"$ICE_HOME/slice\"\nelif [ -f /usr/local/bin/slice2swift ]; then\n    SLICE2SWIFT=/usr/local/bin/slice2swift\n    SLICEDIR=/usr/local/share/ice/slice\nelse\n    echo \"Failed to locate slice2swift compiler\"\n    exit 1\nfi\n\n\"$SLICE2SWIFT\" -I\"$SLICEDIR\" -I\"$INPUT_FILE_DIR\" --output-dir \"$DERIVED_FILE_DIR\" \"$INPUT_FILE_PATH\"\n";
 		};
-		E42832E72A8082C162926B43 /* PBXBuildRule */ = {
+		EB1D4B8EDAE3BF2E17F810ED /* PBXBuildRule */ = {
 			isa = PBXBuildRule;
 			compilerSpec = com.apple.compilers.proxy.script;
 			filePatterns = "*.ice";
@@ -884,7 +878,7 @@
 			runOncePerArchitecture = 0;
 			script = "if [ -f \"${ICE_HOME-unset}/bin/slice2swift\" ]; then\n    SLICE2SWIFT=\"$ICE_HOME/bin/slice2swift\"\n    SLICEDIR=\"$ICE_HOME/slice\"\nelif [ -f /usr/local/bin/slice2swift ]; then\n    SLICE2SWIFT=/usr/local/bin/slice2swift\n    SLICEDIR=/usr/local/share/ice/slice\nelse\n    echo \"Failed to locate slice2swift compiler\"\n    exit 1\nfi\n\n\"$SLICE2SWIFT\" -I\"$SLICEDIR\" -I\"$INPUT_FILE_DIR\" --output-dir \"$DERIVED_FILE_DIR\" \"$INPUT_FILE_PATH\"\n";
 		};
-		E8FB65305DCE581EBA6AF18C /* PBXBuildRule */ = {
+		EC17EBB10AE82FBBAC91CDA8 /* PBXBuildRule */ = {
 			isa = PBXBuildRule;
 			compilerSpec = com.apple.compilers.proxy.script;
 			filePatterns = "*.ice";
@@ -899,7 +893,7 @@
 			runOncePerArchitecture = 0;
 			script = "if [ -f \"${ICE_HOME-unset}/bin/slice2swift\" ]; then\n    SLICE2SWIFT=\"$ICE_HOME/bin/slice2swift\"\n    SLICEDIR=\"$ICE_HOME/slice\"\nelif [ -f /usr/local/bin/slice2swift ]; then\n    SLICE2SWIFT=/usr/local/bin/slice2swift\n    SLICEDIR=/usr/local/share/ice/slice\nelse\n    echo \"Failed to locate slice2swift compiler\"\n    exit 1\nfi\n\n\"$SLICE2SWIFT\" -I\"$SLICEDIR\" -I\"$INPUT_FILE_DIR\" --output-dir \"$DERIVED_FILE_DIR\" \"$INPUT_FILE_PATH\"\n";
 		};
-		F6321A69FAB896D576AC1E10 /* PBXBuildRule */ = {
+		FF1144A4A89CEB15B5C2327D /* PBXBuildRule */ = {
 			isa = PBXBuildRule;
 			compilerSpec = com.apple.compilers.proxy.script;
 			filePatterns = "*.ice";
@@ -917,321 +911,320 @@
 /* End PBXBuildRule section */
 
 /* Begin PBXContainerItemProxy section */
-		0B8904A274FA8C175C4A41CD /* PBXContainerItemProxy */ = {
+		019C952AD7D957641982816E /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = EB97194894496C5DB10325DC /* Project object */;
+			containerPortal = ED7A4595F994579960C2BA8E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = A6F15048BA62D0740B115770;
-			remoteInfo = IOSChat;
-		};
-		0C326F9191A3BC5085FEDAAB /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = EB97194894496C5DB10325DC /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = E7FF091AC675DE1B5A97F3BB;
-			remoteInfo = IceHelloClient;
-		};
-		0D5EC3148FBA8C2B030FED9B /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = EB97194894496C5DB10325DC /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 4E426E1AF0E71376C9E873BB;
-			remoteInfo = IceBidirClient;
-		};
-		1D4D47606BCAE753A4E145F1 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = EB97194894496C5DB10325DC /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 58E3C656CAC60E5D4435A63A;
-			remoteInfo = IceInterceptorServer;
-		};
-		2F688196AAAF35FF9346B413 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = EB97194894496C5DB10325DC /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = BC411A1038EBE1215648035D;
-			remoteInfo = IceAsyncInvocationClient;
-		};
-		32580EE14DCB3BCF2F65AE30 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = EB97194894496C5DB10325DC /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 0040AFB2BDF7A4FC5F2A6D3C;
-			remoteInfo = IceDiscoveryHelloClient;
-		};
-		36293BFD5862D1D023D4CB45 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = EB97194894496C5DB10325DC /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 5B5E6A9FEB4E4E67A418460C;
-			remoteInfo = IceBidirServer;
-		};
-		3BE12E835AE5543B5C79C159 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = EB97194894496C5DB10325DC /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = F278530FC73733F84C3B351A;
-			remoteInfo = IceLatencyClient;
-		};
-		40E8EBE9EF91F747A6E3CA0E /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = EB97194894496C5DB10325DC /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 365E2519E773257B91EA2017;
-			remoteInfo = ManualSimpleFilesystemClient;
-		};
-		46C321BF94C54FC8E80C981E /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = EB97194894496C5DB10325DC /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 3D0479F643E6EBFDE4F41251;
-			remoteInfo = IceOptionalServer;
-		};
-		496E4631D7AF70ED5C5371CF /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = EB97194894496C5DB10325DC /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = A16D90A9F6AFEC8E5F36B277;
-			remoteInfo = IceContextServer;
-		};
-		4C7B9532FD369B0CD4F2BA0E /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = EB97194894496C5DB10325DC /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = E3DF7A1C971AE032647A29C2;
-			remoteInfo = IceAsyncInvocationServer;
-		};
-		4DB1ABC150490B92360C177F /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = EB97194894496C5DB10325DC /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 3455DFD133AC5C33DE41401D;
-			remoteInfo = ManualSimpleFilesystemServer;
-		};
-		58654AD4C1F3A66A5A3F89A4 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = EB97194894496C5DB10325DC /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 5DEB7AA4511B4B1F1983ECA8;
-			remoteInfo = IceStormClockPublisher;
-		};
-		62429F39B0C45A9586D91065 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = EB97194894496C5DB10325DC /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 1687F343DF79EA8213972141;
-			remoteInfo = IceAsyncClient;
-		};
-		6491F8D00990393771B8F183 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = EB97194894496C5DB10325DC /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 86A3F4B19E9DAF9E4B15533A;
-			remoteInfo = IceGridSimpleClient;
-		};
-		6B2CE321A1AF81EC076EE1B6 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = EB97194894496C5DB10325DC /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = ACB5ECC440F9694952C7B84C;
-			remoteInfo = IceLatencyServer;
-		};
-		79DF54AEFCFCBD27E7722B49 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = EB97194894496C5DB10325DC /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 1FD7893AE80DF5B104A80BA6;
-			remoteInfo = IceStormClockSubscriber;
-		};
-		80721687FF88494EECD69774 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = EB97194894496C5DB10325DC /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 7F125170B599E70103C6F1A4;
-			remoteInfo = ManualPrinterClient;
-		};
-		876D1AD5C3397DF0EF0D741F /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = EB97194894496C5DB10325DC /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 5C6AA42A0C3A9B8309B6C879;
-			remoteInfo = IceDiscoveryReplicationServer;
-		};
-		8E2311577DAE7E84D5AA1B42 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = EB97194894496C5DB10325DC /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 50C7DC4E4B424490F7F59AE9;
-			remoteInfo = ManualPrinterServer;
-		};
-		90ECED75B4BCAAAD7AACD646 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = EB97194894496C5DB10325DC /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = FB515029F564EEC25346D66A;
-			remoteInfo = IceHelloServer;
-		};
-		925AB48A70315B4700A85490 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = EB97194894496C5DB10325DC /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 08FFABF181D09958170A8064;
+			remoteGlobalIDString = 764B259011A33FA3A95412E9;
 			remoteInfo = IceInvokeServer;
 		};
-		96E5E20EB84280144F4B6CB6 /* PBXContainerItemProxy */ = {
+		0D4B87CAF2AB5ED21484FE00 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = EB97194894496C5DB10325DC /* Project object */;
+			containerPortal = ED7A4595F994579960C2BA8E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 7B111AE4525C41AA7E021233;
-			remoteInfo = IceOptionalClient;
+			remoteGlobalIDString = F658A5FB5551039F774F74EF;
+			remoteInfo = ManualPrinterClient;
 		};
-		9A271DC17146B86DA5DACEB2 /* PBXContainerItemProxy */ = {
+		12BC6DBA93A63CE93CFAEC1C /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = EB97194894496C5DB10325DC /* Project object */;
+			containerPortal = ED7A4595F994579960C2BA8E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = A61365A18C78646CBE55C376;
-			remoteInfo = IOSLibrary;
+			remoteGlobalIDString = 42561EDFCCB220DEAFE26FA5;
+			remoteInfo = IceStormClockSubscriber;
 		};
-		9CD7BC101525588F9A305BC2 /* PBXContainerItemProxy */ = {
+		1B595A8F668E5DE4E3AA841B /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = EB97194894496C5DB10325DC /* Project object */;
+			containerPortal = ED7A4595F994579960C2BA8E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = E542D48F2448F7F27D80BDD0;
-			remoteInfo = IceGridSimpleServer;
+			remoteGlobalIDString = 21FA6A38274DBCD88814D274;
+			remoteInfo = ManualPrinterServer;
 		};
-		9F0BB33D5C40039916D6C3A0 /* PBXContainerItemProxy */ = {
+		1E59D26711F97FF5AA590F38 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = EB97194894496C5DB10325DC /* Project object */;
+			containerPortal = ED7A4595F994579960C2BA8E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 2EC0D18A54E54780FF0CA0C0;
-			remoteInfo = Glacier2CallbackClient;
+			remoteGlobalIDString = F4A581497FDEB379F7675C88;
+			remoteInfo = IceAsyncClient;
 		};
-		AC3C14F11F3C4BC182C89A3E /* PBXContainerItemProxy */ = {
+		23329BBA8240C37E6D0CB6EC /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = EB97194894496C5DB10325DC /* Project object */;
+			containerPortal = ED7A4595F994579960C2BA8E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 17295EE8D54F50AC8BC95360;
-			remoteInfo = Glacier2CallbackServer;
-		};
-		AD0AE6C0E54FE4BFB06C2697 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = EB97194894496C5DB10325DC /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 3487D0246103973B15740CF3;
-			remoteInfo = IceInterceptorClient;
-		};
-		B545F81D50CB3D7B9A451E89 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = EB97194894496C5DB10325DC /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = A02EBE57139105D20DA043C0;
-			remoteInfo = IceMinimalServer;
-		};
-		B58269CF98B8FF7734EF3245 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = EB97194894496C5DB10325DC /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 838136AD0308E0D7D7EC2582;
+			remoteGlobalIDString = 68AAF193626BC30C4CD8884F;
 			remoteInfo = IceAsyncServer;
 		};
-		B90DA744A66E504BD1D4E123 /* PBXContainerItemProxy */ = {
+		2B4201EE481CA31C1F87C519 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = EB97194894496C5DB10325DC /* Project object */;
+			containerPortal = ED7A4595F994579960C2BA8E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 1CEA3A13E08931B50C514BD0;
-			remoteInfo = IceMinimalClient;
+			remoteGlobalIDString = 8DEC3881159900B77EBC1E89;
+			remoteInfo = IceHelloClient;
 		};
-		D3CB513EA8768662AA501F26 /* PBXContainerItemProxy */ = {
+		2C77E4A4622047D8F9B53150 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = EB97194894496C5DB10325DC /* Project object */;
+			containerPortal = ED7A4595F994579960C2BA8E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = C55F08EC4140C753CCD40E6B;
-			remoteInfo = IceContextClient;
+			remoteGlobalIDString = C389294E4BB98ADFCDF8F54E;
+			remoteInfo = IceGridSimpleClient;
 		};
-		D6F219FF84D3918D6583F27C /* PBXContainerItemProxy */ = {
+		2E0E6DF0C05D1FDC6DBACE80 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = EB97194894496C5DB10325DC /* Project object */;
+			containerPortal = ED7A4595F994579960C2BA8E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = CBE5A662859EB3A829D935EB;
-			remoteInfo = IceThroughputClient;
+			remoteGlobalIDString = 010C5E8438CC6EBBB1D05568;
+			remoteInfo = IceOptionalServer;
 		};
-		DE931F7C741B82B2FDB72FD8 /* PBXContainerItemProxy */ = {
+		3C2B6E1A2CBF84BDE6D1889A /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = EB97194894496C5DB10325DC /* Project object */;
+			containerPortal = ED7A4595F994579960C2BA8E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 445F4A8EEC5CA2028C536DAE;
-			remoteInfo = IceInvokeClient;
+			remoteGlobalIDString = CBAB61F561408159107E5665;
+			remoteInfo = IceAsyncInvocationClient;
 		};
-		E01866E3BCE5FC272665ADE2 /* PBXContainerItemProxy */ = {
+		3D9D5FFA64F8FBC4FAA88852 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = EB97194894496C5DB10325DC /* Project object */;
+			containerPortal = ED7A4595F994579960C2BA8E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = A8AC5929B89E3A59CD81EB3D;
+			remoteGlobalIDString = 0BF52782AF7FCCEF27A337AE;
+			remoteInfo = Chat;
+		};
+		41B1C5D8558987074E8CCBC9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = ED7A4595F994579960C2BA8E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 7B02D53AC9CADE3781497FE2;
+			remoteInfo = IceStormClockPublisher;
+		};
+		41E3CB0D985C31D3E71B9D80 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = ED7A4595F994579960C2BA8E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 5DA2E0F891AB6C1C5B232CE4;
+			remoteInfo = IceDiscoveryHelloUI;
+		};
+		459C995D4CBF28C828BA4500 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = ED7A4595F994579960C2BA8E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 90C4A14E104360C2D66BE95A;
+			remoteInfo = IceGridSimpleServer;
+		};
+		4A17D782CD94AEDD43B56621 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = ED7A4595F994579960C2BA8E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 1E2F71AC52A0BDDD354133D0;
+			remoteInfo = IceDiscoveryReplicationClient;
+		};
+		586A12EA69F5986ECADC392A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = ED7A4595F994579960C2BA8E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 4159934A7B7D66A462AA96E3;
+			remoteInfo = IceHelloServer;
+		};
+		693851ED711E0AA8C57F836C /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = ED7A4595F994579960C2BA8E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 2EE15C61DC2F49143CC9488C;
+			remoteInfo = IceDiscoveryReplicationServer;
+		};
+		6BF0C8C662B26EB383206C40 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = ED7A4595F994579960C2BA8E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A52F7C41BC31497EF70154BB;
+			remoteInfo = ManualSimpleFilesystemServer;
+		};
+		6C50C7437414AA4024DCC632 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = ED7A4595F994579960C2BA8E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 0F333E1C9E6C91C3396F59A2;
 			remoteInfo = IceDiscoveryHelloServer;
 		};
-		E7FD8E9F0157ADF9CEDE027A /* PBXContainerItemProxy */ = {
+		76162E42F6EA83C50C4CD30B /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = EB97194894496C5DB10325DC /* Project object */;
+			containerPortal = ED7A4595F994579960C2BA8E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 7E534192D654D74C4E38373F;
-			remoteInfo = IOSHello;
+			remoteGlobalIDString = 75886DD9A8F4E2B5F19D1A9A;
+			remoteInfo = IceMinimalClient;
 		};
-		F022B798F9FE24514D10A1EE /* PBXContainerItemProxy */ = {
+		8211C3572D64C32021F0A6C2 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = EB97194894496C5DB10325DC /* Project object */;
+			containerPortal = ED7A4595F994579960C2BA8E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = D8B2F755F5313CF3ED40667F;
+			remoteGlobalIDString = 456CC1D6828C3983EF2241D5;
+			remoteInfo = IceThroughputClient;
+		};
+		825CF42FBA0BB797CFC97167 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = ED7A4595F994579960C2BA8E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 07CAFE2F01A2B040FC16287C;
 			remoteInfo = IceThroughputServer;
 		};
-		F7F0CED654AF02F62EB32D4E /* PBXContainerItemProxy */ = {
+		8439A11095CF8CA0A9C2781F /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = EB97194894496C5DB10325DC /* Project object */;
+			containerPortal = ED7A4595F994579960C2BA8E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 9B342C4AF32DBB323A3A0BBA;
-			remoteInfo = IceDiscoveryReplicationClient;
+			remoteGlobalIDString = E24362D5509CD78EA3C2E846;
+			remoteInfo = IceInterceptorClient;
+		};
+		85E9E22044F8C7EFC493A2EB /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = ED7A4595F994579960C2BA8E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 60AFAA9D313FD61836B69D3F;
+			remoteInfo = IceAsyncInvocationServer;
+		};
+		872D375B18F897D681C365E6 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = ED7A4595F994579960C2BA8E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = E9CFD638AD4E2EBE3E1F95DB;
+			remoteInfo = IceMinimalServer;
+		};
+		88A1582DED14101E99B6812E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = ED7A4595F994579960C2BA8E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = AED3746019CE470B01C4CD89;
+			remoteInfo = IceContextClient;
+		};
+		8F70203498C72724369E6EB4 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = ED7A4595F994579960C2BA8E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 9514BAF35E560E29ACF6770A;
+			remoteInfo = IceBidirServer;
+		};
+		9FE6D59A8B101A8FB42E49D5 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = ED7A4595F994579960C2BA8E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 2B975A6278F9D6CCE53F5E35;
+			remoteInfo = IceLatencyClient;
+		};
+		A941037954E59C14479BCF89 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = ED7A4595F994579960C2BA8E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 9575E4AABF609C87FECCF75E;
+			remoteInfo = IceContextServer;
+		};
+		AABCC613B7BDD2ACEB26957D /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = ED7A4595F994579960C2BA8E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 6C69582EEABAE4429977B37A;
+			remoteInfo = IceOptionalClient;
+		};
+		AD6C40A15EE50A6155CC4003 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = ED7A4595F994579960C2BA8E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 62CD0C57C3183B4C1ACFB7E7;
+			remoteInfo = Glacier2CallbackServer;
+		};
+		B212E327713138C5FD46DF62 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = ED7A4595F994579960C2BA8E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 99EA7DE41DE8CC2A65D1B2C8;
+			remoteInfo = IceInvokeClient;
+		};
+		B922C62E381FA912414D5E6F /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = ED7A4595F994579960C2BA8E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 0EDB6F8830769A463C145F4E;
+			remoteInfo = ManualSimpleFilesystemClient;
+		};
+		CBA2AC9F58B2138EE35A9A9E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = ED7A4595F994579960C2BA8E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 0AE8C7670A42B03A39CDA3C5;
+			remoteInfo = IceDiscoveryHelloClient;
+		};
+		CF99885B13A30AECF185306A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = ED7A4595F994579960C2BA8E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 6D9EBD901A955C9B5D5C1AE3;
+			remoteInfo = IceHelloUI;
+		};
+		CFFFE07FC37E166E6D9702E4 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = ED7A4595F994579960C2BA8E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 10114A97EDF918D7074BC9E8;
+			remoteInfo = IceBidirClient;
+		};
+		DC0A32D69BA2E81EE1521147 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = ED7A4595F994579960C2BA8E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 8421E27006F16414C9BB2D92;
+			remoteInfo = Glacier2CallbackClient;
+		};
+		EE190BFC55A3A86826C1867C /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = ED7A4595F994579960C2BA8E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = BD669BA1D9DFD486901D342F;
+			remoteInfo = IceInterceptorServer;
+		};
+		FB3D45D8E6A951CB97876B42 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = ED7A4595F994579960C2BA8E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 1D324440A0F5469DC7B3CE68;
+			remoteInfo = IceLatencyServer;
 		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
-		6FF2F8EACE9BCA4B7C32640F /* Embed Frameworks */ = {
+		085495C825A1B54FDC3C60EA /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				8A73156BB0693578CFC70CD6 /* Ice.xcframework in Embed Frameworks */,
-				16841EEC752AE669FF860A28 /* IceImpl.xcframework in Embed Frameworks */,
-				FABB8B99C0CC31F983A710BC /* PromiseKit.xcframework in Embed Frameworks */,
+				DE870E0875BDCD3589DD81B9 /* Ice.xcframework in Embed Frameworks */,
+				76C3E5FEFEFF0C38B8F5D81E /* IceImpl.xcframework in Embed Frameworks */,
+				D3DAECABBB46132BC75329B5 /* PromiseKit.xcframework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		E3FC160E08F566B7F7190721 /* Embed Frameworks */ = {
+		41498733F2631F5127B2A983 /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				A0F390FFD28C816316318200 /* Glacier2.xcframework in Embed Frameworks */,
-				4092F0E6F262FDBCF7BE4D3B /* Ice.xcframework in Embed Frameworks */,
-				681C86B6B39F63097347A465 /* IceImpl.xcframework in Embed Frameworks */,
-				B9970D1C9424B23C56F7D0BD /* PromiseKit.xcframework in Embed Frameworks */,
+				F6B146D65A2114694C15A26C /* Ice.xcframework in Embed Frameworks */,
+				922A8900A3C17A8E69A22FB9 /* IceImpl.xcframework in Embed Frameworks */,
+				3D4BB6ADC54B7D0112414BD0 /* PromiseKit.xcframework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		FEE07ED1090D596DED44996E /* Embed Frameworks */ = {
+		FB748DFB58D56E164F2AB72F /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				526E06AF28894ACB154AAFA5 /* Glacier2.xcframework in Embed Frameworks */,
-				402F87AC13D27D7F50EEB2C5 /* Ice.xcframework in Embed Frameworks */,
-				1515090A8F460C2A8D4143CB /* IceImpl.xcframework in Embed Frameworks */,
-				13C6818DF564007890DB1402 /* InputBarAccessoryView.xcframework in Embed Frameworks */,
-				7BAEFD2E4CE634061DB81263 /* MessageKit.xcframework in Embed Frameworks */,
-				BFE19108A71379FBD40D4015 /* PromiseKit.xcframework in Embed Frameworks */,
+				E5A59CA6972B19A66BC38E1C /* Glacier2.xcframework in Embed Frameworks */,
+				32A399636483721E49F83D5A /* Ice.xcframework in Embed Frameworks */,
+				4C62A4D89471B0E78F97AE08 /* IceImpl.xcframework in Embed Frameworks */,
+				BFE8E78DF08D391D3811E620 /* InputBarAccessoryView.xcframework in Embed Frameworks */,
+				01BBF3B7DAB8FBABEC3405C4 /* MessageKit.xcframework in Embed Frameworks */,
+				6CC0B49DB9B252989721D2D6 /* PromiseKit.xcframework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1239,2226 +1232,2209 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		00E639D7AAB89720BD2AF551 /* main.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = main.swift; path = Ice/context/Sources/Client/main.swift; sourceTree = "<group>"; };
-		017A6BF2C245B1938F34C6C8 /* IceDiscoveryReplicationServer */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = text; name = IceDiscoveryReplicationServer; path = server; sourceTree = BUILT_PRODUCTS_DIR; };
-		018AF44E0CED15AAF2DDEC48 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = iOS/hello/README.md; sourceTree = "<group>"; };
-		01DCB1638386E8F076C4527F /* main.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = main.swift; path = IceDiscovery/hello/Sources/Server/main.swift; sourceTree = "<group>"; };
-		04B294665F8365C4660E5293 /* ChatController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ChatController.swift; path = iOS/chat/ChatController.swift; sourceTree = "<group>"; };
-		04E169866A28CE4C09EC830C /* IceAsyncInvocationServer */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = text; name = IceAsyncInvocationServer; path = server; sourceTree = BUILT_PRODUCTS_DIR; };
-		062D4FF632571C9B1EE57EDA /* main.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = main.swift; path = Ice/async/Sources/Client/main.swift; sourceTree = "<group>"; };
-		06BE5622AC513229E4D8C1DA /* main.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = main.swift; path = Ice/context/Sources/Server/main.swift; sourceTree = "<group>"; };
-		0942CEA562FE56F14AE24E39 /* Contact.ice */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Contact.ice; path = Ice/optional/Sources/Contact.ice; sourceTree = "<group>"; };
-		0BF7011B044009FEDA7643A3 /* Hello.ice */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Hello.ice; path = IceGrid/simple/Sources/Hello.ice; sourceTree = "<group>"; };
-		0C4552F3A57E06F1FE087CA3 /* main.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = main.swift; path = Ice/interceptor/Sources/Server/main.swift; sourceTree = "<group>"; };
-		0CC9437BF449759BC05DF17E /* CalculatorI.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CalculatorI.swift; path = Ice/asyncInvocation/Sources/Server/CalculatorI.swift; sourceTree = "<group>"; };
-		10580C577F8088ACB4185AFF /* config.server */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = config.server; path = Ice/invoke/config.server; sourceTree = "<group>"; };
-		10A521847822A38F221AF2AF /* Callback.ice */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Callback.ice; path = Glacier2/callback/Sources/Callback.ice; sourceTree = "<group>"; };
-		115E221C6424603632377848 /* ChatUser.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ChatUser.swift; path = iOS/chat/ChatUser.swift; sourceTree = "<group>"; };
-		16B1909C47C25A2F958F9B42 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = Ice/interceptor/README.md; sourceTree = "<group>"; };
-		16DBCF84A11CA84DB546F2A8 /* Calculator.ice */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Calculator.ice; path = Ice/asyncInvocation/Sources/Calculator.ice; sourceTree = "<group>"; };
-		17040B3C51149ECC64FDA2F3 /* config.sub */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = config.sub; path = IceStorm/clock/config.sub; sourceTree = "<group>"; };
-		176C6FB865C900ACDE99E192 /* ChatSession.ice */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = ChatSession.ice; path = iOS/chat/ChatSession.ice; sourceTree = "<group>"; };
-		1778B75182C1B414605236A2 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = Ice/optional/README.md; sourceTree = "<group>"; };
-		17C01B6B96D318BD91BCCED7 /* LoadingButton.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LoadingButton.swift; path = iOS/chat/LoadingButton.swift; sourceTree = "<group>"; };
-		196EF0A3C8C45D4604C52011 /* main.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = main.swift; path = Ice/interceptor/Sources/Client/main.swift; sourceTree = "<group>"; };
-		1E17322B9B3129F67236C598 /* config.client */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = config.client; path = iOS/chat/config.client; sourceTree = "<group>"; };
-		1EA7D8DD444806C4FE809AC5 /* IceAsyncClient */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = text; name = IceAsyncClient; path = client; sourceTree = BUILT_PRODUCTS_DIR; };
-		2210BCF19216BBCAD944F9D6 /* ManualSimpleFilesystemClient */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = text; name = ManualSimpleFilesystemClient; path = client; sourceTree = BUILT_PRODUCTS_DIR; };
-		22C91647BDCDB9779AB19CA3 /* IceHelloServer */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = text; name = IceHelloServer; path = server; sourceTree = BUILT_PRODUCTS_DIR; };
-		22F9E0B5646525E4BCDD65DB /* ThermostatI.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ThermostatI.swift; path = Ice/interceptor/Sources/Server/ThermostatI.swift; sourceTree = "<group>"; };
-		243D3F8A601DE2B8A3FA36B3 /* config.client */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = config.client; path = Ice/interceptor/config.client; sourceTree = "<group>"; };
-		26C4F52C904CDC3D4D1A5308 /* config.client */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = config.client; path = Glacier2/callback/config.client; sourceTree = "<group>"; };
-		28C558DB55A446508E4FF509 /* Ice.xcframework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.xcframework; name = Ice.xcframework; path = Carthage/Build/Ice.xcframework; sourceTree = "<group>"; };
-		28DADE4A9B6DA1704649740D /* main.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = main.swift; path = Ice/asyncInvocation/Sources/Server/main.swift; sourceTree = "<group>"; };
-		2A4CA42CA6ED3C00EE5DC00C /* IceBidirServer */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = text; name = IceBidirServer; path = server; sourceTree = BUILT_PRODUCTS_DIR; };
-		2BB13C7076DA20F0C7BFDC36 /* config.server */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = config.server; path = Ice/bidir/config.server; sourceTree = "<group>"; };
-		2C3DB1C65D1B9ED24051DE99 /* IceBidirClient */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = text; name = IceBidirClient; path = client; sourceTree = BUILT_PRODUCTS_DIR; };
-		2DA6A62EE8B96C49196C6104 /* Main.storyboard */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file.storyboard; name = Main.storyboard; path = iOS/chat/Base.lproj/Main.storyboard; sourceTree = "<group>"; };
-		2F5252E6DE7462352320FB7A /* LoginController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LoginController.swift; path = iOS/chat/LoginController.swift; sourceTree = "<group>"; };
-		32029539794EF0F1BBB97D18 /* MessageKit.xcframework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.xcframework; name = MessageKit.xcframework; path = Carthage/Build/MessageKit.xcframework; sourceTree = "<group>"; };
-		33A4936D644169FE316E54E1 /* main.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = main.swift; path = Ice/optional/Sources/Client/main.swift; sourceTree = "<group>"; };
-		344F81939D64CD391A3B64BA /* main.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = main.swift; path = Ice/optional/Sources/Server/main.swift; sourceTree = "<group>"; };
-		38D692F7A1A59D07B3A84D38 /* Context.ice */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Context.ice; path = Ice/context/Sources/Context.ice; sourceTree = "<group>"; };
-		393A11CCE8A9AF5886257EB1 /* Printer.ice */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Printer.ice; path = Manual/printer/Sources/Printer.ice; sourceTree = "<group>"; };
-		3963729A3421FF714DB83E79 /* IOSHello.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; name = IOSHello.app; path = hello.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		39C8A1A7AB5FD2BC8E5D7419 /* IceStormClockPublisher */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = text; name = IceStormClockPublisher; path = publisher; sourceTree = BUILT_PRODUCTS_DIR; };
-		3A68D8EB52D1135866BCA2C2 /* IceLatencyServer */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = text; name = IceLatencyServer; path = server; sourceTree = BUILT_PRODUCTS_DIR; };
-		3C8B097D24CC045E9397A8BF /* IceDiscoveryHelloClient */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = text; name = IceDiscoveryHelloClient; path = client; sourceTree = BUILT_PRODUCTS_DIR; };
-		3CF7DDAE1C22F11406087F6D /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = Ice/throughput/README.md; sourceTree = "<group>"; };
-		3E73A8039907731FCD618C1F /* main.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = main.swift; path = Glacier2/callback/Sources/Client/main.swift; sourceTree = "<group>"; };
-		3F541373F0B62EAD850F2FBD /* config.server */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = config.server; path = Ice/optional/config.server; sourceTree = "<group>"; };
-		4008AF26901E735EE9EC40FD /* config.server */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = config.server; path = Glacier2/callback/config.server; sourceTree = "<group>"; };
-		401F230285604E1ADBEA9689 /* Hello.ice */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Hello.ice; path = IceDiscovery/replication/Sources/Hello.ice; sourceTree = "<group>"; };
-		40E1DE82E595DADFE3DE206F /* config.glacier2 */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = config.glacier2; path = Glacier2/callback/config.glacier2; sourceTree = "<group>"; };
-		412158B51D090DBE79E8588C /* main.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = main.swift; path = Manual/simpleFilesystem/Sources/Client/main.swift; sourceTree = "<group>"; };
-		418BEF74D1793129A5C72B23 /* IceInvokeServer */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = text; name = IceInvokeServer; path = server; sourceTree = BUILT_PRODUCTS_DIR; };
-		44E2EF3378D9F7C7F0D447C2 /* IceImpl.xcframework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.xcframework; name = IceImpl.xcframework; path = Carthage/Build/IceImpl.xcframework; sourceTree = "<group>"; };
-		452D5F978671BA38A3F94EB3 /* main.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = main.swift; path = Ice/latency/Sources/Client/main.swift; sourceTree = "<group>"; };
-		45F2D35942591858FBD901DD /* Images.xcassets */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = iOS/hello/Images.xcassets; sourceTree = "<group>"; };
-		48532032567C26634A42F761 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
-		489A8AB8E6B33500B4C3F442 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = IceStorm/clock/README.md; sourceTree = "<group>"; };
-		48B5E1B84C2F4810AF3BE092 /* Library.ice */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Library.ice; path = iOS/library/Library.ice; sourceTree = "<group>"; };
-		49B861EA9E13E74C4707A9BD /* config.admin */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = config.admin; path = IceStorm/clock/config.admin; sourceTree = "<group>"; };
-		4B30F8E39455552DCCB5A76E /* config.server */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = config.server; path = Ice/latency/config.server; sourceTree = "<group>"; };
-		4D8C4A502C81A17810483EAC /* Images.xcassets */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = iOS/library/Images.xcassets; sourceTree = "<group>"; };
-		4DCF7B3212E070F32DE5D06F /* Main.storyboard */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file.storyboard; name = Main.storyboard; path = iOS/hello/Base.lproj/Main.storyboard; sourceTree = "<group>"; };
-		4E1ACB62C85FF06D49A7E781 /* IceGridSimpleClient */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = text; name = IceGridSimpleClient; path = client; sourceTree = BUILT_PRODUCTS_DIR; };
-		5300F0985211B122CE67D3DE /* main.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = main.swift; path = Ice/throughput/Sources/Client/main.swift; sourceTree = "<group>"; };
-		542A970BC1F69E2C31ED478B /* config.client */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = config.client; path = IceDiscovery/hello/config.client; sourceTree = "<group>"; };
-		555B4E4C32AB73151AC64B48 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = Ice/context/README.md; sourceTree = "<group>"; };
-		5570BD4237087EEDD3669912 /* config.client */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = config.client; path = Ice/invoke/config.client; sourceTree = "<group>"; };
-		55A37C8DED853A4C0C0212D7 /* PromiseKit.xcframework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.xcframework; name = PromiseKit.xcframework; path = Carthage/Build/PromiseKit.xcframework; sourceTree = "<group>"; };
-		55BA08D94F88634B1FCC8444 /* config.client */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = config.client; path = Ice/async/config.client; sourceTree = "<group>"; };
-		55BD51CDE4F248ED184B9C03 /* IceInvokeClient */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = text; name = IceInvokeClient; path = client; sourceTree = BUILT_PRODUCTS_DIR; };
-		560295E3FB26C30FE4279071 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file.storyboard; name = LaunchScreen.storyboard; path = iOS/chat/Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
-		564EEE78D51984E4FC201895 /* main.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = main.swift; path = IceGrid/simple/Sources/Server/main.swift; sourceTree = "<group>"; };
-		572B6823AAC759EDC9E19B71 /* LoginController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LoginController.swift; path = iOS/library/LoginController.swift; sourceTree = "<group>"; };
-		5A69CA4F896CFA76B7F4FC54 /* IceLatencyClient */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = text; name = IceLatencyClient; path = client; sourceTree = BUILT_PRODUCTS_DIR; };
-		5CA1965D308C6B95B2D02B01 /* main.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = main.swift; path = IceDiscovery/hello/Sources/Client/main.swift; sourceTree = "<group>"; };
-		60650B913C1E84C7982E4061 /* IceGridSimpleServer */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = text; name = IceGridSimpleServer; path = server; sourceTree = BUILT_PRODUCTS_DIR; };
-		6068627F8185893E1E823DD0 /* config.client */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = config.client; path = IceGrid/simple/config.client; sourceTree = "<group>"; };
-		6141C3CBC55BB9133DDD5F29 /* IceStormClockSubscriber */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = text; name = IceStormClockSubscriber; path = subscriber; sourceTree = BUILT_PRODUCTS_DIR; };
-		626DF7CBBBF14EA0C5B37ADA /* main.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = main.swift; path = IceDiscovery/replication/Sources/Server/main.swift; sourceTree = "<group>"; };
-		62889D9BEFF1DD78E140F388 /* Throughput.ice */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Throughput.ice; path = Ice/throughput/Sources/Throughput.ice; sourceTree = "<group>"; };
-		62F56BC2E31623E888EE6519 /* main.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = main.swift; path = Ice/minimal/Sources/Server/main.swift; sourceTree = "<group>"; };
-		63215B9BDD9CB595E01658F8 /* main.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = main.swift; path = Ice/bidir/Sources/Client/main.swift; sourceTree = "<group>"; };
-		6509D4615F63497D8F3A1415 /* IceInterceptorClient */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = text; name = IceInterceptorClient; path = client; sourceTree = BUILT_PRODUCTS_DIR; };
-		6643D756BFA7EEC23DC768D2 /* EditController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EditController.swift; path = iOS/library/EditController.swift; sourceTree = "<group>"; };
-		664BB7725F3CE5BF2D6D1362 /* Chat.ice */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Chat.ice; path = iOS/chat/Chat.ice; sourceTree = "<group>"; };
-		6827D0D0191C586EC4231BA4 /* Callback.ice */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Callback.ice; path = Ice/bidir/Sources/Callback.ice; sourceTree = "<group>"; };
-		685E3D4F4F23123EA4349688 /* config.server1 */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = config.server1; path = IceDiscovery/replication/config.server1; sourceTree = "<group>"; };
-		6A9CC980FC134C230BC7EF63 /* Glacier2.xcframework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.xcframework; name = Glacier2.xcframework; path = Carthage/Build/Glacier2.xcframework; sourceTree = "<group>"; };
-		6B62B83268F60F7C2F99ED08 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = IceGrid/simple/README.md; sourceTree = "<group>"; };
-		6BE3E92C43F1D4A3709F9319 /* main.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = main.swift; path = Glacier2/callback/Sources/Server/main.swift; sourceTree = "<group>"; };
-		6CA52058B78D6D362BFE4799 /* main.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = main.swift; path = Ice/minimal/Sources/Client/main.swift; sourceTree = "<group>"; };
-		6D76908AFC77A69CC01C4A45 /* InputBarAccessoryView.xcframework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.xcframework; name = InputBarAccessoryView.xcframework; path = Carthage/Build/InputBarAccessoryView.xcframework; sourceTree = "<group>"; };
-		6DA9D65FCBB43921AE081B19 /* ChatApp.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ChatApp.swift; path = iOS/chat/ChatApp.swift; sourceTree = "<group>"; };
-		6E24D220EF2E79E445C87850 /* Glacier2CallbackServer */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = text; name = Glacier2CallbackServer; path = server; sourceTree = BUILT_PRODUCTS_DIR; };
-		6E84CD23DB9FAE071A069EC8 /* config.server */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = config.server; path = IceDiscovery/hello/config.server; sourceTree = "<group>"; };
-		7011BF01BCEDBFABCB6AAB74 /* main.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = main.swift; path = Ice/hello/Sources/Server/main.swift; sourceTree = "<group>"; };
-		70F2BD7A488A205C3F2FFF1F /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = iOS/library/README.md; sourceTree = "<group>"; };
-		7141F96B9E1438EE1FD9324B /* PrinterI.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PrinterI.swift; path = Ice/invoke/Sources/Server/PrinterI.swift; sourceTree = "<group>"; };
-		734F7EBAF5DD523F69E07AEA /* certs */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder; name = certs; path = ../certs; sourceTree = "<group>"; };
-		7451971287B9F34894391172 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file.storyboard; name = LaunchScreen.storyboard; path = iOS/hello/Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
-		75A364B7B36A2F27E0C7B5EE /* IceAsyncServer */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = text; name = IceAsyncServer; path = server; sourceTree = BUILT_PRODUCTS_DIR; };
-		78FB10F066D761AF1A24DB94 /* Hello.ice */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Hello.ice; path = Ice/hello/Sources/Hello.ice; sourceTree = "<group>"; };
-		795BDD345A8758BE1BCE1037 /* chat.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = chat.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		7D135994048263BF1FDD1606 /* main.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = main.swift; path = Ice/latency/Sources/Server/main.swift; sourceTree = "<group>"; };
-		7E17AB21DCAF1F73A95C330A /* config.client */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = config.client; path = Ice/latency/config.client; sourceTree = "<group>"; };
-		7EA465016479DB7783F7D599 /* main.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = main.swift; path = IceStorm/clock/Sources/Subscriber/main.swift; sourceTree = "<group>"; };
-		7FE03B5CC4924485E04FC7BA /* ChatLayoutController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ChatLayoutController.swift; path = iOS/chat/ChatLayoutController.swift; sourceTree = "<group>"; };
-		81B6BBD37B3FB2976F76A36D /* IceOptionalClient */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = text; name = IceOptionalClient; path = client; sourceTree = BUILT_PRODUCTS_DIR; };
-		8328076C5A54A89E5C1C6A77 /* Clock.ice */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Clock.ice; path = IceStorm/clock/Sources/Clock.ice; sourceTree = "<group>"; };
-		84A42613BC359BA2823E3450 /* config.client */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = config.client; path = Ice/optional/config.client; sourceTree = "<group>"; };
-		86E08919DF7384C8501E200E /* AuthenticatorI.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AuthenticatorI.swift; path = Ice/interceptor/Sources/Server/AuthenticatorI.swift; sourceTree = "<group>"; };
-		87326C9631EA22318B8FA8B7 /* IceContextServer */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = text; name = IceContextServer; path = server; sourceTree = BUILT_PRODUCTS_DIR; };
-		887EA3F372177378BBB92B74 /* config.grid */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = config.grid; path = IceGrid/simple/config.grid; sourceTree = "<group>"; };
-		89D4B0BEAB0413B93B185EA9 /* Main.storyboard */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file.storyboard; name = Main.storyboard; path = iOS/library/Base.lproj/Main.storyboard; sourceTree = "<group>"; };
-		8B51D44CE59C7B800960E3A3 /* IOSLibrary.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; name = IOSLibrary.app; path = library.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		8B8E083932784B369B4A3549 /* ManualPrinterServer */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = text; name = ManualPrinterServer; path = server; sourceTree = BUILT_PRODUCTS_DIR; };
-		8D28BE3CE7F6D7DFC1075304 /* Hello.ice */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Hello.ice; path = iOS/hello/Hello.ice; sourceTree = "<group>"; };
-		9169D28F09D967F0B93C7D8A /* ChatMessage.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ChatMessage.swift; path = iOS/chat/ChatMessage.swift; sourceTree = "<group>"; };
-		92D6613B14D8EF0FBDA1351F /* config.icebox */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = config.icebox; path = IceStorm/clock/config.icebox; sourceTree = "<group>"; };
-		94A052DBBD69CB6C57BB5E82 /* config.client */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = config.client; path = iOS/library/config.client; sourceTree = "<group>"; };
-		962F08EBB1AD8F2EDDCA79C2 /* main.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = main.swift; path = Manual/printer/Sources/Client/main.swift; sourceTree = "<group>"; };
-		981FAA0E0B3E4FB23D50B8BA /* ManualPrinterClient */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = text; name = ManualPrinterClient; path = client; sourceTree = BUILT_PRODUCTS_DIR; };
-		9CA03B4D26961B069C956D97 /* config.client */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = config.client; path = Ice/bidir/config.client; sourceTree = "<group>"; };
-		9CB0C08B0D54EB988D212533 /* IceInterceptorServer */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = text; name = IceInterceptorServer; path = server; sourceTree = BUILT_PRODUCTS_DIR; };
-		9F40534B11EFC9339CC9F490 /* Glacier2.xcframework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.xcframework; name = Glacier2.xcframework; path = Carthage/Build/Glacier2.xcframework; sourceTree = "<group>"; };
-		9F90CCBCA51A64124D15A8B4 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = Ice/hello/README.md; sourceTree = "<group>"; };
-		A1ED884AD886A6DEBBC3C728 /* Images.xcassets */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = iOS/chat/Images.xcassets; sourceTree = "<group>"; };
-		A35F2233F0DE4E25E3574F31 /* config.client */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = config.client; path = IceDiscovery/replication/config.client; sourceTree = "<group>"; };
-		A3DFA602DEC55A1DE82BBF9F /* main.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = main.swift; path = Ice/throughput/Sources/Server/main.swift; sourceTree = "<group>"; };
-		A4422835E9642A1937348401 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = Manual/simpleFilesystem/README.md; sourceTree = "<group>"; };
-		A488AF4C5BBD8776F8442C44 /* Session.ice */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Session.ice; path = iOS/library/Session.ice; sourceTree = "<group>"; };
-		A6F51134D874C51E8A43C60F /* ViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ViewController.swift; path = iOS/hello/ViewController.swift; sourceTree = "<group>"; };
-		A768655A27B30C1400E41232 /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
-		A768655C27B3134D00E41232 /* LoginViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewModel.swift; sourceTree = "<group>"; };
-		A848D5911477BACC1B9C18C8 /* ContextI.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ContextI.swift; path = Ice/context/Sources/Server/ContextI.swift; sourceTree = "<group>"; };
-		AB95F2441E6D8C237C489342 /* config.server */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = config.server; path = Ice/context/config.server; sourceTree = "<group>"; };
-		ACA7351C60E3801D9AB14CB1 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file.storyboard; name = LaunchScreen.storyboard; path = iOS/library/Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
-		AE6F2AD2D3EF1EAE5E359219 /* Latency.ice */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Latency.ice; path = Ice/latency/Sources/Latency.ice; sourceTree = "<group>"; };
-		AE71E1166654BE7475DB36BA /* config.server */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = config.server; path = Ice/async/config.server; sourceTree = "<group>"; };
-		AEE29AA3114D5818B8752800 /* IceOptionalServer */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = text; name = IceOptionalServer; path = server; sourceTree = BUILT_PRODUCTS_DIR; };
-		B0EFBEDB18F101F76F3B4348 /* main.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = main.swift; path = IceDiscovery/replication/Sources/Client/main.swift; sourceTree = "<group>"; };
-		B36636F185D07AF691E33EB1 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = Ice/asyncInvocation/README.md; sourceTree = "<group>"; };
-		B3914CEEB182107F446A7D22 /* IceAsyncInvocationClient */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = text; name = IceAsyncInvocationClient; path = client; sourceTree = BUILT_PRODUCTS_DIR; };
-		B9C206C3CF068A0923D1B6BE /* MainController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MainController.swift; path = iOS/library/MainController.swift; sourceTree = "<group>"; };
-		BA319441718A4B4410187238 /* Interceptor.ice */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Interceptor.ice; path = Ice/interceptor/Sources/Interceptor.ice; sourceTree = "<group>"; };
-		BB8DE386B28B2E9220D3FC48 /* config.service */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = config.service; path = IceStorm/clock/config.service; sourceTree = "<group>"; };
-		C1C7EFC80BA45C6FAB2C053C /* IceStorm.xcframework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.xcframework; name = IceStorm.xcframework; path = Carthage/Build/IceStorm.xcframework; sourceTree = "<group>"; };
-		C21EA1694662E040DC2608DE /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = Ice/async/README.md; sourceTree = "<group>"; };
-		C5AB75CEB64242F131C9C4BA /* Printer.ice */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Printer.ice; path = Ice/invoke/Sources/Printer.ice; sourceTree = "<group>"; };
-		C7A2F7EE4FA803841AEE05E6 /* main.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = main.swift; path = Ice/invoke/Sources/Client/main.swift; sourceTree = "<group>"; };
-		CA3625DECE4A1AD3E1926870 /* AppDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = iOS/library/AppDelegate.swift; sourceTree = "<group>"; };
-		CAB0E574877C807BE5637963 /* main.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = main.swift; path = Ice/async/Sources/Server/main.swift; sourceTree = "<group>"; };
-		CAD4C6D304F2992DB034125B /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = Ice/latency/README.md; sourceTree = "<group>"; };
-		CBE746FB0E45B94FB26DBC9A /* Filesystem.ice */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Filesystem.ice; path = Manual/simpleFilesystem/Sources/Filesystem.ice; sourceTree = "<group>"; };
-		CD67B4FA75F306DC428A91EC /* main.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = main.swift; path = Ice/bidir/Sources/Server/main.swift; sourceTree = "<group>"; };
-		CE172FAF992BE42BF38A733D /* AddController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AddController.swift; path = iOS/library/AddController.swift; sourceTree = "<group>"; };
-		CF3CBA7BB3733BC3DFB8B8F3 /* main.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = main.swift; path = IceGrid/simple/Sources/Client/main.swift; sourceTree = "<group>"; };
-		CF856DB0D368176513B5C713 /* config.server3 */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = config.server3; path = IceDiscovery/replication/config.server3; sourceTree = "<group>"; };
-		CFF54020CA34595CE4AAA3D1 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = iOS/chat/README.md; sourceTree = "<group>"; };
-		D2285D300CF1AFBB54CFC603 /* IceHelloClient */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = text; name = IceHelloClient; path = client; sourceTree = BUILT_PRODUCTS_DIR; };
-		D2F6B8689A468A5F9B352314 /* config.client */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = config.client; path = Ice/throughput/config.client; sourceTree = "<group>"; };
-		D36596AA2C4FC9D4E95F3AC4 /* config.server */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = config.server; path = Ice/asyncInvocation/config.server; sourceTree = "<group>"; };
-		D4B9142B71C331252B9ABD6C /* DetailController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DetailController.swift; path = iOS/library/DetailController.swift; sourceTree = "<group>"; };
-		D5C857A08E88266D524C21DE /* config.client */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = config.client; path = Ice/asyncInvocation/config.client; sourceTree = "<group>"; };
-		D79B76AFF6799725A4428FD2 /* Ice.xcframework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.xcframework; name = Ice.xcframework; path = Carthage/Build/Ice.xcframework; sourceTree = "<group>"; };
-		D9225308B90D05589A4A6BDF /* InterceptorI.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = InterceptorI.swift; path = Ice/interceptor/Sources/Server/InterceptorI.swift; sourceTree = "<group>"; };
-		D97456E43139D24DB711B466 /* config.server */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = config.server; path = Ice/throughput/config.server; sourceTree = "<group>"; };
-		DA4598F4AC7F620B4079E250 /* main.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = main.swift; path = Manual/simpleFilesystem/Sources/Server/main.swift; sourceTree = "<group>"; };
-		DB6321B16A4E43CD89148041 /* IceThroughputServer */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = text; name = IceThroughputServer; path = server; sourceTree = BUILT_PRODUCTS_DIR; };
-		DBFF5192CDC30041BE50C4E5 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = IceDiscovery/hello/README.md; sourceTree = "<group>"; };
-		DC44E9365BDEFE5223CA9AC7 /* IceImpl.xcframework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.xcframework; name = IceImpl.xcframework; path = Carthage/Build/IceImpl.xcframework; sourceTree = "<group>"; };
-		DCADEBA495EB820A0A7E41C6 /* IceMinimalClient */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = text; name = IceMinimalClient; path = client; sourceTree = BUILT_PRODUCTS_DIR; };
-		DCBEDF063E959A45ED0D1263 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS14.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
-		DE06C1F13EC4D1CDBC4FBC70 /* AppDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = iOS/hello/AppDelegate.swift; sourceTree = "<group>"; };
-		DFEF9402B01B02D0B30A052A /* config.pub */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = config.pub; path = IceStorm/clock/config.pub; sourceTree = "<group>"; };
-		DFF2A84050F27AAF801166DD /* config.client */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = config.client; path = Ice/context/config.client; sourceTree = "<group>"; };
-		E0CEA765E2311A5EA908CCF7 /* UserController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = UserController.swift; path = iOS/chat/UserController.swift; sourceTree = "<group>"; };
-		E33F8EBD6359013AE72CB2C7 /* PromiseKit.xcframework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.xcframework; name = PromiseKit.xcframework; path = Carthage/Build/PromiseKit.xcframework; sourceTree = "<group>"; };
-		E4ED404F16F47126CD654B7B /* ContactDBI.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ContactDBI.swift; path = Ice/optional/Sources/Server/ContactDBI.swift; sourceTree = "<group>"; };
-		E6265EF8C479AA2FA0C01649 /* config.client */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = config.client; path = Ice/hello/config.client; sourceTree = "<group>"; };
-		E6E16C4D401F03FF0852CAF0 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = Ice/bidir/README.md; sourceTree = "<group>"; };
-		E7394F43D1595EA0A782488C /* Glacier2Session.ice */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Glacier2Session.ice; path = iOS/library/Glacier2Session.ice; sourceTree = "<group>"; };
-		E766A925498F62424246E54C /* Hello.ice */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Hello.ice; path = Ice/async/Sources/Hello.ice; sourceTree = "<group>"; };
-		E88C1C30A300233B9814D013 /* config.server */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = config.server; path = Ice/interceptor/config.server; sourceTree = "<group>"; };
-		E9F1D7FC36EFF1498901294C /* IceDiscoveryReplicationClient */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = text; name = IceDiscoveryReplicationClient; path = client; sourceTree = BUILT_PRODUCTS_DIR; };
-		EFABB932D97DA909193B1439 /* main.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = main.swift; path = Ice/invoke/Sources/Server/main.swift; sourceTree = "<group>"; };
-		F1417615123189DBFB739754 /* main.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = main.swift; path = Manual/printer/Sources/Server/main.swift; sourceTree = "<group>"; };
-		F205564C9B6D912980932EAB /* ManualSimpleFilesystemServer */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = text; name = ManualSimpleFilesystemServer; path = server; sourceTree = BUILT_PRODUCTS_DIR; };
-		F2DFDDEDAC25F902550766D4 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk/System/Library/Frameworks/Cocoa.framework; sourceTree = DEVELOPER_DIR; };
-		F59BA32210DDA4AF9E06A751 /* Hello.ice */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Hello.ice; path = IceDiscovery/hello/Sources/Hello.ice; sourceTree = "<group>"; };
-		F5A28E10628A4036DE52D88B /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = Manual/printer/README.md; sourceTree = "<group>"; };
-		F7449754D30A52F680857B55 /* IceContextClient */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = text; name = IceContextClient; path = client; sourceTree = BUILT_PRODUCTS_DIR; };
-		F78B443277F9161110BF4872 /* IceThroughputClient */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = text; name = IceThroughputClient; path = client; sourceTree = BUILT_PRODUCTS_DIR; };
-		F845036D52ADEC64757D9E9E /* Hello.ice */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Hello.ice; path = Ice/minimal/Sources/Hello.ice; sourceTree = "<group>"; };
-		F901F95276B12496C039F7A0 /* IceDiscoveryHelloServer */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = text; name = IceDiscoveryHelloServer; path = server; sourceTree = BUILT_PRODUCTS_DIR; };
-		F94EBC11263108F8FE222AC8 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = IceDiscovery/replication/README.md; sourceTree = "<group>"; };
-		F96051CE81CCCA810E36B833 /* IceMinimalServer */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = text; name = IceMinimalServer; path = server; sourceTree = BUILT_PRODUCTS_DIR; };
-		FA3BF90C0656239819A25831 /* IceGrid.xcframework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.xcframework; name = IceGrid.xcframework; path = Carthage/Build/IceGrid.xcframework; sourceTree = "<group>"; };
-		FA874A29A31065D4EA8361B7 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = Ice/minimal/README.md; sourceTree = "<group>"; };
-		FADC9269113326F3E56F51EB /* config.server */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = config.server; path = Ice/hello/config.server; sourceTree = "<group>"; };
-		FB86282C2355E1B10F369CC5 /* main.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = main.swift; path = Ice/asyncInvocation/Sources/Client/main.swift; sourceTree = "<group>"; };
-		FCD0FE371EB69FE1DCC961C0 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = Ice/invoke/README.md; sourceTree = "<group>"; };
-		FE066D1FEF2F83460BA73C41 /* config.server2 */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = config.server2; path = IceDiscovery/replication/config.server2; sourceTree = "<group>"; };
-		FE183346DF16C34D553A5778 /* main.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = main.swift; path = IceStorm/clock/Sources/Publisher/main.swift; sourceTree = "<group>"; };
-		FE4AC0DC09B8774590AF2DDF /* main.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = main.swift; path = Ice/hello/Sources/Client/main.swift; sourceTree = "<group>"; };
-		FE75106F54717B3D51C0664A /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = Glacier2/callback/README.md; sourceTree = "<group>"; };
-		FFB00730E6A7AA37BA85E0C4 /* Glacier2CallbackClient */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = text; name = Glacier2CallbackClient; path = client; sourceTree = BUILT_PRODUCTS_DIR; };
+		01659268489EEC0398AE6547 /* main.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = main.swift; path = Ice/async/Sources/Client/main.swift; sourceTree = "<group>"; };
+		017302CFB001ED3B8B8E4C99 /* ThermostatI.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ThermostatI.swift; path = Ice/interceptor/Sources/Server/ThermostatI.swift; sourceTree = "<group>"; };
+		03164D5D43273B40ACC16B18 /* InterceptorI.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = InterceptorI.swift; path = Ice/interceptor/Sources/Server/InterceptorI.swift; sourceTree = "<group>"; };
+		032AD4164F9268ACF34475BD /* Chat.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; name = Chat.app; path = chat.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		03B80F9BF7F22E83B6E50198 /* main.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = main.swift; path = Ice/bidir/Sources/Client/main.swift; sourceTree = "<group>"; };
+		05E0161FDFF7E077E8C26E1D /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = Manual/simpleFilesystem/README.md; sourceTree = "<group>"; };
+		0681A21702B3149176695AFB /* config.client */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = config.client; path = IceGrid/simple/config.client; sourceTree = "<group>"; };
+		06C1AC349C68E9135698BF50 /* config.client */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = config.client; path = Ice/bidir/config.client; sourceTree = "<group>"; };
+		07CBA324F6759CF66AD9F78A /* PrinterI.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PrinterI.swift; path = Ice/invoke/Sources/Server/PrinterI.swift; sourceTree = "<group>"; };
+		0983D2DC20F667ECE804DBCE /* main.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = main.swift; path = Ice/bidir/Sources/Server/main.swift; sourceTree = "<group>"; };
+		0BF2D8AF1D0F9CBA492FFFA0 /* config.client */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = config.client; path = Chat/config.client; sourceTree = "<group>"; };
+		0C3898D57712FCD59D25EE7F /* Latency.ice */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Latency.ice; path = Ice/latency/Sources/Latency.ice; sourceTree = "<group>"; };
+		0E0E12A86B874F17FAEF5FD2 /* main.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = main.swift; path = IceStorm/clock/Sources/Publisher/main.swift; sourceTree = "<group>"; };
+		0FB6F066F7A0E28AD17B8E2B /* main.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = main.swift; path = Ice/latency/Sources/Server/main.swift; sourceTree = "<group>"; };
+		1159DF4CC0FC9B954A10D812 /* Contact.ice */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Contact.ice; path = Ice/optional/Sources/Contact.ice; sourceTree = "<group>"; };
+		119DF9A2E1B9A44EAA8D3A12 /* main.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = main.swift; path = Manual/simpleFilesystem/Sources/Server/main.swift; sourceTree = "<group>"; };
+		14A6541C9B56301D61D6617B /* InputBarAccessoryView.xcframework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.xcframework; name = InputBarAccessoryView.xcframework; path = Carthage/Build/InputBarAccessoryView.xcframework; sourceTree = "<group>"; };
+		14E30ECC6FC00347408358AC /* main.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = main.swift; path = Ice/throughput/Sources/Client/main.swift; sourceTree = "<group>"; };
+		174732B643FAE8038ADD39CC /* ManualPrinterServer */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = text; name = ManualPrinterServer; path = server; sourceTree = BUILT_PRODUCTS_DIR; };
+		182D38D880F51066DF80DA36 /* main.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = main.swift; path = Ice/invoke/Sources/Client/main.swift; sourceTree = "<group>"; };
+		1844EB7D97A6D75CBBCD7023 /* IceInvokeClient */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = text; name = IceInvokeClient; path = client; sourceTree = BUILT_PRODUCTS_DIR; };
+		1CAF9B5AB8BE58FA0EB10620 /* Hello.ice */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Hello.ice; path = IceDiscovery/replication/Sources/Hello.ice; sourceTree = "<group>"; };
+		20A57F673289621EAE237CA6 /* Glacier2CallbackServer */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = text; name = Glacier2CallbackServer; path = server; sourceTree = BUILT_PRODUCTS_DIR; };
+		217DABFD60EE075178E0400E /* config.client */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = config.client; path = Ice/latency/config.client; sourceTree = "<group>"; };
+		237032C49A14937A66AEDE89 /* IceStormClockPublisher */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = text; name = IceStormClockPublisher; path = publisher; sourceTree = BUILT_PRODUCTS_DIR; };
+		2471051F59F384D06E073851 /* UsersView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = UsersView.swift; path = Chat/views/UsersView.swift; sourceTree = "<group>"; };
+		26A1BBF0855400731C6102AB /* config.server */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = config.server; path = Ice/latency/config.server; sourceTree = "<group>"; };
+		27F63A2026D6BA776427CA0E /* Filesystem.ice */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Filesystem.ice; path = Manual/simpleFilesystem/Sources/Filesystem.ice; sourceTree = "<group>"; };
+		297A3C05FC7C5D646BFC71B3 /* Hello.ice */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Hello.ice; path = Ice/minimal/Sources/Hello.ice; sourceTree = "<group>"; };
+		2A1D640865F913073C70C4FF /* main.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = main.swift; path = Ice/context/Sources/Client/main.swift; sourceTree = "<group>"; };
+		2A45A7F3B38042B9A1C6190A /* config.sub */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = config.sub; path = IceStorm/clock/config.sub; sourceTree = "<group>"; };
+		2B076ED60F9CC9A075F8B526 /* config.server1 */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = config.server1; path = IceDiscovery/replication/config.server1; sourceTree = "<group>"; };
+		2B44897C564CE6DB603CB4D2 /* IceOptionalServer */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = text; name = IceOptionalServer; path = server; sourceTree = BUILT_PRODUCTS_DIR; };
+		2B8323ADB0E2AAFB22A11C1F /* Calculator.ice */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Calculator.ice; path = Ice/asyncInvocation/Sources/Calculator.ice; sourceTree = "<group>"; };
+		30111B4320FFB91EA0136E0D /* StatusView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = StatusView.swift; path = IceDiscovery/helloUI/views/StatusView.swift; sourceTree = "<group>"; };
+		3066738A6A797BC7554D7EA6 /* IceStorm.xcframework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.xcframework; name = IceStorm.xcframework; path = Carthage/Build/IceStorm.xcframework; sourceTree = "<group>"; };
+		3095385D6D4C977E3A5FFE0B /* main.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = main.swift; path = Ice/optional/Sources/Client/main.swift; sourceTree = "<group>"; };
+		30AEEE77443915F4B5275267 /* Client.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Client.swift; path = IceDiscovery/helloUI/Client.swift; sourceTree = "<group>"; };
+		3419BF2F5BA87FBBEAA600E2 /* MessageView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MessageView.swift; path = Chat/views/MessageView.swift; sourceTree = "<group>"; };
+		370FDFEDDAE8AB9E2C95ADC3 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = Ice/throughput/README.md; sourceTree = "<group>"; };
+		38240148B810D042548804D4 /* IceDiscoveryReplicationClient */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = text; name = IceDiscoveryReplicationClient; path = client; sourceTree = BUILT_PRODUCTS_DIR; };
+		38744134BEAD371CB759721B /* Printer.ice */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Printer.ice; path = Ice/invoke/Sources/Printer.ice; sourceTree = "<group>"; };
+		3E01850376B12840A28C24DD /* ChatMessage.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ChatMessage.swift; path = Chat/models/ChatMessage.swift; sourceTree = "<group>"; };
+		3E6CB6544FE1C51E9D8563C7 /* config.client */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = config.client; path = Ice/interceptor/config.client; sourceTree = "<group>"; };
+		3E94589557E60F855FCFD732 /* main.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = main.swift; path = Ice/interceptor/Sources/Server/main.swift; sourceTree = "<group>"; };
+		42E1BC68BA3AB2F7B9C429F7 /* IceGridSimpleClient */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = text; name = IceGridSimpleClient; path = client; sourceTree = BUILT_PRODUCTS_DIR; };
+		433CCEA38EC899FF3573DA55 /* Hello.ice */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Hello.ice; path = IceDiscovery/hello/Sources/Hello.ice; sourceTree = "<group>"; };
+		445DC58AEBFC6B3351BAC051 /* config.server3 */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = config.server3; path = IceDiscovery/replication/config.server3; sourceTree = "<group>"; };
+		4533079B702F03A8E4C6C87D /* config.server */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = config.server; path = Ice/context/config.server; sourceTree = "<group>"; };
+		471F66A6A5B0313A7FCC8103 /* main.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = main.swift; path = Ice/invoke/Sources/Server/main.swift; sourceTree = "<group>"; };
+		47DF638C1F0FE8FDDF32230E /* Images.xcassets */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = Chat/Images.xcassets; sourceTree = "<group>"; };
+		489FC987C118929E6AF6C2FD /* IceOptionalClient */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = text; name = IceOptionalClient; path = client; sourceTree = BUILT_PRODUCTS_DIR; };
+		4A66943ED723AF6633F4BA99 /* LoginViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LoginViewModel.swift; path = Chat/models/LoginViewModel.swift; sourceTree = "<group>"; };
+		4AE3EE1D56DB116DB064D5AD /* LoginView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LoginView.swift; path = Chat/views/LoginView.swift; sourceTree = "<group>"; };
+		4B7264AB55E8A3106AC51A36 /* main.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = main.swift; path = Manual/printer/Sources/Client/main.swift; sourceTree = "<group>"; };
+		4DA052D8F357433AFBF0731F /* config.client */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = config.client; path = Ice/context/config.client; sourceTree = "<group>"; };
+		4DD46FB9CCAF0938A7F7A020 /* main.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = main.swift; path = Ice/asyncInvocation/Sources/Client/main.swift; sourceTree = "<group>"; };
+		4E3444B8FDCFF52FD16A86EC /* IceLatencyServer */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = text; name = IceLatencyServer; path = server; sourceTree = BUILT_PRODUCTS_DIR; };
+		50BC31F78661A8214D9AC25E /* config.client */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = config.client; path = Ice/async/config.client; sourceTree = "<group>"; };
+		50ED78D2D71AA4911AC977E4 /* IceMinimalClient */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = text; name = IceMinimalClient; path = client; sourceTree = BUILT_PRODUCTS_DIR; };
+		5243222A3CC5BEAF68C60F71 /* Callback.ice */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Callback.ice; path = Ice/bidir/Sources/Callback.ice; sourceTree = "<group>"; };
+		53175EBECFD91BDAEA5E7A79 /* IceLatencyClient */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = text; name = IceLatencyClient; path = client; sourceTree = BUILT_PRODUCTS_DIR; };
+		53305CC3053FB53A008BE291 /* StatusView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = StatusView.swift; path = Ice/helloUI/views/StatusView.swift; sourceTree = "<group>"; };
+		54E37D3065FF48B94BA98BA4 /* main.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = main.swift; path = Ice/latency/Sources/Client/main.swift; sourceTree = "<group>"; };
+		558F42A0EB85C995C0501E62 /* certs */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder; name = certs; path = ../certs; sourceTree = "<group>"; };
+		576127C28BF88AF71DF9D194 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = Ice/minimal/README.md; sourceTree = "<group>"; };
+		58BB100D0312165F66C317E3 /* IceContextServer */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = text; name = IceContextServer; path = server; sourceTree = BUILT_PRODUCTS_DIR; };
+		58C4812E8B6176167871CACE /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = Ice/asyncInvocation/README.md; sourceTree = "<group>"; };
+		59F54B9F7348F848EADE4E3B /* main.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = main.swift; path = IceDiscovery/hello/Sources/Client/main.swift; sourceTree = "<group>"; };
+		5D84D251295C7D4C751783AC /* config.icebox */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = config.icebox; path = IceStorm/clock/config.icebox; sourceTree = "<group>"; };
+		5E66373CBAE9A5B40D99C5E5 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk/System/Library/Frameworks/Cocoa.framework; sourceTree = DEVELOPER_DIR; };
+		5E747475333ADF987F603E6C /* IceImpl.xcframework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.xcframework; name = IceImpl.xcframework; path = Carthage/Build/IceImpl.xcframework; sourceTree = "<group>"; };
+		5EB97A531498CDA1EDAC9496 /* IceContextClient */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = text; name = IceContextClient; path = client; sourceTree = BUILT_PRODUCTS_DIR; };
+		5F6B564AC40EFA0231A4E05B /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = IceStorm/clock/README.md; sourceTree = "<group>"; };
+		6090A77E36453AEE0FBD5067 /* Glacier2.xcframework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.xcframework; name = Glacier2.xcframework; path = Carthage/Build/Glacier2.xcframework; sourceTree = "<group>"; };
+		6156419DB27240E87FC12AD3 /* main.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = main.swift; path = Ice/optional/Sources/Server/main.swift; sourceTree = "<group>"; };
+		634F4F283DB76162164924F9 /* IceInterceptorClient */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = text; name = IceInterceptorClient; path = client; sourceTree = BUILT_PRODUCTS_DIR; };
+		659807E1F731370BB23B7547 /* Clock.ice */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Clock.ice; path = IceStorm/clock/Sources/Clock.ice; sourceTree = "<group>"; };
+		667E1E1D15930F9FF89E995A /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = Ice/latency/README.md; sourceTree = "<group>"; };
+		66C79E9BF61C66A55F891C76 /* Interceptor.ice */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Interceptor.ice; path = Ice/interceptor/Sources/Interceptor.ice; sourceTree = "<group>"; };
+		682FF469D6A1C7F0B187FCFB /* Client.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Client.swift; path = Ice/helloUI/Client.swift; sourceTree = "<group>"; };
+		68C31C343E0A3B726FFCE13B /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS14.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
+		68FDCA36F2E359A95EFBD5FA /* main.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = main.swift; path = Glacier2/callback/Sources/Server/main.swift; sourceTree = "<group>"; };
+		6A2239121A5E70F72E6FE232 /* IceBidirServer */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = text; name = IceBidirServer; path = server; sourceTree = BUILT_PRODUCTS_DIR; };
+		6ADC915B37D0929F1FA1BC61 /* config.server2 */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = config.server2; path = IceDiscovery/replication/config.server2; sourceTree = "<group>"; };
+		6BFEAD8B2DE9FB136CCFDD3C /* IceHelloUI.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; name = IceHelloUI.app; path = helloui.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		6C18C4EA4CAFFE876F2B9C5A /* IceAsyncInvocationServer */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = text; name = IceAsyncInvocationServer; path = server; sourceTree = BUILT_PRODUCTS_DIR; };
+		6DE4BC8D3B1AC40589A0F47C /* ProxySettings.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ProxySettings.swift; path = IceDiscovery/helloUI/ProxySettings.swift; sourceTree = "<group>"; };
+		7155FDE58250E9D19CA3131E /* main.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = main.swift; path = Manual/simpleFilesystem/Sources/Client/main.swift; sourceTree = "<group>"; };
+		71A1E04348A91014C963D31C /* IceDiscoveryReplicationServer */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = text; name = IceDiscoveryReplicationServer; path = server; sourceTree = BUILT_PRODUCTS_DIR; };
+		71FA03B36793A98FE0D86D99 /* main.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = main.swift; path = IceGrid/simple/Sources/Client/main.swift; sourceTree = "<group>"; };
+		72532D6611FFCB3AEA584CF2 /* MessageKit.xcframework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.xcframework; name = MessageKit.xcframework; path = Carthage/Build/MessageKit.xcframework; sourceTree = "<group>"; };
+		74967D9EDD67C16FEC6DC608 /* IceStormClockSubscriber */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = text; name = IceStormClockSubscriber; path = subscriber; sourceTree = BUILT_PRODUCTS_DIR; };
+		753391F556A5F8C93ABC6ABD /* main.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = main.swift; path = Glacier2/callback/Sources/Client/main.swift; sourceTree = "<group>"; };
+		767E6BD4CF76BB3960550B1B /* FormView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FormView.swift; path = Ice/helloUI/views/FormView.swift; sourceTree = "<group>"; };
+		77DC7E19BB8E9C2427503803 /* config.server */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = config.server; path = Ice/async/config.server; sourceTree = "<group>"; };
+		77EA7B15D8095A7AD933D774 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = Ice/helloUI/README.md; sourceTree = "<group>"; };
+		791FA9627886D784E488A94E /* IceGridSimpleServer */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = text; name = IceGridSimpleServer; path = server; sourceTree = BUILT_PRODUCTS_DIR; };
+		7938BE5DB2B8B9ED4EA6B076 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = Ice/invoke/README.md; sourceTree = "<group>"; };
+		796351E195A29AF6D4C56C50 /* main.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = main.swift; path = Ice/hello/Sources/Client/main.swift; sourceTree = "<group>"; };
+		7AE01E8009BD5112F86F3EE7 /* main.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = main.swift; path = Ice/async/Sources/Server/main.swift; sourceTree = "<group>"; };
+		7B89574B3373F02CB89DD755 /* config.service */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = config.service; path = IceStorm/clock/config.service; sourceTree = "<group>"; };
+		7C640E4B0F5DD34BD040ED3A /* config.glacier2 */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = config.glacier2; path = Glacier2/callback/config.glacier2; sourceTree = "<group>"; };
+		7E03CE17EC29CC0EB9F65C25 /* ProxySettings.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ProxySettings.swift; path = Ice/helloUI/ProxySettings.swift; sourceTree = "<group>"; };
+		7E22546153D6D5A85F656419 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = Ice/async/README.md; sourceTree = "<group>"; };
+		8046165D06F6EE72D935DFD6 /* main.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = main.swift; path = Manual/printer/Sources/Server/main.swift; sourceTree = "<group>"; };
+		80E8C4DFE7FAAD51C145CF29 /* Chat.ice */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Chat.ice; path = Chat/Chat.ice; sourceTree = "<group>"; };
+		81DF672C2D68C7F2F3CF21FE /* config.client */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = config.client; path = IceDiscovery/replication/config.client; sourceTree = "<group>"; };
+		8392CA466DE82E34967ED739 /* AuthenticatorI.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AuthenticatorI.swift; path = Ice/interceptor/Sources/Server/AuthenticatorI.swift; sourceTree = "<group>"; };
+		865C9B290A4F6B73C770716D /* main.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = main.swift; path = IceGrid/simple/Sources/Server/main.swift; sourceTree = "<group>"; };
+		88C5026755B2F338489AFBE9 /* ContactDBI.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ContactDBI.swift; path = Ice/optional/Sources/Server/ContactDBI.swift; sourceTree = "<group>"; };
+		88D1A664E0612A8EB462EEFF /* IceDiscoveryHelloServer */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = text; name = IceDiscoveryHelloServer; path = server; sourceTree = BUILT_PRODUCTS_DIR; };
+		890485C2DE8A237A4F7E6FEF /* ChatSession.ice */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = ChatSession.ice; path = Chat/ChatSession.ice; sourceTree = "<group>"; };
+		89927D974CC0546757B3725F /* config.client */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = config.client; path = Ice/hello/config.client; sourceTree = "<group>"; };
+		89958C96902E761791FB2A36 /* main.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = main.swift; path = IceStorm/clock/Sources/Subscriber/main.swift; sourceTree = "<group>"; };
+		89CF71983E611003BE227C55 /* HelloApp.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HelloApp.swift; path = Ice/helloUI/HelloApp.swift; sourceTree = "<group>"; };
+		8B072E97D7C8C6712C74FA65 /* main.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = main.swift; path = Ice/interceptor/Sources/Client/main.swift; sourceTree = "<group>"; };
+		8BE94C38DB2165FDFF7288A4 /* main.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = main.swift; path = Ice/hello/Sources/Server/main.swift; sourceTree = "<group>"; };
+		8D1F93F5EAFFF88BD6AF411C /* PromiseKit.xcframework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.xcframework; name = PromiseKit.xcframework; path = Carthage/Build/PromiseKit.xcframework; sourceTree = "<group>"; };
+		8D4379A5E70B21CE63A6B6F6 /* config.grid */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = config.grid; path = IceGrid/simple/config.grid; sourceTree = "<group>"; };
+		8D8A0252E35287420AD6F9C4 /* CalculatorI.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CalculatorI.swift; path = Ice/asyncInvocation/Sources/Server/CalculatorI.swift; sourceTree = "<group>"; };
+		8E7D27E1D4A62EF9F607A3DF /* config.server */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = config.server; path = Ice/interceptor/config.server; sourceTree = "<group>"; };
+		91493EA2D9B868513FFDC930 /* Images.xcassets */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = Ice/helloUI/Images.xcassets; sourceTree = "<group>"; };
+		928B5D6019ED78F2F5C21AF1 /* IceDiscoveryHelloClient */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = text; name = IceDiscoveryHelloClient; path = client; sourceTree = BUILT_PRODUCTS_DIR; };
+		9390FFE79FD9D646D574DC1F /* Client.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Client.swift; path = Chat/Client.swift; sourceTree = "<group>"; };
+		954A6B2ECBC0B96B5C91A1BD /* Glacier2CallbackClient */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = text; name = Glacier2CallbackClient; path = client; sourceTree = BUILT_PRODUCTS_DIR; };
+		9614E9716C6E9716276184E3 /* IceAsyncServer */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = text; name = IceAsyncServer; path = server; sourceTree = BUILT_PRODUCTS_DIR; };
+		96ABBE35B930709AB901DF84 /* IceBidirClient */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = text; name = IceBidirClient; path = client; sourceTree = BUILT_PRODUCTS_DIR; };
+		97DA3C7B652B58F96E995626 /* IceThroughputClient */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = text; name = IceThroughputClient; path = client; sourceTree = BUILT_PRODUCTS_DIR; };
+		97F0299BB374A87174167DC2 /* Glacier2.xcframework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.xcframework; name = Glacier2.xcframework; path = Carthage/Build/Glacier2.xcframework; sourceTree = "<group>"; };
+		9C03ACE9054F79C85364DCEE /* Context.ice */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Context.ice; path = Ice/context/Sources/Context.ice; sourceTree = "<group>"; };
+		9D6E4AD2F25CC4A4A74FD31B /* Printer.ice */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Printer.ice; path = Manual/printer/Sources/Printer.ice; sourceTree = "<group>"; };
+		9E0D4A451D2A343DB1071229 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = Manual/printer/README.md; sourceTree = "<group>"; };
+		9EA943805E1195F61F0B9D34 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+		9EBCAF4AD46FBF6910731E57 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = Glacier2/callback/README.md; sourceTree = "<group>"; };
+		9F4E002A1950863B6F7AC89A /* IceAsyncInvocationClient */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = text; name = IceAsyncInvocationClient; path = client; sourceTree = BUILT_PRODUCTS_DIR; };
+		A17DB692E0895FE387DAE12A /* IceImpl.xcframework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.xcframework; name = IceImpl.xcframework; path = Carthage/Build/IceImpl.xcframework; sourceTree = "<group>"; };
+		A3283875DC46723DD0292377 /* PromiseKit.xcframework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.xcframework; name = PromiseKit.xcframework; path = Carthage/Build/PromiseKit.xcframework; sourceTree = "<group>"; };
+		A7756572D8F6D14EB776AEAF /* config.server */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = config.server; path = Glacier2/callback/config.server; sourceTree = "<group>"; };
+		A80A5EE7CF7AB7D924FB4444 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = Ice/hello/README.md; sourceTree = "<group>"; };
+		AAD175AD226F3EDCB2B5DC5F /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = Ice/interceptor/README.md; sourceTree = "<group>"; };
+		AB5E99818282790A5DD1ACC2 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = IceDiscovery/replication/README.md; sourceTree = "<group>"; };
+		ABFD6BCBCC983EA843AD4D2D /* Hello.ice */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Hello.ice; path = IceGrid/simple/Sources/Hello.ice; sourceTree = "<group>"; };
+		AC3FC1A49769889C3D83F35B /* config.client */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = config.client; path = Ice/asyncInvocation/config.client; sourceTree = "<group>"; };
+		ADCEEBFF3D6FE9745DBC0F12 /* IceGrid.xcframework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.xcframework; name = IceGrid.xcframework; path = Carthage/Build/IceGrid.xcframework; sourceTree = "<group>"; };
+		B0E6A06FE6652B7B68DF2300 /* main.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = main.swift; path = IceDiscovery/replication/Sources/Server/main.swift; sourceTree = "<group>"; };
+		B497BA8EDA53618E2B376979 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = Ice/bidir/README.md; sourceTree = "<group>"; };
+		B4C5A5EA57237219BCD6D943 /* config.admin */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = config.admin; path = IceStorm/clock/config.admin; sourceTree = "<group>"; };
+		B4CAEB24950021156B12C284 /* ProxySettingsView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ProxySettingsView.swift; path = Ice/helloUI/views/ProxySettingsView.swift; sourceTree = "<group>"; };
+		B6425B00666CF3BCC4321F5E /* certs */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder; name = certs; path = ../certs; sourceTree = "<group>"; };
+		B8030C583229E314C0DB3AB8 /* IceHelloClient */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = text; name = IceHelloClient; path = client; sourceTree = BUILT_PRODUCTS_DIR; };
+		B98DB4BE5FC6124CD188185D /* main.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = main.swift; path = Ice/minimal/Sources/Server/main.swift; sourceTree = "<group>"; };
+		BAFF519269261E59BCD1EC19 /* Throughput.ice */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Throughput.ice; path = Ice/throughput/Sources/Throughput.ice; sourceTree = "<group>"; };
+		BB5DE059D2B334AFB7F1D71F /* config.server */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = config.server; path = Ice/asyncInvocation/config.server; sourceTree = "<group>"; };
+		BC03557C145BF03816F95E71 /* Ice.xcframework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.xcframework; name = Ice.xcframework; path = Carthage/Build/Ice.xcframework; sourceTree = "<group>"; };
+		BC3E97FBD168151BE75FFABC /* main.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = main.swift; path = Ice/context/Sources/Server/main.swift; sourceTree = "<group>"; };
+		BCC203491E7CE00E9819A24D /* IceAsyncClient */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = text; name = IceAsyncClient; path = client; sourceTree = BUILT_PRODUCTS_DIR; };
+		BEEE328D6BE2266AFD7A3422 /* ManualSimpleFilesystemServer */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = text; name = ManualSimpleFilesystemServer; path = server; sourceTree = BUILT_PRODUCTS_DIR; };
+		C11ECF49C07B3F0D8D24D4CE /* Callback.ice */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Callback.ice; path = Glacier2/callback/Sources/Callback.ice; sourceTree = "<group>"; };
+		C37231FAC4BEBEA690B45FB3 /* IceDiscoveryHelloUI.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; name = IceDiscoveryHelloUI.app; path = helloui.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		C4A7D73F02DE8719A4FA8ACB /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = Ice/context/README.md; sourceTree = "<group>"; };
+		C5BF957583E207844EF3D17D /* ChatUser.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ChatUser.swift; path = Chat/models/ChatUser.swift; sourceTree = "<group>"; };
+		C6642E449C72EBBEDA750080 /* config.server */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = config.server; path = Ice/optional/config.server; sourceTree = "<group>"; };
+		CEFC33ED9950620998C6D44C /* ContextI.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ContextI.swift; path = Ice/context/Sources/Server/ContextI.swift; sourceTree = "<group>"; };
+		D09298A13696CB8450955D26 /* ButtonView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ButtonView.swift; path = Ice/helloUI/views/ButtonView.swift; sourceTree = "<group>"; };
+		D33DCF66E7BE7E370FF9DB33 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = IceDiscovery/hello/README.md; sourceTree = "<group>"; };
+		D41183ED7AF99A5F55B1E8E8 /* FormView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FormView.swift; path = IceDiscovery/helloUI/views/FormView.swift; sourceTree = "<group>"; };
+		D4F0BFBD7206AE0ABB253518 /* IceInvokeServer */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = text; name = IceInvokeServer; path = server; sourceTree = BUILT_PRODUCTS_DIR; };
+		D7088FF2DD5FE9F6CC3190FA /* IceInterceptorServer */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = text; name = IceInterceptorServer; path = server; sourceTree = BUILT_PRODUCTS_DIR; };
+		D7FFECC1E9A92EB99DB45189 /* main.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = main.swift; path = Ice/throughput/Sources/Server/main.swift; sourceTree = "<group>"; };
+		D8C6A957EC20D6E1482CD1A9 /* config.server */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = config.server; path = Ice/bidir/config.server; sourceTree = "<group>"; };
+		D99FE19F282B8EA3BAE3604D /* config.client */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = config.client; path = Ice/optional/config.client; sourceTree = "<group>"; };
+		D9B1A389A4EC6F245A2A60A0 /* Images.xcassets */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = IceDiscovery/helloUI/Images.xcassets; sourceTree = "<group>"; };
+		DA25E550591A21C0C234B79C /* config.server */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = config.server; path = Ice/throughput/config.server; sourceTree = "<group>"; };
+		DE5C59B6BC0B895C2BF40337 /* config.server */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = config.server; path = IceDiscovery/hello/config.server; sourceTree = "<group>"; };
+		DF10F59017B590429C874A30 /* config.client */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = config.client; path = Glacier2/callback/config.client; sourceTree = "<group>"; };
+		DFBB4DB1169406AB65DE0D43 /* config.client */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = config.client; path = Ice/throughput/config.client; sourceTree = "<group>"; };
+		E0BA1758D46D25B723354B2A /* ChatApp.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ChatApp.swift; path = Chat/ChatApp.swift; sourceTree = "<group>"; };
+		E225702D9CBBE0EBF3987CC9 /* IceHelloServer */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = text; name = IceHelloServer; path = server; sourceTree = BUILT_PRODUCTS_DIR; };
+		E258705B5737C00AD85256EB /* ManualSimpleFilesystemClient */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = text; name = ManualSimpleFilesystemClient; path = client; sourceTree = BUILT_PRODUCTS_DIR; };
+		E26BF8F0915B9A9A8A575229 /* ProxySettingsView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ProxySettingsView.swift; path = IceDiscovery/helloUI/views/ProxySettingsView.swift; sourceTree = "<group>"; };
+		E36C6AFB2056519590EB40BC /* HelloApp.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HelloApp.swift; path = IceDiscovery/helloUI/HelloApp.swift; sourceTree = "<group>"; };
+		E39710A5090BEA57D7EEBB3A /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = IceGrid/simple/README.md; sourceTree = "<group>"; };
+		E66EB015682EA85EB843D95F /* IceMinimalServer */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = text; name = IceMinimalServer; path = server; sourceTree = BUILT_PRODUCTS_DIR; };
+		E6C2A46A1A9A6BC1A795FD94 /* ManualPrinterClient */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = text; name = ManualPrinterClient; path = client; sourceTree = BUILT_PRODUCTS_DIR; };
+		E729B07F7DF1A13054A6B6CD /* main.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = main.swift; path = Ice/minimal/Sources/Client/main.swift; sourceTree = "<group>"; };
+		E80F3CC81610D173C9BBAE35 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = Ice/optional/README.md; sourceTree = "<group>"; };
+		EB096EB42E87282807FE0D9D /* Hello.ice */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Hello.ice; path = IceDiscovery/helloUI/Hello.ice; sourceTree = "<group>"; };
+		EBC2F9335513ED56D3880B45 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = IceDiscovery/helloUI/README.md; sourceTree = "<group>"; };
+		EC612259AECEB8BAFD75B122 /* ButtonView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ButtonView.swift; path = IceDiscovery/helloUI/views/ButtonView.swift; sourceTree = "<group>"; };
+		ED632591F04312D373E9E8F7 /* config.pub */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = config.pub; path = IceStorm/clock/config.pub; sourceTree = "<group>"; };
+		EF794987CF7F6B3823048583 /* config.client */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = config.client; path = Ice/invoke/config.client; sourceTree = "<group>"; };
+		F0212F8CFBEB9A40C179AFB6 /* IceThroughputServer */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = text; name = IceThroughputServer; path = server; sourceTree = BUILT_PRODUCTS_DIR; };
+		F21FD317F3E42BD9EE4574FF /* main.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = main.swift; path = IceDiscovery/hello/Sources/Server/main.swift; sourceTree = "<group>"; };
+		F4F1FB2AB678C69D651C799C /* main.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = main.swift; path = IceDiscovery/replication/Sources/Client/main.swift; sourceTree = "<group>"; };
+		F4FADA505AC591B04D682543 /* config.client */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = config.client; path = IceDiscovery/hello/config.client; sourceTree = "<group>"; };
+		F6D5ADFEDCEA37390E6306AB /* Ice.xcframework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.xcframework; name = Ice.xcframework; path = Carthage/Build/Ice.xcframework; sourceTree = "<group>"; };
+		F7026ABA8A9E0B5F0563534B /* config.server */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = config.server; path = Ice/hello/config.server; sourceTree = "<group>"; };
+		F8DFB31774349911B3A41A65 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = Chat/README.md; sourceTree = "<group>"; };
+		FA61DA58008B4C300C53DBBA /* Hello.ice */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Hello.ice; path = Ice/async/Sources/Hello.ice; sourceTree = "<group>"; };
+		FD838DA6C309CBA363DE4B44 /* config.server */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = config.server; path = Ice/invoke/config.server; sourceTree = "<group>"; };
+		FDCC5878BE3F1BDFBDC416C1 /* Hello.ice */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Hello.ice; path = Ice/hello/Sources/Hello.ice; sourceTree = "<group>"; };
+		FDFE811E43D3912A799A2927 /* Hello.ice */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Hello.ice; path = Ice/helloUI/Hello.ice; sourceTree = "<group>"; };
+		FE553DAEFFB91D14B2F1E095 /* main.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = main.swift; path = Ice/asyncInvocation/Sources/Server/main.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		028E531E3400B2F3C917CC02 /* Frameworks */ = {
+		057EC43D2CB93050301716BA /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A5BA6CBA3AE407A039BD77E7 /* Ice.xcframework in Frameworks */,
-				A89B2946882429C77330E49E /* IceImpl.xcframework in Frameworks */,
-				1CBA9A8CACDC460BD2BAA1F4 /* PromiseKit.xcframework in Frameworks */,
+				B09CDEB3C1A22B93296E6358 /* Ice.xcframework in Frameworks */,
+				AF4A20E5FB735EA8FBA5C53C /* IceImpl.xcframework in Frameworks */,
+				0380BEC4FE089A774CC52CBA /* PromiseKit.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		18A17ADC4211385DCA27B8A8 /* Frameworks */ = {
+		0B73AADD24EB2D5BE5493013 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				9E0CEBD3EC2175F0DE047F22 /* Glacier2.xcframework in Frameworks */,
-				84336C703029A580102A9363 /* Ice.xcframework in Frameworks */,
-				31E1105448CF166A2CF40272 /* IceImpl.xcframework in Frameworks */,
-				32FCFBF7FF2F3B3C0630438C /* PromiseKit.xcframework in Frameworks */,
+				CBF4A3C4E604E944E41A0833 /* Ice.xcframework in Frameworks */,
+				3F53D8B1536AFC4B8E11E485 /* IceImpl.xcframework in Frameworks */,
+				0B76A141FA70978EAE7EBE32 /* PromiseKit.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		1B633AC450F9E68776B8BF68 /* Frameworks */ = {
+		19D46149B24C894A00AFCDCF /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				234635F2E2E0A92EF117F799 /* Ice.xcframework in Frameworks */,
-				D376E2BA2DD9DAA1782D5C39 /* IceImpl.xcframework in Frameworks */,
-				E4240F0FF2585E4D04CBE537 /* PromiseKit.xcframework in Frameworks */,
+				08BF2C23CA0AA8F48E1C198F /* Glacier2.xcframework in Frameworks */,
+				E66479ECA0F7DC4E53E48105 /* Ice.xcframework in Frameworks */,
+				9DB00450AF2291C85FF81FE1 /* IceImpl.xcframework in Frameworks */,
+				9ABF363532F6F07CB0E7D281 /* PromiseKit.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		354BFA2742D9590231FD7274 /* Frameworks */ = {
+		1A0E7CE03EBFFE528CDD0B5E /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				FB81BBB83D81E4A0E15445F6 /* Ice.xcframework in Frameworks */,
-				4CFE45787F5217A9950FA6A6 /* IceImpl.xcframework in Frameworks */,
-				A8C98CD18E36973FE4CE89DC /* PromiseKit.xcframework in Frameworks */,
+				CBA480D5C95A81417D89A2FD /* Ice.xcframework in Frameworks */,
+				80DD4A627CF5B052161612E3 /* IceImpl.xcframework in Frameworks */,
+				D6E3611B9225F83EEC96DC0A /* PromiseKit.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		46FAEFD16A7778DC672ECBD7 /* Frameworks */ = {
+		28F460C1E025266A22DA122D /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				28015B80AD567473CB9BD951 /* Ice.xcframework in Frameworks */,
-				372E84B694977688A6DA39E9 /* IceImpl.xcframework in Frameworks */,
-				9D3951C8429C655F8628FA42 /* PromiseKit.xcframework in Frameworks */,
+				93EAB484E4D93F1005F9BF78 /* Ice.xcframework in Frameworks */,
+				31CEB0D30C795E4FD3251110 /* IceImpl.xcframework in Frameworks */,
+				0A40FFCCB7DBAE729612D6E0 /* PromiseKit.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		587235E857AFDA82D765713E /* Frameworks */ = {
+		2ADA13682337CC6F4D3D9E7A /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				75B464E1B3CA4554A6836318 /* Ice.xcframework in Frameworks */,
-				E891BB777495872C66903573 /* IceImpl.xcframework in Frameworks */,
-				8960A62086805B535DC69B00 /* PromiseKit.xcframework in Frameworks */,
+				528848BAB8C2AC1CA4500E65 /* Ice.xcframework in Frameworks */,
+				CD65DE4519703EE25E0C3730 /* IceImpl.xcframework in Frameworks */,
+				373B2557C8FE352364046452 /* PromiseKit.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		58854DE82C14246A52AB6BAA /* Frameworks */ = {
+		331FFB98E886B3820BD53A0D /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				339D867D3A90AC35F69F9A14 /* Glacier2.xcframework in Frameworks */,
-				66B6C551108EBF774A13EC3E /* Ice.xcframework in Frameworks */,
-				1C78C756E2DA1373D19BAEF6 /* IceGrid.xcframework in Frameworks */,
-				17B436C46CBC6530BEEDC9CC /* IceImpl.xcframework in Frameworks */,
-				D308E560C7FA78CFF18EC210 /* PromiseKit.xcframework in Frameworks */,
+				6BC648C12CD0269FBD8D86EB /* Ice.xcframework in Frameworks */,
+				A46BFCFFB91188D689710288 /* IceImpl.xcframework in Frameworks */,
+				5B5BB2ECFB48B1B9373960A8 /* PromiseKit.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		5CBB0D50C42CC4430DA1B376 /* Frameworks */ = {
+		3EAD21A0768509CD327E457B /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E5FAFFC9E536912F25AB23A8 /* Ice.xcframework in Frameworks */,
-				A3B2B498D40D1C15E5AD0CF1 /* IceImpl.xcframework in Frameworks */,
-				CDE548AEDBCF0DA5F5B3E769 /* PromiseKit.xcframework in Frameworks */,
+				F09D7787C66048B4DCF64FE5 /* Ice.xcframework in Frameworks */,
+				36A86037702C43808CD49AF5 /* IceImpl.xcframework in Frameworks */,
+				D8A7D9E653DC8E1508751F8E /* PromiseKit.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		5EC6FE67D919482B235AE433 /* Frameworks */ = {
+		4792586039B9C7EFE338E22D /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				CDFF62B96CE03E0C7AE44018 /* Ice.xcframework in Frameworks */,
-				C39DBF43BD06A1A1A21C1881 /* IceImpl.xcframework in Frameworks */,
-				CCC535ADF4FF4699BAEEF779 /* PromiseKit.xcframework in Frameworks */,
+				2256B421133B6750CABDFBDC /* Ice.xcframework in Frameworks */,
+				06A3340BA611E5DD9C53FFDA /* IceImpl.xcframework in Frameworks */,
+				F5F1CFCC4C702340C63F5FD5 /* PromiseKit.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		672E70B5A65F3C73844D030B /* Frameworks */ = {
+		47E6C1EC00ED38FB0389A5E7 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				995DA1E74797D464FE505707 /* Ice.xcframework in Frameworks */,
-				A2CB957E6B2B58561810243D /* IceImpl.xcframework in Frameworks */,
-				782096ED290E9F9300FF7B35 /* PromiseKit.xcframework in Frameworks */,
+				AD7388526BEBF9F5BEE1241D /* Ice.xcframework in Frameworks */,
+				5B7CD1C62895A8B7FE94573A /* IceImpl.xcframework in Frameworks */,
+				D54E5AFEFAB0CB099A26A53B /* PromiseKit.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		6993D62FAAABC62A39AD626B /* Frameworks */ = {
+		4C987971BFEDA46E21FAE6EC /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				6C53160CE7218F20A786DD2E /* Ice.xcframework in Frameworks */,
-				68A0A99C32C90CD022686DE6 /* IceImpl.xcframework in Frameworks */,
-				A95DCB64A518D3228970C287 /* PromiseKit.xcframework in Frameworks */,
+				F9E7DF7B873E4735C1DBBAB4 /* Ice.xcframework in Frameworks */,
+				DCDA989B93B9E71959050276 /* IceImpl.xcframework in Frameworks */,
+				7C361A3F11FEE415AC4AA1E1 /* PromiseKit.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		6B2C2DE95A1A53D71D98848D /* Frameworks */ = {
+		5DD67869AB68732C013CC099 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				73A546C9013D7EFDFD47B962 /* Glacier2.xcframework in Frameworks */,
-				65CF4660E805EB5C1CA542A3 /* Ice.xcframework in Frameworks */,
-				D064B5105E23783C956801CD /* IceImpl.xcframework in Frameworks */,
-				0E1ED2CEBFCDFB533DEB0740 /* PromiseKit.xcframework in Frameworks */,
+				AC3CEFCA72DCB8B57BC9BE12 /* Glacier2.xcframework in Frameworks */,
+				2969FB85B2BB4833CBA7A297 /* Ice.xcframework in Frameworks */,
+				A4756E4023590AC7DC20A31E /* IceImpl.xcframework in Frameworks */,
+				0B6AE54965581C2B95345EF9 /* InputBarAccessoryView.xcframework in Frameworks */,
+				97B9D82129370E6B55AA6112 /* MessageKit.xcframework in Frameworks */,
+				D7CE3D7E9236A5A16BA7FF37 /* PromiseKit.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		6ECC3541AAB0015190653377 /* Frameworks */ = {
+		69C093AC16C6C2040C309B74 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				6318FEB5B6183174B6497494 /* Ice.xcframework in Frameworks */,
-				1424ADB885E8084865CCE88E /* IceImpl.xcframework in Frameworks */,
-				BAFDDAE70A67570D6435453D /* PromiseKit.xcframework in Frameworks */,
+				8548885819F0240D677BB3C6 /* Glacier2.xcframework in Frameworks */,
+				EE60A1DF0940F76B5285093E /* Ice.xcframework in Frameworks */,
+				42ACE6B72FBE7209C2B5EB7C /* IceGrid.xcframework in Frameworks */,
+				11A60946CA831F4071077227 /* IceImpl.xcframework in Frameworks */,
+				C59B1D4E7732E0B02EB5CBC0 /* PromiseKit.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		7E43817DB68B4395B0A52EF2 /* Frameworks */ = {
+		71EB134F619E0FCD9E1A986E /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				7A53D6E070682728768127C0 /* Ice.xcframework in Frameworks */,
-				F7997B16ED2FC36A4E5978B7 /* IceImpl.xcframework in Frameworks */,
-				47898C1018717BA2AC5717B0 /* PromiseKit.xcframework in Frameworks */,
+				D8DB6D20ABCA1F56E41E6581 /* Ice.xcframework in Frameworks */,
+				F1334E31F424EA6490643ACD /* IceImpl.xcframework in Frameworks */,
+				0CA8906D84EFF888131ED416 /* PromiseKit.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		84075BFCCA18CF6BDCF3D4A3 /* Frameworks */ = {
+		7879FCE640EE47C5E8D77531 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BC4CF78E8F723B0E01F92570 /* Ice.xcframework in Frameworks */,
-				0A83DFF290810DDE023BCA4B /* IceImpl.xcframework in Frameworks */,
-				2DEFBEAAEB28F486953FFCEA /* PromiseKit.xcframework in Frameworks */,
+				882DF5C30256B2D4B981A8E8 /* Ice.xcframework in Frameworks */,
+				14140038F90E29CBE7B4A05C /* IceImpl.xcframework in Frameworks */,
+				0F792206AC740C57490859DD /* PromiseKit.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		8766DFF51BDE5D995B070B4D /* Frameworks */ = {
+		7DD1E48D92B7539426A2F840 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				DB2F920F9FDAB86BA37816DF /* Ice.xcframework in Frameworks */,
-				9AE8AEC03E8536793AB11110 /* IceImpl.xcframework in Frameworks */,
-				568C45B6E3CCDC02B17E3995 /* PromiseKit.xcframework in Frameworks */,
+				3EA8580090524C6DB1F1A8AC /* Ice.xcframework in Frameworks */,
+				81BD1214FC530CEA78E43021 /* IceImpl.xcframework in Frameworks */,
+				52C1F8712856FD48EFEBE872 /* PromiseKit.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		8923261175E3BC6ACE1C3E04 /* Frameworks */ = {
+		848CE79162D9B3FA5928723F /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				1F2551E5A9356F2454BA465D /* Ice.xcframework in Frameworks */,
-				2FA106B4CD04CEBA8699EBFB /* IceImpl.xcframework in Frameworks */,
-				0F86E98A896E81691C4D51A1 /* PromiseKit.xcframework in Frameworks */,
+				12A1FA954A65D9D4B3E938D3 /* Ice.xcframework in Frameworks */,
+				703DC4B712010A7123A4861B /* IceImpl.xcframework in Frameworks */,
+				B27D463C308D2C1CF5184D1C /* IceStorm.xcframework in Frameworks */,
+				334A046B330AA03FB846FCFB /* PromiseKit.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		92C0BD46F83219C4F1998D64 /* Frameworks */ = {
+		8681C7C656D4E60B49431794 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				DCC2AD3D30FCB77C095AC740 /* Ice.xcframework in Frameworks */,
-				7FC979D748B84D20966A7183 /* IceImpl.xcframework in Frameworks */,
-				FB921140FE895DE8FB13DA62 /* PromiseKit.xcframework in Frameworks */,
+				EB2A988F21E2CBD5DF74E4A5 /* Ice.xcframework in Frameworks */,
+				3A59CA7F50DD777AE22D07C7 /* IceImpl.xcframework in Frameworks */,
+				391F30BFAF0DBBF645D2F2DC /* PromiseKit.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		988459F9028EAB05BF8E79BC /* Frameworks */ = {
+		98EB7DB26C64223B82A36CBE /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B5374557598A8C7A3C7E1627 /* Ice.xcframework in Frameworks */,
-				6BA65EC1FAFDE73352940A0A /* IceImpl.xcframework in Frameworks */,
-				ED179FD60AA178A51FEEA3E3 /* PromiseKit.xcframework in Frameworks */,
+				868133D320E6ED4DD57D984D /* Ice.xcframework in Frameworks */,
+				8BB24CCAE7DFDB35FEA9FA33 /* IceImpl.xcframework in Frameworks */,
+				4CE7763D1C1A092AF35459D8 /* PromiseKit.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		9A6357593A3AEFCA1DEE6684 /* Frameworks */ = {
+		9ECE034B5C0FB96437964348 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				1BAE8F95CB7C6BEFED6CE195 /* Ice.xcframework in Frameworks */,
-				4C6010C454D09DAE9709BD29 /* IceImpl.xcframework in Frameworks */,
-				4AEC65F139DDB25046B451B1 /* PromiseKit.xcframework in Frameworks */,
+				3A75E0D04D58A5CF1250C4FC /* Ice.xcframework in Frameworks */,
+				18DAC98BD68252339393FE67 /* IceImpl.xcframework in Frameworks */,
+				9D481B706A909E0DE19D7046 /* PromiseKit.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		9E42618273BBB52D00D567C5 /* Frameworks */ = {
+		A4A4A2BFEC27715FEBCC7A54 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				931292E4DD8EB0D276FF9AE4 /* Ice.xcframework in Frameworks */,
-				940C388D748943FE416FE1C9 /* IceImpl.xcframework in Frameworks */,
-				5C5F43408464276C03A402FA /* PromiseKit.xcframework in Frameworks */,
+				82504D9F15C0C04135019869 /* Glacier2.xcframework in Frameworks */,
+				14B11A164CCEA52D10510215 /* Ice.xcframework in Frameworks */,
+				93B345B674B6E7A8B517390F /* IceImpl.xcframework in Frameworks */,
+				DE385A628CDEFE3388CF037F /* PromiseKit.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		AB32C528E23C3183905B24B2 /* Frameworks */ = {
+		A6D8646B6A47E700131C4274 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				15BFCF206A9046ED582E38A5 /* Ice.xcframework in Frameworks */,
-				FA1626A3A90FEAA304867F45 /* IceImpl.xcframework in Frameworks */,
-				AAC6E3279A6CB6E2EDABF7F3 /* PromiseKit.xcframework in Frameworks */,
+				ECB248D9655461DC0DB1CEDA /* Ice.xcframework in Frameworks */,
+				413C0BC8E402F3BF09259E7E /* IceImpl.xcframework in Frameworks */,
+				F36A09BF4F2AF56A3651178A /* IceStorm.xcframework in Frameworks */,
+				99AA98F0EEDE91ACCADADBAF /* PromiseKit.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		AFBFFB7CEF9E5418E74FA5B3 /* Frameworks */ = {
+		A852B2B2CD3B0FCAFE64465B /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D4B44BF1C728EE01D7B5342D /* Ice.xcframework in Frameworks */,
-				76D0B73E375DD04ED854E004 /* IceImpl.xcframework in Frameworks */,
-				453B1346DCC826C7D38743FE /* PromiseKit.xcframework in Frameworks */,
+				1CFE8DDAAAF53CA1BFBA8443 /* Ice.xcframework in Frameworks */,
+				3BDBFECA833B5E4400654632 /* IceImpl.xcframework in Frameworks */,
+				7F8FEEE3CCDC5AE0F310D404 /* PromiseKit.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		B7A3A8B52699104A64F5ECF3 /* Frameworks */ = {
+		A9D70D1C35905D45E3B7AE94 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				0EE72299D3E516D8DD28FA12 /* Glacier2.xcframework in Frameworks */,
-				BB88916B303AC04F8755E9E0 /* Ice.xcframework in Frameworks */,
-				B4F1A77FF6A2B0189C2AFB2F /* IceImpl.xcframework in Frameworks */,
-				ED72F5559FA208C51D4189B6 /* PromiseKit.xcframework in Frameworks */,
+				09677A5BB6AAF49CCE67966E /* Glacier2.xcframework in Frameworks */,
+				7070D4F0AC60F543926475B3 /* Ice.xcframework in Frameworks */,
+				4621C84EF2908DB9445D3DD1 /* IceGrid.xcframework in Frameworks */,
+				A8CBAC043CB08646045BF12C /* IceImpl.xcframework in Frameworks */,
+				1E189C038023357CA0C911A3 /* PromiseKit.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		B8200B378B8ADF17DA105669 /* Frameworks */ = {
+		B5480E04E37C39E472D21F68 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E43CB6F98E3727A066B2C691 /* Ice.xcframework in Frameworks */,
-				4D5EEB90EA6B18683BE01774 /* IceImpl.xcframework in Frameworks */,
-				072AE5C5B9D219C970838CF3 /* IceStorm.xcframework in Frameworks */,
-				50AE3EC343B91A0E47763DC8 /* PromiseKit.xcframework in Frameworks */,
+				3963BE94336190EC4C1D1573 /* Ice.xcframework in Frameworks */,
+				61991B598153D81AD07F2AEF /* IceImpl.xcframework in Frameworks */,
+				AD93E10D5C99E2E8F57E6E63 /* PromiseKit.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		B9FB98A2474F5216D1D4AAAF /* Frameworks */ = {
+		B8201827EA096271ED52052E /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C9A677BF7ACF228CCA534082 /* Ice.xcframework in Frameworks */,
-				DB8AFFBC433A4672D3587C96 /* IceImpl.xcframework in Frameworks */,
-				483D5387F14E39E25E350437 /* PromiseKit.xcframework in Frameworks */,
+				EFCF553DDB0ECE9ACD2B0E51 /* Ice.xcframework in Frameworks */,
+				1B9AFFD56EF14588A01CC414 /* IceImpl.xcframework in Frameworks */,
+				51AD6E2F4D69B5481868F1F0 /* PromiseKit.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		BA97A010490CDB19C7DAA76E /* Frameworks */ = {
+		B82FE8EDFBB7107A743747CF /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				1E45A049C3A91106DB101B7F /* Ice.xcframework in Frameworks */,
-				96663A86E8947C50DE6CDA5F /* IceImpl.xcframework in Frameworks */,
-				DE086E95B3B5B371B1775916 /* PromiseKit.xcframework in Frameworks */,
+				039B3FF67AB6BFCD9DA2AD97 /* Ice.xcframework in Frameworks */,
+				3B4FA933F8E43155C7EF0107 /* IceImpl.xcframework in Frameworks */,
+				4C1638EFA9335DFC212FB19B /* PromiseKit.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		C069EF91B873D9C7AC470106 /* Frameworks */ = {
+		BBA2005753A8E7D80427F943 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				6BEEBD2460B239E93E6D09FB /* Ice.xcframework in Frameworks */,
-				B6D0A2F25DFF702C5198C6AD /* IceImpl.xcframework in Frameworks */,
-				D4B4718F09D2E67404EA5926 /* PromiseKit.xcframework in Frameworks */,
+				1BF3DBD92C453B8986C593A3 /* Ice.xcframework in Frameworks */,
+				3410071CF783E96E226E9738 /* IceImpl.xcframework in Frameworks */,
+				5E1F30DC3ACBB682C3B35B39 /* PromiseKit.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		C0F5AD19F00FA5F378C72244 /* Frameworks */ = {
+		C5A0165AF3E2EC43C4FA4756 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D77927F9976C69F799AFE7ED /* Ice.xcframework in Frameworks */,
-				13D9F98A3C5D4DBDBB0CAE9E /* IceImpl.xcframework in Frameworks */,
-				E82FD8E9EE1C503CABD75119 /* PromiseKit.xcframework in Frameworks */,
+				8C85ECCAFC9D6EEA763F5050 /* Ice.xcframework in Frameworks */,
+				3BC2B4393E9F8BDA5AA3A77E /* IceImpl.xcframework in Frameworks */,
+				8AA22853F429537AA8B18DCB /* PromiseKit.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		C8EF981FA6652FC517F6E4FF /* Frameworks */ = {
+		C7DA5DC872F7A4DE9DA87814 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				1E25458997C9E03CC9D1F3DF /* Ice.xcframework in Frameworks */,
-				A086446B70993F4A71A8EC42 /* IceImpl.xcframework in Frameworks */,
-				667423DCF8AE97EBE57B7FA4 /* PromiseKit.xcframework in Frameworks */,
+				63267968AB45EEE7A7FDF389 /* Ice.xcframework in Frameworks */,
+				F74460AE1424465DA89A2CE9 /* IceImpl.xcframework in Frameworks */,
+				10B4B2BE1EBC093751D0B008 /* PromiseKit.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		CEBA2B15FACD5AA5A5DDC87A /* Frameworks */ = {
+		CB01B0CA42714E93F88DF61A /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				F34601BEDBF2C941FBC2CB7C /* Glacier2.xcframework in Frameworks */,
-				96B5842FACA240F8DEBC9DD6 /* Ice.xcframework in Frameworks */,
-				010D85C5494670D31D3847FF /* IceImpl.xcframework in Frameworks */,
-				6B83E8CE89C9E0716F63A044 /* InputBarAccessoryView.xcframework in Frameworks */,
-				4E3E21C843024411503857E0 /* MessageKit.xcframework in Frameworks */,
-				958EA4E64A27BCD12FCBBC11 /* PromiseKit.xcframework in Frameworks */,
+				DF027AEF7E29C994AB363061 /* Ice.xcframework in Frameworks */,
+				2E4485260D42FA41E777A160 /* IceImpl.xcframework in Frameworks */,
+				DFC8E28F9F2F3B953C3E1256 /* PromiseKit.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		D864A72C149FC66C0AFF4A8D /* Frameworks */ = {
+		E2AAB758850E6B43606390E4 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				4545A79BFD233609A902A7FA /* Ice.xcframework in Frameworks */,
-				D713022205E0AC521BA9B069 /* IceImpl.xcframework in Frameworks */,
-				CEE51D32579534BF1F9A174A /* PromiseKit.xcframework in Frameworks */,
+				D11BCF36EDE21E3AF23EC0C2 /* Ice.xcframework in Frameworks */,
+				A50FC99DCD0E318ADEC33AD6 /* IceImpl.xcframework in Frameworks */,
+				9915F1DB77481091A31A5290 /* PromiseKit.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		DEBA9DF4AC7AA6B5FD9483ED /* Frameworks */ = {
+		E9FDA3220905C4351970D6C7 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				DEBA1B0114909800D239CA25 /* Ice.xcframework in Frameworks */,
-				0B042FABD01D18992298159D /* IceImpl.xcframework in Frameworks */,
-				E5F5F06DB4680E55E199E88A /* PromiseKit.xcframework in Frameworks */,
+				1F649784C620C36705938E3B /* Ice.xcframework in Frameworks */,
+				B6022CC6E3B960DFAC24466C /* IceImpl.xcframework in Frameworks */,
+				863F9515405B1038F1572097 /* PromiseKit.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		DFC1DD0FDC99D70F55FEC6CC /* Frameworks */ = {
+		ECB324C60A51C6EF4379F191 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				2F7C8F68BFC15C852834A877 /* Ice.xcframework in Frameworks */,
-				2EAFB94822311181E29CA8F7 /* IceImpl.xcframework in Frameworks */,
-				0980C8A0AF7B12D75EDBCE00 /* PromiseKit.xcframework in Frameworks */,
+				A137DFB1CDBF6482313A817F /* Ice.xcframework in Frameworks */,
+				CBF42967279717F602F0090A /* IceImpl.xcframework in Frameworks */,
+				C886FF78467BC2F5F19AB456 /* PromiseKit.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		E3BECC8FAFF49D1E4A1E29AE /* Frameworks */ = {
+		F0334E33710D51608F52736C /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				76E7A2569C1B8B0AEC4DA78A /* Ice.xcframework in Frameworks */,
-				7FD9709EA9A851FE1CDAADA3 /* IceImpl.xcframework in Frameworks */,
-				3D95FB75CC06B9E689D22056 /* PromiseKit.xcframework in Frameworks */,
+				35E3216EFC48E52EE773A716 /* Ice.xcframework in Frameworks */,
+				CE02BBCF94F3B566F58CF1BE /* IceImpl.xcframework in Frameworks */,
+				A38EB238A9D3EBCDABB4D8AC /* PromiseKit.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		EB810A40B01B281E2C3292F5 /* Frameworks */ = {
+		F7E758A8EF305083A223BA59 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				AFA10FE5E010813B1E91834F /* Glacier2.xcframework in Frameworks */,
-				5F4BCCD1C1597091894D5087 /* Ice.xcframework in Frameworks */,
-				5B4D9A6E5418BF3F5F650D18 /* IceGrid.xcframework in Frameworks */,
-				429DA72EB010FE720D6C742B /* IceImpl.xcframework in Frameworks */,
-				E299A77DAD60E8DFCBAA9187 /* PromiseKit.xcframework in Frameworks */,
+				04980A1E0970588D5763A589 /* Ice.xcframework in Frameworks */,
+				25AB0F41B9780AF4856116EA /* IceImpl.xcframework in Frameworks */,
+				23FF46B15DBF2E068AAB8A93 /* PromiseKit.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		FA2E26807D2DABEDA0730144 /* Frameworks */ = {
+		FC7C91626171C52C60A56727 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C576A5F1BD07620DC606EBCF /* Ice.xcframework in Frameworks */,
-				CB34AF9E2101F496F93EAC79 /* IceImpl.xcframework in Frameworks */,
-				B7E26932B35B732187F2FB37 /* PromiseKit.xcframework in Frameworks */,
+				19E00BFF583537AEFBC88424 /* Ice.xcframework in Frameworks */,
+				66C86D41B853871F236B5499 /* IceImpl.xcframework in Frameworks */,
+				7F52C550F5ABE139771A840A /* PromiseKit.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		FE38D59A6986742BEE5A52AE /* Frameworks */ = {
+		FD5EFAC17784950497EA651A /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				AC5F83FFA8B64959FAE9B929 /* Ice.xcframework in Frameworks */,
-				04A0558D9FC21428ADDEB063 /* IceImpl.xcframework in Frameworks */,
-				C5DCDAEE14456FE153F06F05 /* IceStorm.xcframework in Frameworks */,
-				16D343280A66EDF32939167D /* PromiseKit.xcframework in Frameworks */,
+				73CEAFEE072FC6BEF2E1F5C7 /* Ice.xcframework in Frameworks */,
+				9516D35BFFE6F2D66C6FCCE1 /* IceImpl.xcframework in Frameworks */,
+				C2EE59133B5533F2251A576A /* PromiseKit.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		FE58A64A8F63238E79FFFBB9 /* Frameworks */ = {
+		FE63442516858C477D11C096 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				93D50216C1EC663D1BD56766 /* Ice.xcframework in Frameworks */,
-				F98852227C27AA09BEF4DEBA /* IceImpl.xcframework in Frameworks */,
-				CC52D560764B23BBFE53BAE8 /* PromiseKit.xcframework in Frameworks */,
+				910C48BF6007222BB5045854 /* Ice.xcframework in Frameworks */,
+				ACB3DB2EA2DBE16322DC2C66 /* IceImpl.xcframework in Frameworks */,
+				96612D9F85C656B2F2878365 /* PromiseKit.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		009AE49C42EB989C497DBE43 /* Client */ = {
+		03E5E478115A4358BDA2D5E2 /* Server */ = {
 			isa = PBXGroup;
 			children = (
-				33A4936D644169FE316E54E1 /* main.swift */,
-			);
-			name = Client;
-			sourceTree = "<group>";
-		};
-		158C507D746B8731DCA6F298 /* Server */ = {
-			isa = PBXGroup;
-			children = (
-				6BE3E92C43F1D4A3709F9319 /* main.swift */,
+				7AE01E8009BD5112F86F3EE7 /* main.swift */,
 			);
 			name = Server;
 			sourceTree = "<group>";
 		};
-		170BEDC2A6DF2A094FED301F /* context */ = {
+		0785AC5A5A286DE74A9F3E9D /* invoke */ = {
 			isa = PBXGroup;
 			children = (
-				A5867E02B7E400932C7C82A8 /* Client */,
-				629E50D095E24E4E7FF9FA07 /* Server */,
-				DFF2A84050F27AAF801166DD /* config.client */,
-				AB95F2441E6D8C237C489342 /* config.server */,
-				38D692F7A1A59D07B3A84D38 /* Context.ice */,
-				555B4E4C32AB73151AC64B48 /* README.md */,
-			);
-			name = context;
-			sourceTree = "<group>";
-		};
-		187B706D24F421475D761201 /* Server */ = {
-			isa = PBXGroup;
-			children = (
-				0CC9437BF449759BC05DF17E /* CalculatorI.swift */,
-				28DADE4A9B6DA1704649740D /* main.swift */,
-			);
-			name = Server;
-			sourceTree = "<group>";
-		};
-		1DD987B34549122D1DB4C66D /* async */ = {
-			isa = PBXGroup;
-			children = (
-				8C6049D317F667A46446EEEB /* Client */,
-				711199F416D8B4557E4A69CD /* Server */,
-				55BA08D94F88634B1FCC8444 /* config.client */,
-				AE71E1166654BE7475DB36BA /* config.server */,
-				E766A925498F62424246E54C /* Hello.ice */,
-				C21EA1694662E040DC2608DE /* README.md */,
-			);
-			name = async;
-			sourceTree = "<group>";
-		};
-		1E6BEDAE823E4485B92C4502 /* Ice */ = {
-			isa = PBXGroup;
-			children = (
-				1DD987B34549122D1DB4C66D /* async */,
-				4061DBBDAE5D1A597B3958F6 /* asyncInvocation */,
-				648F55CCB78E1C8432E98372 /* bidir */,
-				170BEDC2A6DF2A094FED301F /* context */,
-				CE9DAE44D7DE398110ED097E /* hello */,
-				CEA844520C2D03AB2983A941 /* interceptor */,
-				B9BEBEC631F063B2977D4433 /* invoke */,
-				3A697D08AB2F483DC473695D /* latency */,
-				1F4CE1326EBE1BF1E946C975 /* minimal */,
-				2663B7521B4FD529569693A6 /* optional */,
-				2B49B3FB7F23CAD3653B9FC1 /* throughput */,
-			);
-			name = Ice;
-			sourceTree = "<group>";
-		};
-		1F4CE1326EBE1BF1E946C975 /* minimal */ = {
-			isa = PBXGroup;
-			children = (
-				F9C9A8692C582BB58FC4AB00 /* Client */,
-				CC7EBC4DAACE7A6297C90FC2 /* Server */,
-				F845036D52ADEC64757D9E9E /* Hello.ice */,
-				FA874A29A31065D4EA8361B7 /* README.md */,
-			);
-			name = minimal;
-			sourceTree = "<group>";
-		};
-		208A6D677AD9B2685595BB7E /* iOS */ = {
-			isa = PBXGroup;
-			children = (
-				DCBEDF063E959A45ED0D1263 /* Foundation.framework */,
-				9F40534B11EFC9339CC9F490 /* Glacier2.xcframework */,
-				D79B76AFF6799725A4428FD2 /* Ice.xcframework */,
-				DC44E9365BDEFE5223CA9AC7 /* IceImpl.xcframework */,
-				6D76908AFC77A69CC01C4A45 /* InputBarAccessoryView.xcframework */,
-				32029539794EF0F1BBB97D18 /* MessageKit.xcframework */,
-				55A37C8DED853A4C0C0212D7 /* PromiseKit.xcframework */,
-			);
-			name = iOS;
-			sourceTree = "<group>";
-		};
-		2663B7521B4FD529569693A6 /* optional */ = {
-			isa = PBXGroup;
-			children = (
-				009AE49C42EB989C497DBE43 /* Client */,
-				9C1260FECBFE9B4E03ACEC1B /* Server */,
-				84A42613BC359BA2823E3450 /* config.client */,
-				3F541373F0B62EAD850F2FBD /* config.server */,
-				0942CEA562FE56F14AE24E39 /* Contact.ice */,
-				1778B75182C1B414605236A2 /* README.md */,
-			);
-			name = optional;
-			sourceTree = "<group>";
-		};
-		2B49B3FB7F23CAD3653B9FC1 /* throughput */ = {
-			isa = PBXGroup;
-			children = (
-				A19F6BAE7E915BACBE8CF1F6 /* Client */,
-				F9D8A0E660B41A58DB9B9E8B /* Server */,
-				D2F6B8689A468A5F9B352314 /* config.client */,
-				D97456E43139D24DB711B466 /* config.server */,
-				3CF7DDAE1C22F11406087F6D /* README.md */,
-				62889D9BEFF1DD78E140F388 /* Throughput.ice */,
-			);
-			name = throughput;
-			sourceTree = "<group>";
-		};
-		2BD66A3F16496C5AC37BBD17 /* Server */ = {
-			isa = PBXGroup;
-			children = (
-				EFABB932D97DA909193B1439 /* main.swift */,
-				7141F96B9E1438EE1FD9324B /* PrinterI.swift */,
-			);
-			name = Server;
-			sourceTree = "<group>";
-		};
-		32199827B6EA279022F964E6 /* Client */ = {
-			isa = PBXGroup;
-			children = (
-				FB86282C2355E1B10F369CC5 /* main.swift */,
-			);
-			name = Client;
-			sourceTree = "<group>";
-		};
-		326B250017C8445D4E11AC63 = {
-			isa = PBXGroup;
-			children = (
-				B7F62F39B0D39101FCD682F8 /* Frameworks */,
-				B741A71CA5C8CF74027600C6 /* Glacier2 */,
-				1E6BEDAE823E4485B92C4502 /* Ice */,
-				3E1D5656496E551ECFEDDCF6 /* IceDiscovery */,
-				6A5D1121A741D4F97078AA00 /* IceGrid */,
-				667D8B060D7393F57E69367F /* IceStorm */,
-				7B06EEF106F33BD93440076A /* iOS */,
-				3532997744C03CF881C83A3A /* Manual */,
-				5CB20F0B413543DEFFF51B6F /* Products */,
-				48532032567C26634A42F761 /* README.md */,
-			);
-			sourceTree = "<group>";
-		};
-		3532997744C03CF881C83A3A /* Manual */ = {
-			isa = PBXGroup;
-			children = (
-				589BFAE71C459DB655A8E596 /* printer */,
-				DDBF6FA088139484B565B3FF /* simpleFilesystem */,
-			);
-			name = Manual;
-			sourceTree = "<group>";
-		};
-		3A697D08AB2F483DC473695D /* latency */ = {
-			isa = PBXGroup;
-			children = (
-				8284C74E645D8EE6216DBCA8 /* Client */,
-				57BC018F615960F7999547DA /* Server */,
-				7E17AB21DCAF1F73A95C330A /* config.client */,
-				4B30F8E39455552DCCB5A76E /* config.server */,
-				AE6F2AD2D3EF1EAE5E359219 /* Latency.ice */,
-				CAD4C6D304F2992DB034125B /* README.md */,
-			);
-			name = latency;
-			sourceTree = "<group>";
-		};
-		3E1D5656496E551ECFEDDCF6 /* IceDiscovery */ = {
-			isa = PBXGroup;
-			children = (
-				D76E895357669453AAF482E3 /* hello */,
-				41D9A99099132A288C8B7AAB /* replication */,
-			);
-			name = IceDiscovery;
-			sourceTree = "<group>";
-		};
-		4061DBBDAE5D1A597B3958F6 /* asyncInvocation */ = {
-			isa = PBXGroup;
-			children = (
-				32199827B6EA279022F964E6 /* Client */,
-				187B706D24F421475D761201 /* Server */,
-				16DBCF84A11CA84DB546F2A8 /* Calculator.ice */,
-				D5C857A08E88266D524C21DE /* config.client */,
-				D36596AA2C4FC9D4E95F3AC4 /* config.server */,
-				B36636F185D07AF691E33EB1 /* README.md */,
-			);
-			name = asyncInvocation;
-			sourceTree = "<group>";
-		};
-		416AFDD800E61D9A88336764 /* Client */ = {
-			isa = PBXGroup;
-			children = (
-				B0EFBEDB18F101F76F3B4348 /* main.swift */,
-			);
-			name = Client;
-			sourceTree = "<group>";
-		};
-		41D9A99099132A288C8B7AAB /* replication */ = {
-			isa = PBXGroup;
-			children = (
-				416AFDD800E61D9A88336764 /* Client */,
-				8CFEB91A26AC9466A8FC1724 /* Server */,
-				A35F2233F0DE4E25E3574F31 /* config.client */,
-				685E3D4F4F23123EA4349688 /* config.server1 */,
-				FE066D1FEF2F83460BA73C41 /* config.server2 */,
-				CF856DB0D368176513B5C713 /* config.server3 */,
-				401F230285604E1ADBEA9689 /* Hello.ice */,
-				F94EBC11263108F8FE222AC8 /* README.md */,
-			);
-			name = replication;
-			sourceTree = "<group>";
-		};
-		4BD5F26D81A0B56D5556EFDE /* Client */ = {
-			isa = PBXGroup;
-			children = (
-				196EF0A3C8C45D4604C52011 /* main.swift */,
-			);
-			name = Client;
-			sourceTree = "<group>";
-		};
-		53879DA1A4049CF00CCAA98C /* Server */ = {
-			isa = PBXGroup;
-			children = (
-				7011BF01BCEDBFABCB6AAB74 /* main.swift */,
-			);
-			name = Server;
-			sourceTree = "<group>";
-		};
-		57BC018F615960F7999547DA /* Server */ = {
-			isa = PBXGroup;
-			children = (
-				7D135994048263BF1FDD1606 /* main.swift */,
-			);
-			name = Server;
-			sourceTree = "<group>";
-		};
-		589BFAE71C459DB655A8E596 /* printer */ = {
-			isa = PBXGroup;
-			children = (
-				6D106675C5A5AE960F8C489B /* Client */,
-				B04A4E72BA7AE70DAFF9112B /* Server */,
-				393A11CCE8A9AF5886257EB1 /* Printer.ice */,
-				F5A28E10628A4036DE52D88B /* README.md */,
-			);
-			name = printer;
-			sourceTree = "<group>";
-		};
-		5CB20F0B413543DEFFF51B6F /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				FFB00730E6A7AA37BA85E0C4 /* Glacier2CallbackClient */,
-				6E24D220EF2E79E445C87850 /* Glacier2CallbackServer */,
-				1EA7D8DD444806C4FE809AC5 /* IceAsyncClient */,
-				B3914CEEB182107F446A7D22 /* IceAsyncInvocationClient */,
-				04E169866A28CE4C09EC830C /* IceAsyncInvocationServer */,
-				75A364B7B36A2F27E0C7B5EE /* IceAsyncServer */,
-				2C3DB1C65D1B9ED24051DE99 /* IceBidirClient */,
-				2A4CA42CA6ED3C00EE5DC00C /* IceBidirServer */,
-				F7449754D30A52F680857B55 /* IceContextClient */,
-				87326C9631EA22318B8FA8B7 /* IceContextServer */,
-				3C8B097D24CC045E9397A8BF /* IceDiscoveryHelloClient */,
-				F901F95276B12496C039F7A0 /* IceDiscoveryHelloServer */,
-				E9F1D7FC36EFF1498901294C /* IceDiscoveryReplicationClient */,
-				017A6BF2C245B1938F34C6C8 /* IceDiscoveryReplicationServer */,
-				4E1ACB62C85FF06D49A7E781 /* IceGridSimpleClient */,
-				60650B913C1E84C7982E4061 /* IceGridSimpleServer */,
-				D2285D300CF1AFBB54CFC603 /* IceHelloClient */,
-				22C91647BDCDB9779AB19CA3 /* IceHelloServer */,
-				6509D4615F63497D8F3A1415 /* IceInterceptorClient */,
-				9CB0C08B0D54EB988D212533 /* IceInterceptorServer */,
-				55BD51CDE4F248ED184B9C03 /* IceInvokeClient */,
-				418BEF74D1793129A5C72B23 /* IceInvokeServer */,
-				5A69CA4F896CFA76B7F4FC54 /* IceLatencyClient */,
-				3A68D8EB52D1135866BCA2C2 /* IceLatencyServer */,
-				DCADEBA495EB820A0A7E41C6 /* IceMinimalClient */,
-				F96051CE81CCCA810E36B833 /* IceMinimalServer */,
-				81B6BBD37B3FB2976F76A36D /* IceOptionalClient */,
-				AEE29AA3114D5818B8752800 /* IceOptionalServer */,
-				39C8A1A7AB5FD2BC8E5D7419 /* IceStormClockPublisher */,
-				6141C3CBC55BB9133DDD5F29 /* IceStormClockSubscriber */,
-				F78B443277F9161110BF4872 /* IceThroughputClient */,
-				DB6321B16A4E43CD89148041 /* IceThroughputServer */,
-				795BDD345A8758BE1BCE1037 /* chat.app */,
-				3963729A3421FF714DB83E79 /* IOSHello.app */,
-				8B51D44CE59C7B800960E3A3 /* IOSLibrary.app */,
-				981FAA0E0B3E4FB23D50B8BA /* ManualPrinterClient */,
-				8B8E083932784B369B4A3549 /* ManualPrinterServer */,
-				2210BCF19216BBCAD944F9D6 /* ManualSimpleFilesystemClient */,
-				F205564C9B6D912980932EAB /* ManualSimpleFilesystemServer */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		5D2F88AFC8BD67C0F356E7A9 /* Client */ = {
-			isa = PBXGroup;
-			children = (
-				63215B9BDD9CB595E01658F8 /* main.swift */,
-			);
-			name = Client;
-			sourceTree = "<group>";
-		};
-		61C8A274B873D121E0CAC185 /* simple */ = {
-			isa = PBXGroup;
-			children = (
-				88D684F6D2A60BFA3604BED5 /* Client */,
-				8F52BCF8B7EE84771EE2B805 /* Server */,
-				6068627F8185893E1E823DD0 /* config.client */,
-				887EA3F372177378BBB92B74 /* config.grid */,
-				0BF7011B044009FEDA7643A3 /* Hello.ice */,
-				6B62B83268F60F7C2F99ED08 /* README.md */,
-			);
-			name = simple;
-			sourceTree = "<group>";
-		};
-		629E50D095E24E4E7FF9FA07 /* Server */ = {
-			isa = PBXGroup;
-			children = (
-				A848D5911477BACC1B9C18C8 /* ContextI.swift */,
-				06BE5622AC513229E4D8C1DA /* main.swift */,
-			);
-			name = Server;
-			sourceTree = "<group>";
-		};
-		648F55CCB78E1C8432E98372 /* bidir */ = {
-			isa = PBXGroup;
-			children = (
-				5D2F88AFC8BD67C0F356E7A9 /* Client */,
-				824FE4C833FF0EC8B9C8FFF9 /* Server */,
-				6827D0D0191C586EC4231BA4 /* Callback.ice */,
-				9CA03B4D26961B069C956D97 /* config.client */,
-				2BB13C7076DA20F0C7BFDC36 /* config.server */,
-				E6E16C4D401F03FF0852CAF0 /* README.md */,
-			);
-			name = bidir;
-			sourceTree = "<group>";
-		};
-		64D6281B3D3AC306D04470B6 /* Client */ = {
-			isa = PBXGroup;
-			children = (
-				FE4AC0DC09B8774590AF2DDF /* main.swift */,
-			);
-			name = Client;
-			sourceTree = "<group>";
-		};
-		667D8B060D7393F57E69367F /* IceStorm */ = {
-			isa = PBXGroup;
-			children = (
-				FC429D41C3CBB6EA87E159FE /* clock */,
-			);
-			name = IceStorm;
-			sourceTree = "<group>";
-		};
-		6A3A099743C3C6BD676DDAC1 /* Client */ = {
-			isa = PBXGroup;
-			children = (
-				3E73A8039907731FCD618C1F /* main.swift */,
-			);
-			name = Client;
-			sourceTree = "<group>";
-		};
-		6A5D1121A741D4F97078AA00 /* IceGrid */ = {
-			isa = PBXGroup;
-			children = (
-				61C8A274B873D121E0CAC185 /* simple */,
-			);
-			name = IceGrid;
-			sourceTree = "<group>";
-		};
-		6D106675C5A5AE960F8C489B /* Client */ = {
-			isa = PBXGroup;
-			children = (
-				962F08EBB1AD8F2EDDCA79C2 /* main.swift */,
-			);
-			name = Client;
-			sourceTree = "<group>";
-		};
-		711199F416D8B4557E4A69CD /* Server */ = {
-			isa = PBXGroup;
-			children = (
-				CAB0E574877C807BE5637963 /* main.swift */,
-			);
-			name = Server;
-			sourceTree = "<group>";
-		};
-		7B06EEF106F33BD93440076A /* iOS */ = {
-			isa = PBXGroup;
-			children = (
-				E801909DA95420F4BB54AC5E /* chat */,
-				D79115D4B5FDE59358063B9A /* hello */,
-				91B03E7D9591980DD8D41F13 /* library */,
-			);
-			name = iOS;
-			sourceTree = "<group>";
-		};
-		7F5D7C032455608D4E7086E5 /* Server */ = {
-			isa = PBXGroup;
-			children = (
-				86E08919DF7384C8501E200E /* AuthenticatorI.swift */,
-				D9225308B90D05589A4A6BDF /* InterceptorI.swift */,
-				0C4552F3A57E06F1FE087CA3 /* main.swift */,
-				22F9E0B5646525E4BCDD65DB /* ThermostatI.swift */,
-			);
-			name = Server;
-			sourceTree = "<group>";
-		};
-		824FE4C833FF0EC8B9C8FFF9 /* Server */ = {
-			isa = PBXGroup;
-			children = (
-				CD67B4FA75F306DC428A91EC /* main.swift */,
-			);
-			name = Server;
-			sourceTree = "<group>";
-		};
-		8284C74E645D8EE6216DBCA8 /* Client */ = {
-			isa = PBXGroup;
-			children = (
-				452D5F978671BA38A3F94EB3 /* main.swift */,
-			);
-			name = Client;
-			sourceTree = "<group>";
-		};
-		88D684F6D2A60BFA3604BED5 /* Client */ = {
-			isa = PBXGroup;
-			children = (
-				CF3CBA7BB3733BC3DFB8B8F3 /* main.swift */,
-			);
-			name = Client;
-			sourceTree = "<group>";
-		};
-		8C6049D317F667A46446EEEB /* Client */ = {
-			isa = PBXGroup;
-			children = (
-				062D4FF632571C9B1EE57EDA /* main.swift */,
-			);
-			name = Client;
-			sourceTree = "<group>";
-		};
-		8CFEB91A26AC9466A8FC1724 /* Server */ = {
-			isa = PBXGroup;
-			children = (
-				626DF7CBBBF14EA0C5B37ADA /* main.swift */,
-			);
-			name = Server;
-			sourceTree = "<group>";
-		};
-		8F52BCF8B7EE84771EE2B805 /* Server */ = {
-			isa = PBXGroup;
-			children = (
-				564EEE78D51984E4FC201895 /* main.swift */,
-			);
-			name = Server;
-			sourceTree = "<group>";
-		};
-		91B03E7D9591980DD8D41F13 /* library */ = {
-			isa = PBXGroup;
-			children = (
-				CE172FAF992BE42BF38A733D /* AddController.swift */,
-				CA3625DECE4A1AD3E1926870 /* AppDelegate.swift */,
-				94A052DBBD69CB6C57BB5E82 /* config.client */,
-				D4B9142B71C331252B9ABD6C /* DetailController.swift */,
-				6643D756BFA7EEC23DC768D2 /* EditController.swift */,
-				E7394F43D1595EA0A782488C /* Glacier2Session.ice */,
-				4D8C4A502C81A17810483EAC /* Images.xcassets */,
-				ACA7351C60E3801D9AB14CB1 /* LaunchScreen.storyboard */,
-				48B5E1B84C2F4810AF3BE092 /* Library.ice */,
-				572B6823AAC759EDC9E19B71 /* LoginController.swift */,
-				89D4B0BEAB0413B93B185EA9 /* Main.storyboard */,
-				B9C206C3CF068A0923D1B6BE /* MainController.swift */,
-				70F2BD7A488A205C3F2FFF1F /* README.md */,
-				A488AF4C5BBD8776F8442C44 /* Session.ice */,
-			);
-			name = library;
-			sourceTree = "<group>";
-		};
-		9A5C7803265A8B46D688B47A /* callback */ = {
-			isa = PBXGroup;
-			children = (
-				6A3A099743C3C6BD676DDAC1 /* Client */,
-				158C507D746B8731DCA6F298 /* Server */,
-				10A521847822A38F221AF2AF /* Callback.ice */,
-				26C4F52C904CDC3D4D1A5308 /* config.client */,
-				40E1DE82E595DADFE3DE206F /* config.glacier2 */,
-				4008AF26901E735EE9EC40FD /* config.server */,
-				FE75106F54717B3D51C0664A /* README.md */,
-			);
-			name = callback;
-			sourceTree = "<group>";
-		};
-		9C1260FECBFE9B4E03ACEC1B /* Server */ = {
-			isa = PBXGroup;
-			children = (
-				E4ED404F16F47126CD654B7B /* ContactDBI.swift */,
-				344F81939D64CD391A3B64BA /* main.swift */,
-			);
-			name = Server;
-			sourceTree = "<group>";
-		};
-		A074187374B58AC44D0102C9 /* Client */ = {
-			isa = PBXGroup;
-			children = (
-				412158B51D090DBE79E8588C /* main.swift */,
-			);
-			name = Client;
-			sourceTree = "<group>";
-		};
-		A19F6BAE7E915BACBE8CF1F6 /* Client */ = {
-			isa = PBXGroup;
-			children = (
-				5300F0985211B122CE67D3DE /* main.swift */,
-			);
-			name = Client;
-			sourceTree = "<group>";
-		};
-		A5867E02B7E400932C7C82A8 /* Client */ = {
-			isa = PBXGroup;
-			children = (
-				00E639D7AAB89720BD2AF551 /* main.swift */,
-			);
-			name = Client;
-			sourceTree = "<group>";
-		};
-		A96C6439398071159FCE69E7 /* Publisher */ = {
-			isa = PBXGroup;
-			children = (
-				FE183346DF16C34D553A5778 /* main.swift */,
-			);
-			name = Publisher;
-			sourceTree = "<group>";
-		};
-		B04A4E72BA7AE70DAFF9112B /* Server */ = {
-			isa = PBXGroup;
-			children = (
-				F1417615123189DBFB739754 /* main.swift */,
-			);
-			name = Server;
-			sourceTree = "<group>";
-		};
-		B741A71CA5C8CF74027600C6 /* Glacier2 */ = {
-			isa = PBXGroup;
-			children = (
-				9A5C7803265A8B46D688B47A /* callback */,
-			);
-			name = Glacier2;
-			sourceTree = "<group>";
-		};
-		B7F62F39B0D39101FCD682F8 /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				208A6D677AD9B2685595BB7E /* iOS */,
-				D99A0B865EB5FBAABB1710E0 /* OS X */,
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
-		B9BEBEC631F063B2977D4433 /* invoke */ = {
-			isa = PBXGroup;
-			children = (
-				FBFF3F45A3FC1D137B6874DA /* Client */,
-				2BD66A3F16496C5AC37BBD17 /* Server */,
-				5570BD4237087EEDD3669912 /* config.client */,
-				10580C577F8088ACB4185AFF /* config.server */,
-				C5AB75CEB64242F131C9C4BA /* Printer.ice */,
-				FCD0FE371EB69FE1DCC961C0 /* README.md */,
+				DD7437D0C4533C07ACFB702C /* Client */,
+				6EE8C1DE360D65DB2B209C17 /* Server */,
+				EF794987CF7F6B3823048583 /* config.client */,
+				FD838DA6C309CBA363DE4B44 /* config.server */,
+				38744134BEAD371CB759721B /* Printer.ice */,
+				7938BE5DB2B8B9ED4EA6B076 /* README.md */,
 			);
 			name = invoke;
 			sourceTree = "<group>";
 		};
-		CC7EBC4DAACE7A6297C90FC2 /* Server */ = {
+		088C15EC282F1EF58180878E /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				62F56BC2E31623E888EE6519 /* main.swift */,
+				3AF7ADB40742E7132B2F3480 /* iOS */,
+				9AA04BE2FC0504E7F67B531C /* OS X */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		0C33FEB95F2DFA6167504029 /* simple */ = {
+			isa = PBXGroup;
+			children = (
+				50DD73DE3989CC2D6F1121D1 /* Client */,
+				B53689D74453E8343B2D778D /* Server */,
+				0681A21702B3149176695AFB /* config.client */,
+				8D4379A5E70B21CE63A6B6F6 /* config.grid */,
+				ABFD6BCBCC983EA843AD4D2D /* Hello.ice */,
+				E39710A5090BEA57D7EEBB3A /* README.md */,
+			);
+			name = simple;
+			sourceTree = "<group>";
+		};
+		0DF12B68A1CD4E3FF58197C1 /* Server */ = {
+			isa = PBXGroup;
+			children = (
+				0983D2DC20F667ECE804DBCE /* main.swift */,
 			);
 			name = Server;
 			sourceTree = "<group>";
 		};
-		CE9DAE44D7DE398110ED097E /* hello */ = {
+		10B1E75EED8C751BB439A6D7 /* hello */ = {
 			isa = PBXGroup;
 			children = (
-				64D6281B3D3AC306D04470B6 /* Client */,
-				53879DA1A4049CF00CCAA98C /* Server */,
-				E6265EF8C479AA2FA0C01649 /* config.client */,
-				FADC9269113326F3E56F51EB /* config.server */,
-				78FB10F066D761AF1A24DB94 /* Hello.ice */,
-				9F90CCBCA51A64124D15A8B4 /* README.md */,
+				D8C2C004AF7BF060DC3D4A26 /* Client */,
+				FAE5173F23E6600ED5954490 /* Server */,
+				89927D974CC0546757B3725F /* config.client */,
+				F7026ABA8A9E0B5F0563534B /* config.server */,
+				FDCC5878BE3F1BDFBDC416C1 /* Hello.ice */,
+				A80A5EE7CF7AB7D924FB4444 /* README.md */,
 			);
 			name = hello;
 			sourceTree = "<group>";
 		};
-		CEA844520C2D03AB2983A941 /* interceptor */ = {
+		141D659F459E066A33AF0A60 /* Server */ = {
 			isa = PBXGroup;
 			children = (
-				4BD5F26D81A0B56D5556EFDE /* Client */,
-				7F5D7C032455608D4E7086E5 /* Server */,
-				243D3F8A601DE2B8A3FA36B3 /* config.client */,
-				E88C1C30A300233B9814D013 /* config.server */,
-				BA319441718A4B4410187238 /* Interceptor.ice */,
-				16B1909C47C25A2F958F9B42 /* README.md */,
+				B0E6A06FE6652B7B68DF2300 /* main.swift */,
 			);
-			name = interceptor;
+			name = Server;
 			sourceTree = "<group>";
 		};
-		D76E895357669453AAF482E3 /* hello */ = {
+		1448FF2CA8AB1418BAE92588 /* Client */ = {
 			isa = PBXGroup;
 			children = (
-				F145BE7880082829E964C645 /* Client */,
-				F52BE8FA5C5C7E9811094720 /* Server */,
-				542A970BC1F69E2C31ED478B /* config.client */,
-				6E84CD23DB9FAE071A069EC8 /* config.server */,
-				F59BA32210DDA4AF9E06A751 /* Hello.ice */,
-				DBFF5192CDC30041BE50C4E5 /* README.md */,
-			);
-			name = hello;
-			sourceTree = "<group>";
-		};
-		D79115D4B5FDE59358063B9A /* hello */ = {
-			isa = PBXGroup;
-			children = (
-				DE06C1F13EC4D1CDBC4FBC70 /* AppDelegate.swift */,
-				734F7EBAF5DD523F69E07AEA /* certs */,
-				8D28BE3CE7F6D7DFC1075304 /* Hello.ice */,
-				45F2D35942591858FBD901DD /* Images.xcassets */,
-				7451971287B9F34894391172 /* LaunchScreen.storyboard */,
-				4DCF7B3212E070F32DE5D06F /* Main.storyboard */,
-				018AF44E0CED15AAF2DDEC48 /* README.md */,
-				A6F51134D874C51E8A43C60F /* ViewController.swift */,
-			);
-			name = hello;
-			sourceTree = "<group>";
-		};
-		D99A0B865EB5FBAABB1710E0 /* OS X */ = {
-			isa = PBXGroup;
-			children = (
-				F2DFDDEDAC25F902550766D4 /* Cocoa.framework */,
-				6A9CC980FC134C230BC7EF63 /* Glacier2.xcframework */,
-				28C558DB55A446508E4FF509 /* Ice.xcframework */,
-				FA3BF90C0656239819A25831 /* IceGrid.xcframework */,
-				44E2EF3378D9F7C7F0D447C2 /* IceImpl.xcframework */,
-				C1C7EFC80BA45C6FAB2C053C /* IceStorm.xcframework */,
-				E33F8EBD6359013AE72CB2C7 /* PromiseKit.xcframework */,
-			);
-			name = "OS X";
-			sourceTree = "<group>";
-		};
-		DDBF6FA088139484B565B3FF /* simpleFilesystem */ = {
-			isa = PBXGroup;
-			children = (
-				A074187374B58AC44D0102C9 /* Client */,
-				F5FE86BA41C71E9FCCF6F05D /* Server */,
-				CBE746FB0E45B94FB26DBC9A /* Filesystem.ice */,
-				A4422835E9642A1937348401 /* README.md */,
-			);
-			name = simpleFilesystem;
-			sourceTree = "<group>";
-		};
-		E801909DA95420F4BB54AC5E /* chat */ = {
-			isa = PBXGroup;
-			children = (
-				6DA9D65FCBB43921AE081B19 /* ChatApp.swift */,
-				A768655A27B30C1400E41232 /* LoginView.swift */,
-				664BB7725F3CE5BF2D6D1362 /* Chat.ice */,
-				04B294665F8365C4660E5293 /* ChatController.swift */,
-				7FE03B5CC4924485E04FC7BA /* ChatLayoutController.swift */,
-				9169D28F09D967F0B93C7D8A /* ChatMessage.swift */,
-				176C6FB865C900ACDE99E192 /* ChatSession.ice */,
-				115E221C6424603632377848 /* ChatUser.swift */,
-				1E17322B9B3129F67236C598 /* config.client */,
-				A1ED884AD886A6DEBBC3C728 /* Images.xcassets */,
-				560295E3FB26C30FE4279071 /* LaunchScreen.storyboard */,
-				17C01B6B96D318BD91BCCED7 /* LoadingButton.swift */,
-				2F5252E6DE7462352320FB7A /* LoginController.swift */,
-				2DA6A62EE8B96C49196C6104 /* Main.storyboard */,
-				CFF54020CA34595CE4AAA3D1 /* README.md */,
-				E0CEA765E2311A5EA908CCF7 /* UserController.swift */,
-				A768655C27B3134D00E41232 /* LoginViewModel.swift */,
-			);
-			name = chat;
-			sourceTree = "<group>";
-		};
-		F145BE7880082829E964C645 /* Client */ = {
-			isa = PBXGroup;
-			children = (
-				5CA1965D308C6B95B2D02B01 /* main.swift */,
+				8B072E97D7C8C6712C74FA65 /* main.swift */,
 			);
 			name = Client;
 			sourceTree = "<group>";
 		};
-		F52BE8FA5C5C7E9811094720 /* Server */ = {
+		153BF7B3FDB7C7E3E9E551B0 /* Server */ = {
 			isa = PBXGroup;
 			children = (
-				01DCB1638386E8F076C4527F /* main.swift */,
+				8D8A0252E35287420AD6F9C4 /* CalculatorI.swift */,
+				FE553DAEFFB91D14B2F1E095 /* main.swift */,
 			);
 			name = Server;
 			sourceTree = "<group>";
 		};
-		F5FE86BA41C71E9FCCF6F05D /* Server */ = {
+		197871CCF438824048A2CF43 /* Server */ = {
 			isa = PBXGroup;
 			children = (
-				DA4598F4AC7F620B4079E250 /* main.swift */,
+				CEFC33ED9950620998C6D44C /* ContextI.swift */,
+				BC3E97FBD168151BE75FFABC /* main.swift */,
 			);
 			name = Server;
 			sourceTree = "<group>";
 		};
-		F9C9A8692C582BB58FC4AB00 /* Client */ = {
+		1F3FCC5FFF16397BDE3E48F3 /* printer */ = {
 			isa = PBXGroup;
 			children = (
-				6CA52058B78D6D362BFE4799 /* main.swift */,
+				A9521D2F4C8F38B776D2686E /* Client */,
+				A1B1C26631EACE0283A7884B /* Server */,
+				9D6E4AD2F25CC4A4A74FD31B /* Printer.ice */,
+				9E0D4A451D2A343DB1071229 /* README.md */,
+			);
+			name = printer;
+			sourceTree = "<group>";
+		};
+		3210C2378E519CD9949ACE14 /* Client */ = {
+			isa = PBXGroup;
+			children = (
+				03B80F9BF7F22E83B6E50198 /* main.swift */,
 			);
 			name = Client;
 			sourceTree = "<group>";
 		};
-		F9D8A0E660B41A58DB9B9E8B /* Server */ = {
+		3646BECCE042C748D166DB4A /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				A3DFA602DEC55A1DE82BBF9F /* main.swift */,
+				032AD4164F9268ACF34475BD /* Chat.app */,
+				954A6B2ECBC0B96B5C91A1BD /* Glacier2CallbackClient */,
+				20A57F673289621EAE237CA6 /* Glacier2CallbackServer */,
+				BCC203491E7CE00E9819A24D /* IceAsyncClient */,
+				9F4E002A1950863B6F7AC89A /* IceAsyncInvocationClient */,
+				6C18C4EA4CAFFE876F2B9C5A /* IceAsyncInvocationServer */,
+				9614E9716C6E9716276184E3 /* IceAsyncServer */,
+				96ABBE35B930709AB901DF84 /* IceBidirClient */,
+				6A2239121A5E70F72E6FE232 /* IceBidirServer */,
+				5EB97A531498CDA1EDAC9496 /* IceContextClient */,
+				58BB100D0312165F66C317E3 /* IceContextServer */,
+				928B5D6019ED78F2F5C21AF1 /* IceDiscoveryHelloClient */,
+				88D1A664E0612A8EB462EEFF /* IceDiscoveryHelloServer */,
+				C37231FAC4BEBEA690B45FB3 /* IceDiscoveryHelloUI.app */,
+				38240148B810D042548804D4 /* IceDiscoveryReplicationClient */,
+				71A1E04348A91014C963D31C /* IceDiscoveryReplicationServer */,
+				42E1BC68BA3AB2F7B9C429F7 /* IceGridSimpleClient */,
+				791FA9627886D784E488A94E /* IceGridSimpleServer */,
+				B8030C583229E314C0DB3AB8 /* IceHelloClient */,
+				E225702D9CBBE0EBF3987CC9 /* IceHelloServer */,
+				6BFEAD8B2DE9FB136CCFDD3C /* IceHelloUI.app */,
+				634F4F283DB76162164924F9 /* IceInterceptorClient */,
+				D7088FF2DD5FE9F6CC3190FA /* IceInterceptorServer */,
+				1844EB7D97A6D75CBBCD7023 /* IceInvokeClient */,
+				D4F0BFBD7206AE0ABB253518 /* IceInvokeServer */,
+				53175EBECFD91BDAEA5E7A79 /* IceLatencyClient */,
+				4E3444B8FDCFF52FD16A86EC /* IceLatencyServer */,
+				50ED78D2D71AA4911AC977E4 /* IceMinimalClient */,
+				E66EB015682EA85EB843D95F /* IceMinimalServer */,
+				489FC987C118929E6AF6C2FD /* IceOptionalClient */,
+				2B44897C564CE6DB603CB4D2 /* IceOptionalServer */,
+				237032C49A14937A66AEDE89 /* IceStormClockPublisher */,
+				74967D9EDD67C16FEC6DC608 /* IceStormClockSubscriber */,
+				97DA3C7B652B58F96E995626 /* IceThroughputClient */,
+				F0212F8CFBEB9A40C179AFB6 /* IceThroughputServer */,
+				E6C2A46A1A9A6BC1A795FD94 /* ManualPrinterClient */,
+				174732B643FAE8038ADD39CC /* ManualPrinterServer */,
+				E258705B5737C00AD85256EB /* ManualSimpleFilesystemClient */,
+				BEEE328D6BE2266AFD7A3422 /* ManualSimpleFilesystemServer */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		3AF7ADB40742E7132B2F3480 /* iOS */ = {
+			isa = PBXGroup;
+			children = (
+				68C31C343E0A3B726FFCE13B /* Foundation.framework */,
+				97F0299BB374A87174167DC2 /* Glacier2.xcframework */,
+				BC03557C145BF03816F95E71 /* Ice.xcframework */,
+				5E747475333ADF987F603E6C /* IceImpl.xcframework */,
+				14A6541C9B56301D61D6617B /* InputBarAccessoryView.xcframework */,
+				72532D6611FFCB3AEA584CF2 /* MessageKit.xcframework */,
+				8D1F93F5EAFFF88BD6AF411C /* PromiseKit.xcframework */,
+			);
+			name = iOS;
+			sourceTree = "<group>";
+		};
+		3DA0153B791A16A17CD2E6D0 /* Client */ = {
+			isa = PBXGroup;
+			children = (
+				7155FDE58250E9D19CA3131E /* main.swift */,
+			);
+			name = Client;
+			sourceTree = "<group>";
+		};
+		4443465E086B3EAE2A4C91FA /* bidir */ = {
+			isa = PBXGroup;
+			children = (
+				3210C2378E519CD9949ACE14 /* Client */,
+				0DF12B68A1CD4E3FF58197C1 /* Server */,
+				5243222A3CC5BEAF68C60F71 /* Callback.ice */,
+				06C1AC349C68E9135698BF50 /* config.client */,
+				D8C6A957EC20D6E1482CD1A9 /* config.server */,
+				B497BA8EDA53618E2B376979 /* README.md */,
+			);
+			name = bidir;
+			sourceTree = "<group>";
+		};
+		450B987B2A8C5CC901782284 /* Server */ = {
+			isa = PBXGroup;
+			children = (
+				68FDCA36F2E359A95EFBD5FA /* main.swift */,
 			);
 			name = Server;
 			sourceTree = "<group>";
 		};
-		FB1145F864DD1BB1FEA5765B /* Subscriber */ = {
+		46F41153AD4A7C34A5D3D5DB /* IceGrid */ = {
 			isa = PBXGroup;
 			children = (
-				7EA465016479DB7783F7D599 /* main.swift */,
+				0C33FEB95F2DFA6167504029 /* simple */,
+			);
+			name = IceGrid;
+			sourceTree = "<group>";
+		};
+		50DD73DE3989CC2D6F1121D1 /* Client */ = {
+			isa = PBXGroup;
+			children = (
+				71FA03B36793A98FE0D86D99 /* main.swift */,
+			);
+			name = Client;
+			sourceTree = "<group>";
+		};
+		50FC6176573C89B97EA18825 /* Client */ = {
+			isa = PBXGroup;
+			children = (
+				E729B07F7DF1A13054A6B6CD /* main.swift */,
+			);
+			name = Client;
+			sourceTree = "<group>";
+		};
+		517A32E45C399BF8737B6662 /* Client */ = {
+			isa = PBXGroup;
+			children = (
+				F4F1FB2AB678C69D651C799C /* main.swift */,
+			);
+			name = Client;
+			sourceTree = "<group>";
+		};
+		5465E2C69A1182FFDDC03FF1 /* optional */ = {
+			isa = PBXGroup;
+			children = (
+				94620A33E11856664D259DC7 /* Client */,
+				DF9A37E2FFA899E9F9A259EF /* Server */,
+				D99FE19F282B8EA3BAE3604D /* config.client */,
+				C6642E449C72EBBEDA750080 /* config.server */,
+				1159DF4CC0FC9B954A10D812 /* Contact.ice */,
+				E80F3CC81610D173C9BBAE35 /* README.md */,
+			);
+			name = optional;
+			sourceTree = "<group>";
+		};
+		560743428EB1B6DB97A6B76B /* helloUI */ = {
+			isa = PBXGroup;
+			children = (
+				D09298A13696CB8450955D26 /* ButtonView.swift */,
+				558F42A0EB85C995C0501E62 /* certs */,
+				682FF469D6A1C7F0B187FCFB /* Client.swift */,
+				767E6BD4CF76BB3960550B1B /* FormView.swift */,
+				FDFE811E43D3912A799A2927 /* Hello.ice */,
+				89CF71983E611003BE227C55 /* HelloApp.swift */,
+				91493EA2D9B868513FFDC930 /* Images.xcassets */,
+				7E03CE17EC29CC0EB9F65C25 /* ProxySettings.swift */,
+				B4CAEB24950021156B12C284 /* ProxySettingsView.swift */,
+				77EA7B15D8095A7AD933D774 /* README.md */,
+				53305CC3053FB53A008BE291 /* StatusView.swift */,
+			);
+			name = helloUI;
+			sourceTree = "<group>";
+		};
+		5F237AE37233A01558F66170 /* Subscriber */ = {
+			isa = PBXGroup;
+			children = (
+				89958C96902E761791FB2A36 /* main.swift */,
 			);
 			name = Subscriber;
 			sourceTree = "<group>";
 		};
-		FBFF3F45A3FC1D137B6874DA /* Client */ = {
+		61F38BC5D9EF12D74AF3ECE1 /* IceDiscovery */ = {
 			isa = PBXGroup;
 			children = (
-				C7A2F7EE4FA803841AEE05E6 /* main.swift */,
+				E69CC1033A579B78A498EB75 /* hello */,
+				6CCAD89911DA774C2642A0A7 /* helloUI */,
+				E0FCDECF465A6CEE500F5C87 /* replication */,
+			);
+			name = IceDiscovery;
+			sourceTree = "<group>";
+		};
+		628A9967F27CAC91E4EC82D3 /* throughput */ = {
+			isa = PBXGroup;
+			children = (
+				DAAEEAE432745661B7A95DAC /* Client */,
+				7C50C0BB11CA0D9C0F27ECA1 /* Server */,
+				DFBB4DB1169406AB65DE0D43 /* config.client */,
+				DA25E550591A21C0C234B79C /* config.server */,
+				370FDFEDDAE8AB9E2C95ADC3 /* README.md */,
+				BAFF519269261E59BCD1EC19 /* Throughput.ice */,
+			);
+			name = throughput;
+			sourceTree = "<group>";
+		};
+		62E619C499162BBF8C419BA2 /* Client */ = {
+			isa = PBXGroup;
+			children = (
+				54E37D3065FF48B94BA98BA4 /* main.swift */,
 			);
 			name = Client;
 			sourceTree = "<group>";
 		};
-		FC429D41C3CBB6EA87E159FE /* clock */ = {
+		64F22F49A2E9BF99FE733EFC /* context */ = {
 			isa = PBXGroup;
 			children = (
-				A96C6439398071159FCE69E7 /* Publisher */,
-				FB1145F864DD1BB1FEA5765B /* Subscriber */,
-				8328076C5A54A89E5C1C6A77 /* Clock.ice */,
-				49B861EA9E13E74C4707A9BD /* config.admin */,
-				92D6613B14D8EF0FBDA1351F /* config.icebox */,
-				DFEF9402B01B02D0B30A052A /* config.pub */,
-				BB8DE386B28B2E9220D3FC48 /* config.service */,
-				17040B3C51149ECC64FDA2F3 /* config.sub */,
-				489A8AB8E6B33500B4C3F442 /* README.md */,
+				7A09A4F061223FF072666DF7 /* Client */,
+				197871CCF438824048A2CF43 /* Server */,
+				4DA052D8F357433AFBF0731F /* config.client */,
+				4533079B702F03A8E4C6C87D /* config.server */,
+				9C03ACE9054F79C85364DCEE /* Context.ice */,
+				C4A7D73F02DE8719A4FA8ACB /* README.md */,
+			);
+			name = context;
+			sourceTree = "<group>";
+		};
+		692F503CAC30319C510B7859 /* callback */ = {
+			isa = PBXGroup;
+			children = (
+				736AC19CBE779BCEA4A59DFD /* Client */,
+				450B987B2A8C5CC901782284 /* Server */,
+				C11ECF49C07B3F0D8D24D4CE /* Callback.ice */,
+				DF10F59017B590429C874A30 /* config.client */,
+				7C640E4B0F5DD34BD040ED3A /* config.glacier2 */,
+				A7756572D8F6D14EB776AEAF /* config.server */,
+				9EBCAF4AD46FBF6910731E57 /* README.md */,
+			);
+			name = callback;
+			sourceTree = "<group>";
+		};
+		6B4AA40C7B2950799A4C5DB4 /* Glacier2 */ = {
+			isa = PBXGroup;
+			children = (
+				692F503CAC30319C510B7859 /* callback */,
+			);
+			name = Glacier2;
+			sourceTree = "<group>";
+		};
+		6CCAD89911DA774C2642A0A7 /* helloUI */ = {
+			isa = PBXGroup;
+			children = (
+				EC612259AECEB8BAFD75B122 /* ButtonView.swift */,
+				B6425B00666CF3BCC4321F5E /* certs */,
+				30AEEE77443915F4B5275267 /* Client.swift */,
+				D41183ED7AF99A5F55B1E8E8 /* FormView.swift */,
+				EB096EB42E87282807FE0D9D /* Hello.ice */,
+				E36C6AFB2056519590EB40BC /* HelloApp.swift */,
+				D9B1A389A4EC6F245A2A60A0 /* Images.xcassets */,
+				6DE4BC8D3B1AC40589A0F47C /* ProxySettings.swift */,
+				E26BF8F0915B9A9A8A575229 /* ProxySettingsView.swift */,
+				EBC2F9335513ED56D3880B45 /* README.md */,
+				30111B4320FFB91EA0136E0D /* StatusView.swift */,
+			);
+			name = helloUI;
+			sourceTree = "<group>";
+		};
+		6EE8C1DE360D65DB2B209C17 /* Server */ = {
+			isa = PBXGroup;
+			children = (
+				471F66A6A5B0313A7FCC8103 /* main.swift */,
+				07CBA324F6759CF66AD9F78A /* PrinterI.swift */,
+			);
+			name = Server;
+			sourceTree = "<group>";
+		};
+		736AC19CBE779BCEA4A59DFD /* Client */ = {
+			isa = PBXGroup;
+			children = (
+				753391F556A5F8C93ABC6ABD /* main.swift */,
+			);
+			name = Client;
+			sourceTree = "<group>";
+		};
+		75BDD37177983AFEB0A44962 /* minimal */ = {
+			isa = PBXGroup;
+			children = (
+				50FC6176573C89B97EA18825 /* Client */,
+				B097DDCD1A082CEB8E3B8696 /* Server */,
+				297A3C05FC7C5D646BFC71B3 /* Hello.ice */,
+				576127C28BF88AF71DF9D194 /* README.md */,
+			);
+			name = minimal;
+			sourceTree = "<group>";
+		};
+		7883BDF81F616F2DE6E2A7B7 /* async */ = {
+			isa = PBXGroup;
+			children = (
+				BFDB30AEA5105FA978DD3C73 /* Client */,
+				03E5E478115A4358BDA2D5E2 /* Server */,
+				50BC31F78661A8214D9AC25E /* config.client */,
+				77DC7E19BB8E9C2427503803 /* config.server */,
+				FA61DA58008B4C300C53DBBA /* Hello.ice */,
+				7E22546153D6D5A85F656419 /* README.md */,
+			);
+			name = async;
+			sourceTree = "<group>";
+		};
+		7A09A4F061223FF072666DF7 /* Client */ = {
+			isa = PBXGroup;
+			children = (
+				2A1D640865F913073C70C4FF /* main.swift */,
+			);
+			name = Client;
+			sourceTree = "<group>";
+		};
+		7C50C0BB11CA0D9C0F27ECA1 /* Server */ = {
+			isa = PBXGroup;
+			children = (
+				D7FFECC1E9A92EB99DB45189 /* main.swift */,
+			);
+			name = Server;
+			sourceTree = "<group>";
+		};
+		7E11268B6652280F308CA095 /* Server */ = {
+			isa = PBXGroup;
+			children = (
+				0FB6F066F7A0E28AD17B8E2B /* main.swift */,
+			);
+			name = Server;
+			sourceTree = "<group>";
+		};
+		82067A01D62D6A82F4ABE2B2 /* Client */ = {
+			isa = PBXGroup;
+			children = (
+				4DD46FB9CCAF0938A7F7A020 /* main.swift */,
+			);
+			name = Client;
+			sourceTree = "<group>";
+		};
+		94620A33E11856664D259DC7 /* Client */ = {
+			isa = PBXGroup;
+			children = (
+				3095385D6D4C977E3A5FFE0B /* main.swift */,
+			);
+			name = Client;
+			sourceTree = "<group>";
+		};
+		947F26CE9B7B705C6727335E /* interceptor */ = {
+			isa = PBXGroup;
+			children = (
+				1448FF2CA8AB1418BAE92588 /* Client */,
+				DD55A109A00FCE3C741306B8 /* Server */,
+				3E6CB6544FE1C51E9D8563C7 /* config.client */,
+				8E7D27E1D4A62EF9F607A3DF /* config.server */,
+				66C79E9BF61C66A55F891C76 /* Interceptor.ice */,
+				AAD175AD226F3EDCB2B5DC5F /* README.md */,
+			);
+			name = interceptor;
+			sourceTree = "<group>";
+		};
+		9AA04BE2FC0504E7F67B531C /* OS X */ = {
+			isa = PBXGroup;
+			children = (
+				5E66373CBAE9A5B40D99C5E5 /* Cocoa.framework */,
+				6090A77E36453AEE0FBD5067 /* Glacier2.xcframework */,
+				F6D5ADFEDCEA37390E6306AB /* Ice.xcframework */,
+				ADCEEBFF3D6FE9745DBC0F12 /* IceGrid.xcframework */,
+				A17DB692E0895FE387DAE12A /* IceImpl.xcframework */,
+				3066738A6A797BC7554D7EA6 /* IceStorm.xcframework */,
+				A3283875DC46723DD0292377 /* PromiseKit.xcframework */,
+			);
+			name = "OS X";
+			sourceTree = "<group>";
+		};
+		9BB6E649E2DB87DC952F93C5 /* Chat */ = {
+			isa = PBXGroup;
+			children = (
+				80E8C4DFE7FAAD51C145CF29 /* Chat.ice */,
+				E0BA1758D46D25B723354B2A /* ChatApp.swift */,
+				3E01850376B12840A28C24DD /* ChatMessage.swift */,
+				890485C2DE8A237A4F7E6FEF /* ChatSession.ice */,
+				C5BF957583E207844EF3D17D /* ChatUser.swift */,
+				9390FFE79FD9D646D574DC1F /* Client.swift */,
+				0BF2D8AF1D0F9CBA492FFFA0 /* config.client */,
+				47DF638C1F0FE8FDDF32230E /* Images.xcassets */,
+				4AE3EE1D56DB116DB064D5AD /* LoginView.swift */,
+				4A66943ED723AF6633F4BA99 /* LoginViewModel.swift */,
+				3419BF2F5BA87FBBEAA600E2 /* MessageView.swift */,
+				F8DFB31774349911B3A41A65 /* README.md */,
+				2471051F59F384D06E073851 /* UsersView.swift */,
+			);
+			name = Chat;
+			sourceTree = "<group>";
+		};
+		A1B1C26631EACE0283A7884B /* Server */ = {
+			isa = PBXGroup;
+			children = (
+				8046165D06F6EE72D935DFD6 /* main.swift */,
+			);
+			name = Server;
+			sourceTree = "<group>";
+		};
+		A20C3B5D452D91FB0F6C4F22 /* Server */ = {
+			isa = PBXGroup;
+			children = (
+				119DF9A2E1B9A44EAA8D3A12 /* main.swift */,
+			);
+			name = Server;
+			sourceTree = "<group>";
+		};
+		A3009FD06C7DDBAA05E591FD /* Publisher */ = {
+			isa = PBXGroup;
+			children = (
+				0E0E12A86B874F17FAEF5FD2 /* main.swift */,
+			);
+			name = Publisher;
+			sourceTree = "<group>";
+		};
+		A9521D2F4C8F38B776D2686E /* Client */ = {
+			isa = PBXGroup;
+			children = (
+				4B7264AB55E8A3106AC51A36 /* main.swift */,
+			);
+			name = Client;
+			sourceTree = "<group>";
+		};
+		ACC7D13F1681FFAF8CE8A5E7 /* Server */ = {
+			isa = PBXGroup;
+			children = (
+				F21FD317F3E42BD9EE4574FF /* main.swift */,
+			);
+			name = Server;
+			sourceTree = "<group>";
+		};
+		B097DDCD1A082CEB8E3B8696 /* Server */ = {
+			isa = PBXGroup;
+			children = (
+				B98DB4BE5FC6124CD188185D /* main.swift */,
+			);
+			name = Server;
+			sourceTree = "<group>";
+		};
+		B4D812433E7ECC2FFE490B50 /* IceStorm */ = {
+			isa = PBXGroup;
+			children = (
+				D596D01D2F4B483607E7DD0D /* clock */,
+			);
+			name = IceStorm;
+			sourceTree = "<group>";
+		};
+		B53689D74453E8343B2D778D /* Server */ = {
+			isa = PBXGroup;
+			children = (
+				865C9B290A4F6B73C770716D /* main.swift */,
+			);
+			name = Server;
+			sourceTree = "<group>";
+		};
+		B8D484444133145395577EC8 /* latency */ = {
+			isa = PBXGroup;
+			children = (
+				62E619C499162BBF8C419BA2 /* Client */,
+				7E11268B6652280F308CA095 /* Server */,
+				217DABFD60EE075178E0400E /* config.client */,
+				26A1BBF0855400731C6102AB /* config.server */,
+				0C3898D57712FCD59D25EE7F /* Latency.ice */,
+				667E1E1D15930F9FF89E995A /* README.md */,
+			);
+			name = latency;
+			sourceTree = "<group>";
+		};
+		BFDB30AEA5105FA978DD3C73 /* Client */ = {
+			isa = PBXGroup;
+			children = (
+				01659268489EEC0398AE6547 /* main.swift */,
+			);
+			name = Client;
+			sourceTree = "<group>";
+		};
+		D0107224B7BD34FB60DF166A /* simpleFilesystem */ = {
+			isa = PBXGroup;
+			children = (
+				3DA0153B791A16A17CD2E6D0 /* Client */,
+				A20C3B5D452D91FB0F6C4F22 /* Server */,
+				27F63A2026D6BA776427CA0E /* Filesystem.ice */,
+				05E0161FDFF7E077E8C26E1D /* README.md */,
+			);
+			name = simpleFilesystem;
+			sourceTree = "<group>";
+		};
+		D596D01D2F4B483607E7DD0D /* clock */ = {
+			isa = PBXGroup;
+			children = (
+				A3009FD06C7DDBAA05E591FD /* Publisher */,
+				5F237AE37233A01558F66170 /* Subscriber */,
+				659807E1F731370BB23B7547 /* Clock.ice */,
+				B4C5A5EA57237219BCD6D943 /* config.admin */,
+				5D84D251295C7D4C751783AC /* config.icebox */,
+				ED632591F04312D373E9E8F7 /* config.pub */,
+				7B89574B3373F02CB89DD755 /* config.service */,
+				2A45A7F3B38042B9A1C6190A /* config.sub */,
+				5F6B564AC40EFA0231A4E05B /* README.md */,
 			);
 			name = clock;
+			sourceTree = "<group>";
+		};
+		D6BED64FECAE1D163F003897 = {
+			isa = PBXGroup;
+			children = (
+				9BB6E649E2DB87DC952F93C5 /* Chat */,
+				088C15EC282F1EF58180878E /* Frameworks */,
+				6B4AA40C7B2950799A4C5DB4 /* Glacier2 */,
+				FEE9D1C06050ADFFAB0589AC /* Ice */,
+				61F38BC5D9EF12D74AF3ECE1 /* IceDiscovery */,
+				46F41153AD4A7C34A5D3D5DB /* IceGrid */,
+				B4D812433E7ECC2FFE490B50 /* IceStorm */,
+				DC4A6A4FB21B606ADDC90B7B /* Manual */,
+				3646BECCE042C748D166DB4A /* Products */,
+				9EA943805E1195F61F0B9D34 /* README.md */,
+			);
+			sourceTree = "<group>";
+		};
+		D8C2C004AF7BF060DC3D4A26 /* Client */ = {
+			isa = PBXGroup;
+			children = (
+				796351E195A29AF6D4C56C50 /* main.swift */,
+			);
+			name = Client;
+			sourceTree = "<group>";
+		};
+		DAAEEAE432745661B7A95DAC /* Client */ = {
+			isa = PBXGroup;
+			children = (
+				14E30ECC6FC00347408358AC /* main.swift */,
+			);
+			name = Client;
+			sourceTree = "<group>";
+		};
+		DC4A6A4FB21B606ADDC90B7B /* Manual */ = {
+			isa = PBXGroup;
+			children = (
+				1F3FCC5FFF16397BDE3E48F3 /* printer */,
+				D0107224B7BD34FB60DF166A /* simpleFilesystem */,
+			);
+			name = Manual;
+			sourceTree = "<group>";
+		};
+		DD55A109A00FCE3C741306B8 /* Server */ = {
+			isa = PBXGroup;
+			children = (
+				8392CA466DE82E34967ED739 /* AuthenticatorI.swift */,
+				03164D5D43273B40ACC16B18 /* InterceptorI.swift */,
+				3E94589557E60F855FCFD732 /* main.swift */,
+				017302CFB001ED3B8B8E4C99 /* ThermostatI.swift */,
+			);
+			name = Server;
+			sourceTree = "<group>";
+		};
+		DD7437D0C4533C07ACFB702C /* Client */ = {
+			isa = PBXGroup;
+			children = (
+				182D38D880F51066DF80DA36 /* main.swift */,
+			);
+			name = Client;
+			sourceTree = "<group>";
+		};
+		DF9A37E2FFA899E9F9A259EF /* Server */ = {
+			isa = PBXGroup;
+			children = (
+				88C5026755B2F338489AFBE9 /* ContactDBI.swift */,
+				6156419DB27240E87FC12AD3 /* main.swift */,
+			);
+			name = Server;
+			sourceTree = "<group>";
+		};
+		E0FCDECF465A6CEE500F5C87 /* replication */ = {
+			isa = PBXGroup;
+			children = (
+				517A32E45C399BF8737B6662 /* Client */,
+				141D659F459E066A33AF0A60 /* Server */,
+				81DF672C2D68C7F2F3CF21FE /* config.client */,
+				2B076ED60F9CC9A075F8B526 /* config.server1 */,
+				6ADC915B37D0929F1FA1BC61 /* config.server2 */,
+				445DC58AEBFC6B3351BAC051 /* config.server3 */,
+				1CAF9B5AB8BE58FA0EB10620 /* Hello.ice */,
+				AB5E99818282790A5DD1ACC2 /* README.md */,
+			);
+			name = replication;
+			sourceTree = "<group>";
+		};
+		E69CC1033A579B78A498EB75 /* hello */ = {
+			isa = PBXGroup;
+			children = (
+				F57B3ABE3AEA7F3C6DA348B2 /* Client */,
+				ACC7D13F1681FFAF8CE8A5E7 /* Server */,
+				F4FADA505AC591B04D682543 /* config.client */,
+				DE5C59B6BC0B895C2BF40337 /* config.server */,
+				433CCEA38EC899FF3573DA55 /* Hello.ice */,
+				D33DCF66E7BE7E370FF9DB33 /* README.md */,
+			);
+			name = hello;
+			sourceTree = "<group>";
+		};
+		F57B3ABE3AEA7F3C6DA348B2 /* Client */ = {
+			isa = PBXGroup;
+			children = (
+				59F54B9F7348F848EADE4E3B /* main.swift */,
+			);
+			name = Client;
+			sourceTree = "<group>";
+		};
+		F6AE39CBC6ED15FC8DDD6BCD /* asyncInvocation */ = {
+			isa = PBXGroup;
+			children = (
+				82067A01D62D6A82F4ABE2B2 /* Client */,
+				153BF7B3FDB7C7E3E9E551B0 /* Server */,
+				2B8323ADB0E2AAFB22A11C1F /* Calculator.ice */,
+				AC3FC1A49769889C3D83F35B /* config.client */,
+				BB5DE059D2B334AFB7F1D71F /* config.server */,
+				58C4812E8B6176167871CACE /* README.md */,
+			);
+			name = asyncInvocation;
+			sourceTree = "<group>";
+		};
+		FAE5173F23E6600ED5954490 /* Server */ = {
+			isa = PBXGroup;
+			children = (
+				8BE94C38DB2165FDFF7288A4 /* main.swift */,
+			);
+			name = Server;
+			sourceTree = "<group>";
+		};
+		FEE9D1C06050ADFFAB0589AC /* Ice */ = {
+			isa = PBXGroup;
+			children = (
+				7883BDF81F616F2DE6E2A7B7 /* async */,
+				F6AE39CBC6ED15FC8DDD6BCD /* asyncInvocation */,
+				4443465E086B3EAE2A4C91FA /* bidir */,
+				64F22F49A2E9BF99FE733EFC /* context */,
+				10B1E75EED8C751BB439A6D7 /* hello */,
+				560743428EB1B6DB97A6B76B /* helloUI */,
+				947F26CE9B7B705C6727335E /* interceptor */,
+				0785AC5A5A286DE74A9F3E9D /* invoke */,
+				B8D484444133145395577EC8 /* latency */,
+				75BDD37177983AFEB0A44962 /* minimal */,
+				5465E2C69A1182FFDDC03FF1 /* optional */,
+				628A9967F27CAC91E4EC82D3 /* throughput */,
+			);
+			name = Ice;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
-		0040AFB2BDF7A4FC5F2A6D3C /* IceDiscoveryHelloClient */ = {
+		010C5E8438CC6EBBB1D05568 /* IceOptionalServer */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 4C23DA67FE2344D08FCF1354 /* Build configuration list for PBXNativeTarget "IceDiscoveryHelloClient" */;
+			buildConfigurationList = F5C893FF9A5E99B51E0AC52B /* Build configuration list for PBXNativeTarget "IceOptionalServer" */;
 			buildPhases = (
-				3C9EF7E67751B7517A4B14C0 /* Sources */,
-				C8EF981FA6652FC517F6E4FF /* Frameworks */,
-				38C9822816608FAC34AAC0B6 /* Swiftformat & Swiftlint */,
+				A0F798223E419C6C6BF91408 /* Sources */,
+				B8201827EA096271ED52052E /* Frameworks */,
+				CC3CAE0029D25CE8EDB4E2D3 /* Swiftformat & Swiftlint */,
 			);
 			buildRules = (
-				70254A2FFE981A7314224F2C /* PBXBuildRule */,
-			);
-			dependencies = (
-			);
-			name = IceDiscoveryHelloClient;
-			productName = IceDiscoveryHelloClient;
-			productReference = 3C8B097D24CC045E9397A8BF /* IceDiscoveryHelloClient */;
-			productType = "com.apple.product-type.tool";
-		};
-		08FFABF181D09958170A8064 /* IceInvokeServer */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 00EA2003459891C598218C90 /* Build configuration list for PBXNativeTarget "IceInvokeServer" */;
-			buildPhases = (
-				46996F4A55BD2D439A58CF2F /* Sources */,
-				B9FB98A2474F5216D1D4AAAF /* Frameworks */,
-				338F79C59057B0DC12254715 /* Swiftformat & Swiftlint */,
-			);
-			buildRules = (
-				41C4A8D3BE8CF66A8FADAF00 /* PBXBuildRule */,
-			);
-			dependencies = (
-			);
-			name = IceInvokeServer;
-			productName = IceInvokeServer;
-			productReference = 418BEF74D1793129A5C72B23 /* IceInvokeServer */;
-			productType = "com.apple.product-type.tool";
-		};
-		1687F343DF79EA8213972141 /* IceAsyncClient */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 540AA1CE227A94705A039762 /* Build configuration list for PBXNativeTarget "IceAsyncClient" */;
-			buildPhases = (
-				2FF832FDE3A741A109A8C649 /* Sources */,
-				BA97A010490CDB19C7DAA76E /* Frameworks */,
-				F5C2DCD75F0532DE5B7D0105 /* Swiftformat & Swiftlint */,
-			);
-			buildRules = (
-				56A42DF76C566BFA9FFDEF6E /* PBXBuildRule */,
-			);
-			dependencies = (
-			);
-			name = IceAsyncClient;
-			productName = IceAsyncClient;
-			productReference = 1EA7D8DD444806C4FE809AC5 /* IceAsyncClient */;
-			productType = "com.apple.product-type.tool";
-		};
-		17295EE8D54F50AC8BC95360 /* Glacier2CallbackServer */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = A897D1D102B49B3A778BFBB0 /* Build configuration list for PBXNativeTarget "Glacier2CallbackServer" */;
-			buildPhases = (
-				D28962DA0F3BE31F9BCB0B8C /* Sources */,
-				6B2C2DE95A1A53D71D98848D /* Frameworks */,
-				950E937066F3A4D128951BC4 /* Swiftformat & Swiftlint */,
-			);
-			buildRules = (
-				9FCC1FCFC7A3D808D523097C /* PBXBuildRule */,
-			);
-			dependencies = (
-			);
-			name = Glacier2CallbackServer;
-			productName = Glacier2CallbackServer;
-			productReference = 6E24D220EF2E79E445C87850 /* Glacier2CallbackServer */;
-			productType = "com.apple.product-type.tool";
-		};
-		1CEA3A13E08931B50C514BD0 /* IceMinimalClient */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = BDA4474131B634CCA8361736 /* Build configuration list for PBXNativeTarget "IceMinimalClient" */;
-			buildPhases = (
-				E0C081321BCB9F1B77A85C62 /* Sources */,
-				9E42618273BBB52D00D567C5 /* Frameworks */,
-				28E5DE62DE1562551B40F76E /* Swiftformat & Swiftlint */,
-			);
-			buildRules = (
-				4585E5EB3CA7339430A627B7 /* PBXBuildRule */,
-			);
-			dependencies = (
-			);
-			name = IceMinimalClient;
-			productName = IceMinimalClient;
-			productReference = DCADEBA495EB820A0A7E41C6 /* IceMinimalClient */;
-			productType = "com.apple.product-type.tool";
-		};
-		1FD7893AE80DF5B104A80BA6 /* IceStormClockSubscriber */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 89453109B4357FEAED6111F0 /* Build configuration list for PBXNativeTarget "IceStormClockSubscriber" */;
-			buildPhases = (
-				9B623055C93DB8E2D5B404C0 /* Sources */,
-				FE38D59A6986742BEE5A52AE /* Frameworks */,
-				5748CE40F3793780000C1576 /* Swiftformat & Swiftlint */,
-			);
-			buildRules = (
-				421C8FEC21D23626888A39F8 /* PBXBuildRule */,
-			);
-			dependencies = (
-			);
-			name = IceStormClockSubscriber;
-			productName = IceStormClockSubscriber;
-			productReference = 6141C3CBC55BB9133DDD5F29 /* IceStormClockSubscriber */;
-			productType = "com.apple.product-type.tool";
-		};
-		2EC0D18A54E54780FF0CA0C0 /* Glacier2CallbackClient */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 590E6C63A4E703ED5C37C10A /* Build configuration list for PBXNativeTarget "Glacier2CallbackClient" */;
-			buildPhases = (
-				64B644B1FE867D3E4B51B029 /* Sources */,
-				18A17ADC4211385DCA27B8A8 /* Frameworks */,
-				F9FFC7590DF15BCC0F5FDF60 /* Swiftformat & Swiftlint */,
-			);
-			buildRules = (
-				7527A13F00BAC0CF95F59030 /* PBXBuildRule */,
-			);
-			dependencies = (
-			);
-			name = Glacier2CallbackClient;
-			productName = Glacier2CallbackClient;
-			productReference = FFB00730E6A7AA37BA85E0C4 /* Glacier2CallbackClient */;
-			productType = "com.apple.product-type.tool";
-		};
-		3455DFD133AC5C33DE41401D /* ManualSimpleFilesystemServer */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = DF912EF23FD5DB0EC4914DA9 /* Build configuration list for PBXNativeTarget "ManualSimpleFilesystemServer" */;
-			buildPhases = (
-				BBF810073B51EA212D1AC7D3 /* Sources */,
-				8766DFF51BDE5D995B070B4D /* Frameworks */,
-				374CB7719159FEA730B50AF5 /* Swiftformat & Swiftlint */,
-			);
-			buildRules = (
-				A218157A7BC216EBAE82D348 /* PBXBuildRule */,
-			);
-			dependencies = (
-			);
-			name = ManualSimpleFilesystemServer;
-			productName = ManualSimpleFilesystemServer;
-			productReference = F205564C9B6D912980932EAB /* ManualSimpleFilesystemServer */;
-			productType = "com.apple.product-type.tool";
-		};
-		3487D0246103973B15740CF3 /* IceInterceptorClient */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = B3AA58A85C88E200FEFF4969 /* Build configuration list for PBXNativeTarget "IceInterceptorClient" */;
-			buildPhases = (
-				31BA747D0E68368FA615A3ED /* Sources */,
-				988459F9028EAB05BF8E79BC /* Frameworks */,
-				E56B836B5EA5E841B5E21E20 /* Swiftformat & Swiftlint */,
-			);
-			buildRules = (
-				A228580E1A43A248CA4AA122 /* PBXBuildRule */,
-			);
-			dependencies = (
-			);
-			name = IceInterceptorClient;
-			productName = IceInterceptorClient;
-			productReference = 6509D4615F63497D8F3A1415 /* IceInterceptorClient */;
-			productType = "com.apple.product-type.tool";
-		};
-		365E2519E773257B91EA2017 /* ManualSimpleFilesystemClient */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 8B706BEF1426196ACF12C1D3 /* Build configuration list for PBXNativeTarget "ManualSimpleFilesystemClient" */;
-			buildPhases = (
-				E6B5183C96E544B2503BA43C /* Sources */,
-				84075BFCCA18CF6BDCF3D4A3 /* Frameworks */,
-				1CC1AC9B4859B18CBBE853F0 /* Swiftformat & Swiftlint */,
-			);
-			buildRules = (
-				4299ACAFB66C19199BCAB016 /* PBXBuildRule */,
-			);
-			dependencies = (
-			);
-			name = ManualSimpleFilesystemClient;
-			productName = ManualSimpleFilesystemClient;
-			productReference = 2210BCF19216BBCAD944F9D6 /* ManualSimpleFilesystemClient */;
-			productType = "com.apple.product-type.tool";
-		};
-		3D0479F643E6EBFDE4F41251 /* IceOptionalServer */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = BA49156F45F7453B13FEF8B2 /* Build configuration list for PBXNativeTarget "IceOptionalServer" */;
-			buildPhases = (
-				1783026E7056DE9278D3F0D2 /* Sources */,
-				7E43817DB68B4395B0A52EF2 /* Frameworks */,
-				CDD1F5F7A451B0A6675BE467 /* Swiftformat & Swiftlint */,
-			);
-			buildRules = (
-				3D3ADFD2AF40F1BAE040430B /* PBXBuildRule */,
+				C05844AFC4473A58B91C8D3E /* PBXBuildRule */,
 			);
 			dependencies = (
 			);
 			name = IceOptionalServer;
 			productName = IceOptionalServer;
-			productReference = AEE29AA3114D5818B8752800 /* IceOptionalServer */;
+			productReference = 2B44897C564CE6DB603CB4D2 /* IceOptionalServer */;
 			productType = "com.apple.product-type.tool";
 		};
-		445F4A8EEC5CA2028C536DAE /* IceInvokeClient */ = {
+		07CAFE2F01A2B040FC16287C /* IceThroughputServer */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = C21C29AEAAFF06961BADDE24 /* Build configuration list for PBXNativeTarget "IceInvokeClient" */;
+			buildConfigurationList = 47F871B84A7762A6EA86CC51 /* Build configuration list for PBXNativeTarget "IceThroughputServer" */;
 			buildPhases = (
-				B7C5AF90DE4BA4CE3A355D76 /* Sources */,
-				028E531E3400B2F3C917CC02 /* Frameworks */,
-				C0F0295DA696DEC1F8456128 /* Swiftformat & Swiftlint */,
+				38024EC4C56B675635E221A3 /* Sources */,
+				4C987971BFEDA46E21FAE6EC /* Frameworks */,
+				DDAB4463ABF1902EF133000F /* Swiftformat & Swiftlint */,
 			);
 			buildRules = (
-				E27F3AD87BAAA937B31B3F71 /* PBXBuildRule */,
-			);
-			dependencies = (
-			);
-			name = IceInvokeClient;
-			productName = IceInvokeClient;
-			productReference = 55BD51CDE4F248ED184B9C03 /* IceInvokeClient */;
-			productType = "com.apple.product-type.tool";
-		};
-		4E426E1AF0E71376C9E873BB /* IceBidirClient */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = B0F9CF3EF9219C6642864998 /* Build configuration list for PBXNativeTarget "IceBidirClient" */;
-			buildPhases = (
-				CA16CC530E3D90E1BB5B33DD /* Sources */,
-				C069EF91B873D9C7AC470106 /* Frameworks */,
-				B607C54DD8F412A61E5576B3 /* Swiftformat & Swiftlint */,
-			);
-			buildRules = (
-				0E06F531F9FFA91015B0E888 /* PBXBuildRule */,
-			);
-			dependencies = (
-			);
-			name = IceBidirClient;
-			productName = IceBidirClient;
-			productReference = 2C3DB1C65D1B9ED24051DE99 /* IceBidirClient */;
-			productType = "com.apple.product-type.tool";
-		};
-		50C7DC4E4B424490F7F59AE9 /* ManualPrinterServer */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = B1F51375608717E2A57E1DCC /* Build configuration list for PBXNativeTarget "ManualPrinterServer" */;
-			buildPhases = (
-				6753F6B6F20DF4EE26AAF02B /* Sources */,
-				9A6357593A3AEFCA1DEE6684 /* Frameworks */,
-				B69D8AF9A5F77C6AE4A84128 /* Swiftformat & Swiftlint */,
-			);
-			buildRules = (
-				C4F3C5561F9031CA3D26999E /* PBXBuildRule */,
-			);
-			dependencies = (
-			);
-			name = ManualPrinterServer;
-			productName = ManualPrinterServer;
-			productReference = 8B8E083932784B369B4A3549 /* ManualPrinterServer */;
-			productType = "com.apple.product-type.tool";
-		};
-		58E3C656CAC60E5D4435A63A /* IceInterceptorServer */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 65E607EB4C0068D271C83421 /* Build configuration list for PBXNativeTarget "IceInterceptorServer" */;
-			buildPhases = (
-				CF89B487D0F59617290EFB1B /* Sources */,
-				92C0BD46F83219C4F1998D64 /* Frameworks */,
-				83BC64B247558709EC02A82F /* Swiftformat & Swiftlint */,
-			);
-			buildRules = (
-				7D8737FD3499AE4DACC5B7F5 /* PBXBuildRule */,
-			);
-			dependencies = (
-			);
-			name = IceInterceptorServer;
-			productName = IceInterceptorServer;
-			productReference = 9CB0C08B0D54EB988D212533 /* IceInterceptorServer */;
-			productType = "com.apple.product-type.tool";
-		};
-		5B5E6A9FEB4E4E67A418460C /* IceBidirServer */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = DFC770DA6333AD2B412DA911 /* Build configuration list for PBXNativeTarget "IceBidirServer" */;
-			buildPhases = (
-				B661DB9A2C6DD169758116CB /* Sources */,
-				E3BECC8FAFF49D1E4A1E29AE /* Frameworks */,
-				E394CCE7479FF09D72E83251 /* Swiftformat & Swiftlint */,
-			);
-			buildRules = (
-				8EF4AD55275B1DBDF9B9A43E /* PBXBuildRule */,
-			);
-			dependencies = (
-			);
-			name = IceBidirServer;
-			productName = IceBidirServer;
-			productReference = 2A4CA42CA6ED3C00EE5DC00C /* IceBidirServer */;
-			productType = "com.apple.product-type.tool";
-		};
-		5C6AA42A0C3A9B8309B6C879 /* IceDiscoveryReplicationServer */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 74AB20302D0B6A8E7301684A /* Build configuration list for PBXNativeTarget "IceDiscoveryReplicationServer" */;
-			buildPhases = (
-				A3918551C47C9B3EA0AFE69A /* Sources */,
-				AB32C528E23C3183905B24B2 /* Frameworks */,
-				C0325B458C9B0AA13E83855F /* Swiftformat & Swiftlint */,
-			);
-			buildRules = (
-				32983ED06FB64B16AC6747A5 /* PBXBuildRule */,
-			);
-			dependencies = (
-			);
-			name = IceDiscoveryReplicationServer;
-			productName = IceDiscoveryReplicationServer;
-			productReference = 017A6BF2C245B1938F34C6C8 /* IceDiscoveryReplicationServer */;
-			productType = "com.apple.product-type.tool";
-		};
-		5DEB7AA4511B4B1F1983ECA8 /* IceStormClockPublisher */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 1662F20592C3CA8BB8F3C72C /* Build configuration list for PBXNativeTarget "IceStormClockPublisher" */;
-			buildPhases = (
-				DECDEB8818E0946DA78818FF /* Sources */,
-				B8200B378B8ADF17DA105669 /* Frameworks */,
-				B154F41F9A2C2FD5A439DD17 /* Swiftformat & Swiftlint */,
-			);
-			buildRules = (
-				1FD0F9896E0C0A8E941A61BE /* PBXBuildRule */,
-			);
-			dependencies = (
-			);
-			name = IceStormClockPublisher;
-			productName = IceStormClockPublisher;
-			productReference = 39C8A1A7AB5FD2BC8E5D7419 /* IceStormClockPublisher */;
-			productType = "com.apple.product-type.tool";
-		};
-		7B111AE4525C41AA7E021233 /* IceOptionalClient */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = FE60CFBC42EDE94D5CD1436E /* Build configuration list for PBXNativeTarget "IceOptionalClient" */;
-			buildPhases = (
-				508142D70C3213D1D85C15BD /* Sources */,
-				DEBA9DF4AC7AA6B5FD9483ED /* Frameworks */,
-				852D21BE96ABE71CEDA9CCA2 /* Swiftformat & Swiftlint */,
-			);
-			buildRules = (
-				9B76F1C4D8A7A0F002D98D9F /* PBXBuildRule */,
-			);
-			dependencies = (
-			);
-			name = IceOptionalClient;
-			productName = IceOptionalClient;
-			productReference = 81B6BBD37B3FB2976F76A36D /* IceOptionalClient */;
-			productType = "com.apple.product-type.tool";
-		};
-		7E534192D654D74C4E38373F /* IOSHello */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 4D65493F20B4E0CDDA5F32DB /* Build configuration list for PBXNativeTarget "IOSHello" */;
-			buildPhases = (
-				67A6BC00D02B5C71A86096A2 /* Sources */,
-				D864A72C149FC66C0AFF4A8D /* Frameworks */,
-				17F9B4EF18B4BE1BBD9EAC38 /* Resources */,
-				6FF2F8EACE9BCA4B7C32640F /* Embed Frameworks */,
-				5F6B2788432347BA99F280F5 /* Swiftformat & Swiftlint */,
-			);
-			buildRules = (
-				3719C432F43D3FAEF5A07132 /* PBXBuildRule */,
-			);
-			dependencies = (
-			);
-			name = IOSHello;
-			productName = IOSHello;
-			productReference = 3963729A3421FF714DB83E79 /* IOSHello.app */;
-			productType = "com.apple.product-type.application";
-		};
-		7F125170B599E70103C6F1A4 /* ManualPrinterClient */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = C2179CA3066C87E3F3A33C7C /* Build configuration list for PBXNativeTarget "ManualPrinterClient" */;
-			buildPhases = (
-				E708D1D0FBF7F4CB157BBB3D /* Sources */,
-				6993D62FAAABC62A39AD626B /* Frameworks */,
-				F9D8F88D81EE76435F04F581 /* Swiftformat & Swiftlint */,
-			);
-			buildRules = (
-				851736E0B6157559A3C74F87 /* PBXBuildRule */,
-			);
-			dependencies = (
-			);
-			name = ManualPrinterClient;
-			productName = ManualPrinterClient;
-			productReference = 981FAA0E0B3E4FB23D50B8BA /* ManualPrinterClient */;
-			productType = "com.apple.product-type.tool";
-		};
-		838136AD0308E0D7D7EC2582 /* IceAsyncServer */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = BCAFBBAD835A85E28CC4D76F /* Build configuration list for PBXNativeTarget "IceAsyncServer" */;
-			buildPhases = (
-				6472542E4B5C6120841D698F /* Sources */,
-				C0F5AD19F00FA5F378C72244 /* Frameworks */,
-				A641ACDB2E5579B28A23DDA9 /* Swiftformat & Swiftlint */,
-			);
-			buildRules = (
-				A9B74F9AFB4557E7DBD6800B /* PBXBuildRule */,
-			);
-			dependencies = (
-			);
-			name = IceAsyncServer;
-			productName = IceAsyncServer;
-			productReference = 75A364B7B36A2F27E0C7B5EE /* IceAsyncServer */;
-			productType = "com.apple.product-type.tool";
-		};
-		86A3F4B19E9DAF9E4B15533A /* IceGridSimpleClient */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = D4562A2DDDA2791556A09F92 /* Build configuration list for PBXNativeTarget "IceGridSimpleClient" */;
-			buildPhases = (
-				0F4D55D8494421FCBD27FEFC /* Sources */,
-				EB810A40B01B281E2C3292F5 /* Frameworks */,
-				46278A7426E3C6C00798FD2C /* Swiftformat & Swiftlint */,
-			);
-			buildRules = (
-				1CFE4A43AA960CF8FD6431C2 /* PBXBuildRule */,
-			);
-			dependencies = (
-			);
-			name = IceGridSimpleClient;
-			productName = IceGridSimpleClient;
-			productReference = 4E1ACB62C85FF06D49A7E781 /* IceGridSimpleClient */;
-			productType = "com.apple.product-type.tool";
-		};
-		9B342C4AF32DBB323A3A0BBA /* IceDiscoveryReplicationClient */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = AB712B67CDEF04D274EC6D69 /* Build configuration list for PBXNativeTarget "IceDiscoveryReplicationClient" */;
-			buildPhases = (
-				5443A1B9A0D7C2977AA65469 /* Sources */,
-				DFC1DD0FDC99D70F55FEC6CC /* Frameworks */,
-				304532B794370B25F4479D83 /* Swiftformat & Swiftlint */,
-			);
-			buildRules = (
-				E8FB65305DCE581EBA6AF18C /* PBXBuildRule */,
-			);
-			dependencies = (
-			);
-			name = IceDiscoveryReplicationClient;
-			productName = IceDiscoveryReplicationClient;
-			productReference = E9F1D7FC36EFF1498901294C /* IceDiscoveryReplicationClient */;
-			productType = "com.apple.product-type.tool";
-		};
-		A02EBE57139105D20DA043C0 /* IceMinimalServer */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = F2B5D81BEA80B456322045A6 /* Build configuration list for PBXNativeTarget "IceMinimalServer" */;
-			buildPhases = (
-				3F9AFDCD7C19B31A0CE13271 /* Sources */,
-				FA2E26807D2DABEDA0730144 /* Frameworks */,
-				240A9E84510E242EED9E296D /* Swiftformat & Swiftlint */,
-			);
-			buildRules = (
-				B402161F82F03A5286729412 /* PBXBuildRule */,
-			);
-			dependencies = (
-			);
-			name = IceMinimalServer;
-			productName = IceMinimalServer;
-			productReference = F96051CE81CCCA810E36B833 /* IceMinimalServer */;
-			productType = "com.apple.product-type.tool";
-		};
-		A16D90A9F6AFEC8E5F36B277 /* IceContextServer */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 7CA397F4251ECCE98C893188 /* Build configuration list for PBXNativeTarget "IceContextServer" */;
-			buildPhases = (
-				59BFD03CE1E9E83B753FF788 /* Sources */,
-				FE58A64A8F63238E79FFFBB9 /* Frameworks */,
-				32B27A33621C560AEEED89A5 /* Swiftformat & Swiftlint */,
-			);
-			buildRules = (
-				CF57CC737724508D9B3D9334 /* PBXBuildRule */,
-			);
-			dependencies = (
-			);
-			name = IceContextServer;
-			productName = IceContextServer;
-			productReference = 87326C9631EA22318B8FA8B7 /* IceContextServer */;
-			productType = "com.apple.product-type.tool";
-		};
-		A61365A18C78646CBE55C376 /* IOSLibrary */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 255A8B3231CC13B6A7B034EE /* Build configuration list for PBXNativeTarget "IOSLibrary" */;
-			buildPhases = (
-				B112D34B537C9F98D9D8200E /* Sources */,
-				B7A3A8B52699104A64F5ECF3 /* Frameworks */,
-				95F64D70096EA8F19F011F64 /* Resources */,
-				E3FC160E08F566B7F7190721 /* Embed Frameworks */,
-				E3A640C872EE801513DB944B /* Swiftformat & Swiftlint */,
-			);
-			buildRules = (
-				E42832E72A8082C162926B43 /* PBXBuildRule */,
-			);
-			dependencies = (
-			);
-			name = IOSLibrary;
-			productName = IOSLibrary;
-			productReference = 8B51D44CE59C7B800960E3A3 /* IOSLibrary.app */;
-			productType = "com.apple.product-type.application";
-		};
-		A6F15048BA62D0740B115770 /* IOSChat */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = D4ABA528D89F3F2B4AC8A13E /* Build configuration list for PBXNativeTarget "IOSChat" */;
-			buildPhases = (
-				B4FA90133DE94D6CB2818AB0 /* Sources */,
-				CEBA2B15FACD5AA5A5DDC87A /* Frameworks */,
-				18667D3BD9A46A189545E47C /* Resources */,
-				FEE07ED1090D596DED44996E /* Embed Frameworks */,
-				F9E781170CCEFE9152BF9D0E /* Swiftformat & Swiftlint */,
-			);
-			buildRules = (
-				406F45E9E963EED4233296A3 /* PBXBuildRule */,
-			);
-			dependencies = (
-			);
-			name = IOSChat;
-			productName = IOSChat;
-			productReference = 795BDD345A8758BE1BCE1037 /* chat.app */;
-			productType = "com.apple.product-type.application";
-		};
-		A8AC5929B89E3A59CD81EB3D /* IceDiscoveryHelloServer */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 90913A7AF8AD359EDA1E26F9 /* Build configuration list for PBXNativeTarget "IceDiscoveryHelloServer" */;
-			buildPhases = (
-				B2B8BAABF7D0A25B4F2AC6FA /* Sources */,
-				1B633AC450F9E68776B8BF68 /* Frameworks */,
-				CBB702D75E17ECF45917C8DD /* Swiftformat & Swiftlint */,
-			);
-			buildRules = (
-				C24C58A904C5A31E6267936A /* PBXBuildRule */,
-			);
-			dependencies = (
-			);
-			name = IceDiscoveryHelloServer;
-			productName = IceDiscoveryHelloServer;
-			productReference = F901F95276B12496C039F7A0 /* IceDiscoveryHelloServer */;
-			productType = "com.apple.product-type.tool";
-		};
-		ACB5ECC440F9694952C7B84C /* IceLatencyServer */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 4D28FADA985218DEBED6EDB4 /* Build configuration list for PBXNativeTarget "IceLatencyServer" */;
-			buildPhases = (
-				7577CED21E25CFCDE3358E32 /* Sources */,
-				AFBFFB7CEF9E5418E74FA5B3 /* Frameworks */,
-				C1663C2F6CBF5BE10BABB96E /* Swiftformat & Swiftlint */,
-			);
-			buildRules = (
-				819889159CBDC04DFA75199F /* PBXBuildRule */,
-			);
-			dependencies = (
-			);
-			name = IceLatencyServer;
-			productName = IceLatencyServer;
-			productReference = 3A68D8EB52D1135866BCA2C2 /* IceLatencyServer */;
-			productType = "com.apple.product-type.tool";
-		};
-		BC411A1038EBE1215648035D /* IceAsyncInvocationClient */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 2C979B40A9B83E8D3D20C5B8 /* Build configuration list for PBXNativeTarget "IceAsyncInvocationClient" */;
-			buildPhases = (
-				7B49BB8710DBCF9B1D70593D /* Sources */,
-				5CBB0D50C42CC4430DA1B376 /* Frameworks */,
-				97DF1DF68F195AC853982299 /* Swiftformat & Swiftlint */,
-			);
-			buildRules = (
-				7E193C93AA1D3754DA045CF7 /* PBXBuildRule */,
-			);
-			dependencies = (
-			);
-			name = IceAsyncInvocationClient;
-			productName = IceAsyncInvocationClient;
-			productReference = B3914CEEB182107F446A7D22 /* IceAsyncInvocationClient */;
-			productType = "com.apple.product-type.tool";
-		};
-		C55F08EC4140C753CCD40E6B /* IceContextClient */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = C8567BB5E0ED1B46910BBCBB /* Build configuration list for PBXNativeTarget "IceContextClient" */;
-			buildPhases = (
-				FA5F1D0A1D02DA68D0C4B363 /* Sources */,
-				6ECC3541AAB0015190653377 /* Frameworks */,
-				2758A849B9DF19D5D4986531 /* Swiftformat & Swiftlint */,
-			);
-			buildRules = (
-				C3C9DF19F1223F72D2085A2C /* PBXBuildRule */,
-			);
-			dependencies = (
-			);
-			name = IceContextClient;
-			productName = IceContextClient;
-			productReference = F7449754D30A52F680857B55 /* IceContextClient */;
-			productType = "com.apple.product-type.tool";
-		};
-		CBE5A662859EB3A829D935EB /* IceThroughputClient */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = CE9B58718C321CE74DEE8C13 /* Build configuration list for PBXNativeTarget "IceThroughputClient" */;
-			buildPhases = (
-				9644172CD096511C0A9EBADB /* Sources */,
-				672E70B5A65F3C73844D030B /* Frameworks */,
-				5F4B50AFF623D55D5222860D /* Swiftformat & Swiftlint */,
-			);
-			buildRules = (
-				B36FFF764B7EF2F513C9AD7B /* PBXBuildRule */,
-			);
-			dependencies = (
-			);
-			name = IceThroughputClient;
-			productName = IceThroughputClient;
-			productReference = F78B443277F9161110BF4872 /* IceThroughputClient */;
-			productType = "com.apple.product-type.tool";
-		};
-		D8B2F755F5313CF3ED40667F /* IceThroughputServer */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 6273F343B340BC2B3077B30B /* Build configuration list for PBXNativeTarget "IceThroughputServer" */;
-			buildPhases = (
-				A55316A3F68FF56A8215BC00 /* Sources */,
-				587235E857AFDA82D765713E /* Frameworks */,
-				E7801F619963B46D569508AE /* Swiftformat & Swiftlint */,
-			);
-			buildRules = (
-				66A4E283D5F13032BD2C9B9B /* PBXBuildRule */,
+				27ADB387DD96190E8368149F /* PBXBuildRule */,
 			);
 			dependencies = (
 			);
 			name = IceThroughputServer;
 			productName = IceThroughputServer;
-			productReference = DB6321B16A4E43CD89148041 /* IceThroughputServer */;
+			productReference = F0212F8CFBEB9A40C179AFB6 /* IceThroughputServer */;
 			productType = "com.apple.product-type.tool";
 		};
-		E3DF7A1C971AE032647A29C2 /* IceAsyncInvocationServer */ = {
+		0AE8C7670A42B03A39CDA3C5 /* IceDiscoveryHelloClient */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 80CCF7745F9FAA4E18C1C935 /* Build configuration list for PBXNativeTarget "IceAsyncInvocationServer" */;
+			buildConfigurationList = BE551E77DF2CF4D43219C651 /* Build configuration list for PBXNativeTarget "IceDiscoveryHelloClient" */;
 			buildPhases = (
-				A06425E3FEE942A5CBC3972B /* Sources */,
-				46FAEFD16A7778DC672ECBD7 /* Frameworks */,
-				8F54E8B685C26F0B9D303753 /* Swiftformat & Swiftlint */,
+				063AEB6ACDFA2EFB31AB3A33 /* Sources */,
+				FE63442516858C477D11C096 /* Frameworks */,
+				38A134A7CC14D2A83C5D2464 /* Swiftformat & Swiftlint */,
 			);
 			buildRules = (
-				F6321A69FAB896D576AC1E10 /* PBXBuildRule */,
+				857B547C99E563D5F0561D21 /* PBXBuildRule */,
 			);
 			dependencies = (
 			);
-			name = IceAsyncInvocationServer;
-			productName = IceAsyncInvocationServer;
-			productReference = 04E169866A28CE4C09EC830C /* IceAsyncInvocationServer */;
+			name = IceDiscoveryHelloClient;
+			productName = IceDiscoveryHelloClient;
+			productReference = 928B5D6019ED78F2F5C21AF1 /* IceDiscoveryHelloClient */;
 			productType = "com.apple.product-type.tool";
 		};
-		E542D48F2448F7F27D80BDD0 /* IceGridSimpleServer */ = {
+		0BF52782AF7FCCEF27A337AE /* Chat */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 827FC53EE32182A7861FA861 /* Build configuration list for PBXNativeTarget "IceGridSimpleServer" */;
+			buildConfigurationList = 320E9D3263C4EF994BF0ACB0 /* Build configuration list for PBXNativeTarget "Chat" */;
 			buildPhases = (
-				523AA0DDF82C04ABF82DF7FE /* Sources */,
-				58854DE82C14246A52AB6BAA /* Frameworks */,
-				845C014E0511D853B5D26BDE /* Swiftformat & Swiftlint */,
+				F2397CD6E1716C3AF63143F9 /* Sources */,
+				5DD67869AB68732C013CC099 /* Frameworks */,
+				FBFF38BF51A1B617CCDA77EB /* Resources */,
+				FB748DFB58D56E164F2AB72F /* Embed Frameworks */,
+				D285BAAF4351941FEA9ECC9F /* Swiftformat & Swiftlint */,
 			);
 			buildRules = (
-				8C00F1B419F603FE73EE85A3 /* PBXBuildRule */,
+				8373C509512D2258C99A88DF /* PBXBuildRule */,
 			);
 			dependencies = (
 			);
-			name = IceGridSimpleServer;
-			productName = IceGridSimpleServer;
-			productReference = 60650B913C1E84C7982E4061 /* IceGridSimpleServer */;
-			productType = "com.apple.product-type.tool";
+			name = Chat;
+			productName = Chat;
+			productReference = 032AD4164F9268ACF34475BD /* Chat.app */;
+			productType = "com.apple.product-type.application";
 		};
-		E7FF091AC675DE1B5A97F3BB /* IceHelloClient */ = {
+		0EDB6F8830769A463C145F4E /* ManualSimpleFilesystemClient */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = DFDCFA4F1609E1A9A7FD5907 /* Build configuration list for PBXNativeTarget "IceHelloClient" */;
+			buildConfigurationList = 3DD9F5EEAE7F71DFC0B81DCE /* Build configuration list for PBXNativeTarget "ManualSimpleFilesystemClient" */;
 			buildPhases = (
-				3A9A4B032E66852D2F81E772 /* Sources */,
-				8923261175E3BC6ACE1C3E04 /* Frameworks */,
-				B23B3C1FB6FF5D661B3C6BA5 /* Swiftformat & Swiftlint */,
+				FE813AE76FF06FA4229330DE /* Sources */,
+				FD5EFAC17784950497EA651A /* Frameworks */,
+				6266996BD7A76F7F5EB46FC5 /* Swiftformat & Swiftlint */,
 			);
 			buildRules = (
-				B634FC0262466B3FAD8D65EC /* PBXBuildRule */,
+				B73312EDBC1AF0035D53A4CF /* PBXBuildRule */,
 			);
 			dependencies = (
 			);
-			name = IceHelloClient;
-			productName = IceHelloClient;
-			productReference = D2285D300CF1AFBB54CFC603 /* IceHelloClient */;
+			name = ManualSimpleFilesystemClient;
+			productName = ManualSimpleFilesystemClient;
+			productReference = E258705B5737C00AD85256EB /* ManualSimpleFilesystemClient */;
 			productType = "com.apple.product-type.tool";
 		};
-		F278530FC73733F84C3B351A /* IceLatencyClient */ = {
+		0F333E1C9E6C91C3396F59A2 /* IceDiscoveryHelloServer */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 1477EF932D609567F15FD17D /* Build configuration list for PBXNativeTarget "IceLatencyClient" */;
+			buildConfigurationList = 169F1F3007DC0FA109F32D73 /* Build configuration list for PBXNativeTarget "IceDiscoveryHelloServer" */;
 			buildPhases = (
-				C97EE7DFEA138DE5CB32D73E /* Sources */,
-				5EC6FE67D919482B235AE433 /* Frameworks */,
-				CE5684F5FF89AFF9172759C9 /* Swiftformat & Swiftlint */,
+				A49C138998A46E8E183B57D9 /* Sources */,
+				7DD1E48D92B7539426A2F840 /* Frameworks */,
+				1685E94ADB605C5E0CF2FB4B /* Swiftformat & Swiftlint */,
 			);
 			buildRules = (
-				6F1821E03518B1E82C60F750 /* PBXBuildRule */,
+				88780369B9F230397EF5C066 /* PBXBuildRule */,
+			);
+			dependencies = (
+			);
+			name = IceDiscoveryHelloServer;
+			productName = IceDiscoveryHelloServer;
+			productReference = 88D1A664E0612A8EB462EEFF /* IceDiscoveryHelloServer */;
+			productType = "com.apple.product-type.tool";
+		};
+		10114A97EDF918D7074BC9E8 /* IceBidirClient */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 9A272BA413D4B1A341628D43 /* Build configuration list for PBXNativeTarget "IceBidirClient" */;
+			buildPhases = (
+				7D04FC5C8B953CDA1C78601A /* Sources */,
+				2ADA13682337CC6F4D3D9E7A /* Frameworks */,
+				DC93217B66C09033F9FDACE9 /* Swiftformat & Swiftlint */,
+			);
+			buildRules = (
+				6683676801DC5340F7461EB3 /* PBXBuildRule */,
+			);
+			dependencies = (
+			);
+			name = IceBidirClient;
+			productName = IceBidirClient;
+			productReference = 96ABBE35B930709AB901DF84 /* IceBidirClient */;
+			productType = "com.apple.product-type.tool";
+		};
+		1D324440A0F5469DC7B3CE68 /* IceLatencyServer */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = AC0916E07C12D8419E3DF06A /* Build configuration list for PBXNativeTarget "IceLatencyServer" */;
+			buildPhases = (
+				BEC58BA0163CD9AEC40DA224 /* Sources */,
+				CB01B0CA42714E93F88DF61A /* Frameworks */,
+				186181244A994F16E495080F /* Swiftformat & Swiftlint */,
+			);
+			buildRules = (
+				ADBC0D864075F574B4CEE6CE /* PBXBuildRule */,
+			);
+			dependencies = (
+			);
+			name = IceLatencyServer;
+			productName = IceLatencyServer;
+			productReference = 4E3444B8FDCFF52FD16A86EC /* IceLatencyServer */;
+			productType = "com.apple.product-type.tool";
+		};
+		1E2F71AC52A0BDDD354133D0 /* IceDiscoveryReplicationClient */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 0C9A64174C9644B5ED2C41F4 /* Build configuration list for PBXNativeTarget "IceDiscoveryReplicationClient" */;
+			buildPhases = (
+				3A84249CAFBC691ACD3E2124 /* Sources */,
+				71EB134F619E0FCD9E1A986E /* Frameworks */,
+				09FF58AF88522B2053DC19CC /* Swiftformat & Swiftlint */,
+			);
+			buildRules = (
+				6969C041D92817702DDD3E05 /* PBXBuildRule */,
+			);
+			dependencies = (
+			);
+			name = IceDiscoveryReplicationClient;
+			productName = IceDiscoveryReplicationClient;
+			productReference = 38240148B810D042548804D4 /* IceDiscoveryReplicationClient */;
+			productType = "com.apple.product-type.tool";
+		};
+		21FA6A38274DBCD88814D274 /* ManualPrinterServer */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 98069F0465634A2B7DF722C2 /* Build configuration list for PBXNativeTarget "ManualPrinterServer" */;
+			buildPhases = (
+				7885C3ED5CBE41E64145B22F /* Sources */,
+				A852B2B2CD3B0FCAFE64465B /* Frameworks */,
+				0B27BA635A1FDB0EBE1ABC88 /* Swiftformat & Swiftlint */,
+			);
+			buildRules = (
+				6E8BEFB904F45A399EF18CFF /* PBXBuildRule */,
+			);
+			dependencies = (
+			);
+			name = ManualPrinterServer;
+			productName = ManualPrinterServer;
+			productReference = 174732B643FAE8038ADD39CC /* ManualPrinterServer */;
+			productType = "com.apple.product-type.tool";
+		};
+		2B975A6278F9D6CCE53F5E35 /* IceLatencyClient */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 8150E043A0B68EAFEFE3E267 /* Build configuration list for PBXNativeTarget "IceLatencyClient" */;
+			buildPhases = (
+				3F25FCD0489CF56EA0F6D01D /* Sources */,
+				C7DA5DC872F7A4DE9DA87814 /* Frameworks */,
+				FD8390D3E5FD21AD72A652BE /* Swiftformat & Swiftlint */,
+			);
+			buildRules = (
+				EC17EBB10AE82FBBAC91CDA8 /* PBXBuildRule */,
 			);
 			dependencies = (
 			);
 			name = IceLatencyClient;
 			productName = IceLatencyClient;
-			productReference = 5A69CA4F896CFA76B7F4FC54 /* IceLatencyClient */;
+			productReference = 53175EBECFD91BDAEA5E7A79 /* IceLatencyClient */;
 			productType = "com.apple.product-type.tool";
 		};
-		FB515029F564EEC25346D66A /* IceHelloServer */ = {
+		2EE15C61DC2F49143CC9488C /* IceDiscoveryReplicationServer */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = C8C00A4981A8A430185FB865 /* Build configuration list for PBXNativeTarget "IceHelloServer" */;
+			buildConfigurationList = 276B44590FB6644D55603174 /* Build configuration list for PBXNativeTarget "IceDiscoveryReplicationServer" */;
 			buildPhases = (
-				C1EEC7E0AA00B36401390753 /* Sources */,
-				354BFA2742D9590231FD7274 /* Frameworks */,
-				1A65F5B4FE36E90BC8B58E9E /* Swiftformat & Swiftlint */,
+				0B4751B0AF14F0958D7F1ED5 /* Sources */,
+				ECB324C60A51C6EF4379F191 /* Frameworks */,
+				F11DA04FC27ED8BEF12AD50B /* Swiftformat & Swiftlint */,
 			);
 			buildRules = (
-				4CDFB47EF0E9A0B3CA8C9B0E /* PBXBuildRule */,
+				87469216BECB3530AAE040D1 /* PBXBuildRule */,
+			);
+			dependencies = (
+			);
+			name = IceDiscoveryReplicationServer;
+			productName = IceDiscoveryReplicationServer;
+			productReference = 71A1E04348A91014C963D31C /* IceDiscoveryReplicationServer */;
+			productType = "com.apple.product-type.tool";
+		};
+		4159934A7B7D66A462AA96E3 /* IceHelloServer */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 1A1F296C9C2DFAFC8E9EE849 /* Build configuration list for PBXNativeTarget "IceHelloServer" */;
+			buildPhases = (
+				C2AFF7E114034DD15D760C56 /* Sources */,
+				98EB7DB26C64223B82A36CBE /* Frameworks */,
+				111166342EE7EAABAE5EF788 /* Swiftformat & Swiftlint */,
+			);
+			buildRules = (
+				D2C1B0C447C447F9EB9CC359 /* PBXBuildRule */,
 			);
 			dependencies = (
 			);
 			name = IceHelloServer;
 			productName = IceHelloServer;
-			productReference = 22C91647BDCDB9779AB19CA3 /* IceHelloServer */;
+			productReference = E225702D9CBBE0EBF3987CC9 /* IceHelloServer */;
+			productType = "com.apple.product-type.tool";
+		};
+		42561EDFCCB220DEAFE26FA5 /* IceStormClockSubscriber */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = D8A689E605A9CF40A85A02D8 /* Build configuration list for PBXNativeTarget "IceStormClockSubscriber" */;
+			buildPhases = (
+				14A1C3BECB9C312B9A243012 /* Sources */,
+				A6D8646B6A47E700131C4274 /* Frameworks */,
+				BA06224E831CFEFE310F6236 /* Swiftformat & Swiftlint */,
+			);
+			buildRules = (
+				FF1144A4A89CEB15B5C2327D /* PBXBuildRule */,
+			);
+			dependencies = (
+			);
+			name = IceStormClockSubscriber;
+			productName = IceStormClockSubscriber;
+			productReference = 74967D9EDD67C16FEC6DC608 /* IceStormClockSubscriber */;
+			productType = "com.apple.product-type.tool";
+		};
+		456CC1D6828C3983EF2241D5 /* IceThroughputClient */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = C1A2DEDB7D0701CA1A7808C8 /* Build configuration list for PBXNativeTarget "IceThroughputClient" */;
+			buildPhases = (
+				7701E494882A290A6A90495F /* Sources */,
+				F0334E33710D51608F52736C /* Frameworks */,
+				A0E6E8A09C955328C69D7376 /* Swiftformat & Swiftlint */,
+			);
+			buildRules = (
+				928486546746E8F5486B4AF3 /* PBXBuildRule */,
+			);
+			dependencies = (
+			);
+			name = IceThroughputClient;
+			productName = IceThroughputClient;
+			productReference = 97DA3C7B652B58F96E995626 /* IceThroughputClient */;
+			productType = "com.apple.product-type.tool";
+		};
+		5DA2E0F891AB6C1C5B232CE4 /* IceDiscoveryHelloUI */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 1E5B2E9429A78A1F2F7FE1C4 /* Build configuration list for PBXNativeTarget "IceDiscoveryHelloUI" */;
+			buildPhases = (
+				48A8ED0A4B002EE5F63377AC /* Sources */,
+				8681C7C656D4E60B49431794 /* Frameworks */,
+				3B978A20C34FE60E5CE2C00D /* Resources */,
+				085495C825A1B54FDC3C60EA /* Embed Frameworks */,
+				BE4AEF385A16C089B6563E63 /* Swiftformat & Swiftlint */,
+			);
+			buildRules = (
+				DFBF4F5E260F24C2A49DB36C /* PBXBuildRule */,
+			);
+			dependencies = (
+			);
+			name = IceDiscoveryHelloUI;
+			productName = IceDiscoveryHelloUI;
+			productReference = C37231FAC4BEBEA690B45FB3 /* IceDiscoveryHelloUI.app */;
+			productType = "com.apple.product-type.application";
+		};
+		60AFAA9D313FD61836B69D3F /* IceAsyncInvocationServer */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = C59D28140D012AE46D0F7987 /* Build configuration list for PBXNativeTarget "IceAsyncInvocationServer" */;
+			buildPhases = (
+				BBFB30DA0A83A63910B9308E /* Sources */,
+				C5A0165AF3E2EC43C4FA4756 /* Frameworks */,
+				D28E5EE0F12247F549B480C1 /* Swiftformat & Swiftlint */,
+			);
+			buildRules = (
+				1B49080C136F32951D92F4ED /* PBXBuildRule */,
+			);
+			dependencies = (
+			);
+			name = IceAsyncInvocationServer;
+			productName = IceAsyncInvocationServer;
+			productReference = 6C18C4EA4CAFFE876F2B9C5A /* IceAsyncInvocationServer */;
+			productType = "com.apple.product-type.tool";
+		};
+		62CD0C57C3183B4C1ACFB7E7 /* Glacier2CallbackServer */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 5DAA1FD741044347B763D93F /* Build configuration list for PBXNativeTarget "Glacier2CallbackServer" */;
+			buildPhases = (
+				208ADC79C0274D38BA5145E1 /* Sources */,
+				19D46149B24C894A00AFCDCF /* Frameworks */,
+				C80A8B0308A3E7B730045131 /* Swiftformat & Swiftlint */,
+			);
+			buildRules = (
+				EB1D4B8EDAE3BF2E17F810ED /* PBXBuildRule */,
+			);
+			dependencies = (
+			);
+			name = Glacier2CallbackServer;
+			productName = Glacier2CallbackServer;
+			productReference = 20A57F673289621EAE237CA6 /* Glacier2CallbackServer */;
+			productType = "com.apple.product-type.tool";
+		};
+		68AAF193626BC30C4CD8884F /* IceAsyncServer */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 4C756B9FDEB5F9DDFEE191A2 /* Build configuration list for PBXNativeTarget "IceAsyncServer" */;
+			buildPhases = (
+				F0AE8FB038522A98FD1C8A52 /* Sources */,
+				BBA2005753A8E7D80427F943 /* Frameworks */,
+				DA890368934E22E7963B6241 /* Swiftformat & Swiftlint */,
+			);
+			buildRules = (
+				C6348C017141B2AC009D7B20 /* PBXBuildRule */,
+			);
+			dependencies = (
+			);
+			name = IceAsyncServer;
+			productName = IceAsyncServer;
+			productReference = 9614E9716C6E9716276184E3 /* IceAsyncServer */;
+			productType = "com.apple.product-type.tool";
+		};
+		6C69582EEABAE4429977B37A /* IceOptionalClient */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = D420CCF7CC1428A9FAF8E23B /* Build configuration list for PBXNativeTarget "IceOptionalClient" */;
+			buildPhases = (
+				68ECB9131F0699AA196B6E2C /* Sources */,
+				9ECE034B5C0FB96437964348 /* Frameworks */,
+				4B5D516EF0474BD40D33AB69 /* Swiftformat & Swiftlint */,
+			);
+			buildRules = (
+				E04266D5EFC8A13C1653471F /* PBXBuildRule */,
+			);
+			dependencies = (
+			);
+			name = IceOptionalClient;
+			productName = IceOptionalClient;
+			productReference = 489FC987C118929E6AF6C2FD /* IceOptionalClient */;
+			productType = "com.apple.product-type.tool";
+		};
+		6D9EBD901A955C9B5D5C1AE3 /* IceHelloUI */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 84128DFC5D92D6DBF5430595 /* Build configuration list for PBXNativeTarget "IceHelloUI" */;
+			buildPhases = (
+				284820F452A9FAEC278DFB96 /* Sources */,
+				7879FCE640EE47C5E8D77531 /* Frameworks */,
+				3F1E3B787B591D06C5529B09 /* Resources */,
+				41498733F2631F5127B2A983 /* Embed Frameworks */,
+				7A0FA879A8A2AD40F23E081D /* Swiftformat & Swiftlint */,
+			);
+			buildRules = (
+				6592CAD54A0B4EAE3690334B /* PBXBuildRule */,
+			);
+			dependencies = (
+			);
+			name = IceHelloUI;
+			productName = IceHelloUI;
+			productReference = 6BFEAD8B2DE9FB136CCFDD3C /* IceHelloUI.app */;
+			productType = "com.apple.product-type.application";
+		};
+		75886DD9A8F4E2B5F19D1A9A /* IceMinimalClient */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 542F5EFE654DD57E0C11307D /* Build configuration list for PBXNativeTarget "IceMinimalClient" */;
+			buildPhases = (
+				270AC6C8963FA07EC13875E6 /* Sources */,
+				1A0E7CE03EBFFE528CDD0B5E /* Frameworks */,
+				9AD390633432C29AB2DFFD0A /* Swiftformat & Swiftlint */,
+			);
+			buildRules = (
+				A09A3CBFC6D99459D28FCC7A /* PBXBuildRule */,
+			);
+			dependencies = (
+			);
+			name = IceMinimalClient;
+			productName = IceMinimalClient;
+			productReference = 50ED78D2D71AA4911AC977E4 /* IceMinimalClient */;
+			productType = "com.apple.product-type.tool";
+		};
+		764B259011A33FA3A95412E9 /* IceInvokeServer */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CF4BAF9DF89BFAF3E97C9BE5 /* Build configuration list for PBXNativeTarget "IceInvokeServer" */;
+			buildPhases = (
+				602E3D7ACFEADA9C5E3A2B37 /* Sources */,
+				28F460C1E025266A22DA122D /* Frameworks */,
+				F48821D5B313F36E4531A4E8 /* Swiftformat & Swiftlint */,
+			);
+			buildRules = (
+				173B6DA731F8A6A3C1BB752C /* PBXBuildRule */,
+			);
+			dependencies = (
+			);
+			name = IceInvokeServer;
+			productName = IceInvokeServer;
+			productReference = D4F0BFBD7206AE0ABB253518 /* IceInvokeServer */;
+			productType = "com.apple.product-type.tool";
+		};
+		7B02D53AC9CADE3781497FE2 /* IceStormClockPublisher */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = B9753D2999179047C0F843D6 /* Build configuration list for PBXNativeTarget "IceStormClockPublisher" */;
+			buildPhases = (
+				0001A26A2CCABABAD28D9071 /* Sources */,
+				848CE79162D9B3FA5928723F /* Frameworks */,
+				571ACB992B2632820870AFBE /* Swiftformat & Swiftlint */,
+			);
+			buildRules = (
+				278092AC96609633F23F3170 /* PBXBuildRule */,
+			);
+			dependencies = (
+			);
+			name = IceStormClockPublisher;
+			productName = IceStormClockPublisher;
+			productReference = 237032C49A14937A66AEDE89 /* IceStormClockPublisher */;
+			productType = "com.apple.product-type.tool";
+		};
+		8421E27006F16414C9BB2D92 /* Glacier2CallbackClient */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 398FA99AF60CC10017DF6DD8 /* Build configuration list for PBXNativeTarget "Glacier2CallbackClient" */;
+			buildPhases = (
+				54E6600DA7127307E591BB29 /* Sources */,
+				A4A4A2BFEC27715FEBCC7A54 /* Frameworks */,
+				6E3633A945CCBB16FA3B74A8 /* Swiftformat & Swiftlint */,
+			);
+			buildRules = (
+				853DDA973B06366CBD4924E0 /* PBXBuildRule */,
+			);
+			dependencies = (
+			);
+			name = Glacier2CallbackClient;
+			productName = Glacier2CallbackClient;
+			productReference = 954A6B2ECBC0B96B5C91A1BD /* Glacier2CallbackClient */;
+			productType = "com.apple.product-type.tool";
+		};
+		8DEC3881159900B77EBC1E89 /* IceHelloClient */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E009F87BD497BEFD31C4B710 /* Build configuration list for PBXNativeTarget "IceHelloClient" */;
+			buildPhases = (
+				06DA11216975B5A583977131 /* Sources */,
+				0B73AADD24EB2D5BE5493013 /* Frameworks */,
+				1614C1996D15A39DB8223A3B /* Swiftformat & Swiftlint */,
+			);
+			buildRules = (
+				19B1F356D43A751A68A31FA0 /* PBXBuildRule */,
+			);
+			dependencies = (
+			);
+			name = IceHelloClient;
+			productName = IceHelloClient;
+			productReference = B8030C583229E314C0DB3AB8 /* IceHelloClient */;
+			productType = "com.apple.product-type.tool";
+		};
+		90C4A14E104360C2D66BE95A /* IceGridSimpleServer */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 17EED16FD192835E37C08F02 /* Build configuration list for PBXNativeTarget "IceGridSimpleServer" */;
+			buildPhases = (
+				E4D9818D14FD9450FCFEC081 /* Sources */,
+				A9D70D1C35905D45E3B7AE94 /* Frameworks */,
+				E11B198A029559C7D8F2FDA0 /* Swiftformat & Swiftlint */,
+			);
+			buildRules = (
+				3FA52435382FDEC0BA851B9F /* PBXBuildRule */,
+			);
+			dependencies = (
+			);
+			name = IceGridSimpleServer;
+			productName = IceGridSimpleServer;
+			productReference = 791FA9627886D784E488A94E /* IceGridSimpleServer */;
+			productType = "com.apple.product-type.tool";
+		};
+		9514BAF35E560E29ACF6770A /* IceBidirServer */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E5BE94CC7E12A4C7636881CC /* Build configuration list for PBXNativeTarget "IceBidirServer" */;
+			buildPhases = (
+				1A29E654F9E5289533A97844 /* Sources */,
+				3EAD21A0768509CD327E457B /* Frameworks */,
+				074332BB1B51BD8B18FD1B0B /* Swiftformat & Swiftlint */,
+			);
+			buildRules = (
+				4B8F1E606B26D31B0A872B9C /* PBXBuildRule */,
+			);
+			dependencies = (
+			);
+			name = IceBidirServer;
+			productName = IceBidirServer;
+			productReference = 6A2239121A5E70F72E6FE232 /* IceBidirServer */;
+			productType = "com.apple.product-type.tool";
+		};
+		9575E4AABF609C87FECCF75E /* IceContextServer */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 2019457B7736436BDD6908FF /* Build configuration list for PBXNativeTarget "IceContextServer" */;
+			buildPhases = (
+				749F8AE1D113D4F4DA757F9A /* Sources */,
+				B5480E04E37C39E472D21F68 /* Frameworks */,
+				C7DDB851EE642AAE347CDC6C /* Swiftformat & Swiftlint */,
+			);
+			buildRules = (
+				59B8BA36CEA2A1C02A6646C0 /* PBXBuildRule */,
+			);
+			dependencies = (
+			);
+			name = IceContextServer;
+			productName = IceContextServer;
+			productReference = 58BB100D0312165F66C317E3 /* IceContextServer */;
+			productType = "com.apple.product-type.tool";
+		};
+		99EA7DE41DE8CC2A65D1B2C8 /* IceInvokeClient */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 18FC462EB7FAF94D59CBFA66 /* Build configuration list for PBXNativeTarget "IceInvokeClient" */;
+			buildPhases = (
+				4FEFFC8D3E4ED2998498AC1C /* Sources */,
+				E9FDA3220905C4351970D6C7 /* Frameworks */,
+				CE03AE8E2D2776E1F0B2D85A /* Swiftformat & Swiftlint */,
+			);
+			buildRules = (
+				4EFA8054DAC43541B5D8A6B1 /* PBXBuildRule */,
+			);
+			dependencies = (
+			);
+			name = IceInvokeClient;
+			productName = IceInvokeClient;
+			productReference = 1844EB7D97A6D75CBBCD7023 /* IceInvokeClient */;
+			productType = "com.apple.product-type.tool";
+		};
+		A52F7C41BC31497EF70154BB /* ManualSimpleFilesystemServer */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 027C68065DE24751572B7E37 /* Build configuration list for PBXNativeTarget "ManualSimpleFilesystemServer" */;
+			buildPhases = (
+				3625CF5031A6B868E02DA677 /* Sources */,
+				331FFB98E886B3820BD53A0D /* Frameworks */,
+				59F728ED77F67D0FDD7361C8 /* Swiftformat & Swiftlint */,
+			);
+			buildRules = (
+				09FA64871309C790F4915829 /* PBXBuildRule */,
+			);
+			dependencies = (
+			);
+			name = ManualSimpleFilesystemServer;
+			productName = ManualSimpleFilesystemServer;
+			productReference = BEEE328D6BE2266AFD7A3422 /* ManualSimpleFilesystemServer */;
+			productType = "com.apple.product-type.tool";
+		};
+		AED3746019CE470B01C4CD89 /* IceContextClient */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 4B4171E8C36C8C7DE57E5CE4 /* Build configuration list for PBXNativeTarget "IceContextClient" */;
+			buildPhases = (
+				7A23A4DEA118C7E7A87C1895 /* Sources */,
+				057EC43D2CB93050301716BA /* Frameworks */,
+				074B7968509665F8CA399FD1 /* Swiftformat & Swiftlint */,
+			);
+			buildRules = (
+				51807347603BF086887A412D /* PBXBuildRule */,
+			);
+			dependencies = (
+			);
+			name = IceContextClient;
+			productName = IceContextClient;
+			productReference = 5EB97A531498CDA1EDAC9496 /* IceContextClient */;
+			productType = "com.apple.product-type.tool";
+		};
+		BD669BA1D9DFD486901D342F /* IceInterceptorServer */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 6DE6ECA62A425FC1AF752B7D /* Build configuration list for PBXNativeTarget "IceInterceptorServer" */;
+			buildPhases = (
+				2DC9AB326C416A15A1410DBF /* Sources */,
+				F7E758A8EF305083A223BA59 /* Frameworks */,
+				0AC753DDB2692168A84668D4 /* Swiftformat & Swiftlint */,
+			);
+			buildRules = (
+				BFD3A71AF9B9141C7003A969 /* PBXBuildRule */,
+			);
+			dependencies = (
+			);
+			name = IceInterceptorServer;
+			productName = IceInterceptorServer;
+			productReference = D7088FF2DD5FE9F6CC3190FA /* IceInterceptorServer */;
+			productType = "com.apple.product-type.tool";
+		};
+		C389294E4BB98ADFCDF8F54E /* IceGridSimpleClient */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 7E3D80CE3E75EED82FCFE10B /* Build configuration list for PBXNativeTarget "IceGridSimpleClient" */;
+			buildPhases = (
+				DC3B4132043C84955037EF33 /* Sources */,
+				69C093AC16C6C2040C309B74 /* Frameworks */,
+				5EAAD2B27A2E1F71519C23DE /* Swiftformat & Swiftlint */,
+			);
+			buildRules = (
+				7BBDFAFB105F20244737212C /* PBXBuildRule */,
+			);
+			dependencies = (
+			);
+			name = IceGridSimpleClient;
+			productName = IceGridSimpleClient;
+			productReference = 42E1BC68BA3AB2F7B9C429F7 /* IceGridSimpleClient */;
+			productType = "com.apple.product-type.tool";
+		};
+		CBAB61F561408159107E5665 /* IceAsyncInvocationClient */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 72FFAD0DAD9BBB1BC3BDDBE7 /* Build configuration list for PBXNativeTarget "IceAsyncInvocationClient" */;
+			buildPhases = (
+				8BD52FF86ECA3B23C8E68735 /* Sources */,
+				47E6C1EC00ED38FB0389A5E7 /* Frameworks */,
+				AAE21862CBE2488DACD39C13 /* Swiftformat & Swiftlint */,
+			);
+			buildRules = (
+				1A523D52193A5779418E5077 /* PBXBuildRule */,
+			);
+			dependencies = (
+			);
+			name = IceAsyncInvocationClient;
+			productName = IceAsyncInvocationClient;
+			productReference = 9F4E002A1950863B6F7AC89A /* IceAsyncInvocationClient */;
+			productType = "com.apple.product-type.tool";
+		};
+		E24362D5509CD78EA3C2E846 /* IceInterceptorClient */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CA434A8635C37FC1ED823AFA /* Build configuration list for PBXNativeTarget "IceInterceptorClient" */;
+			buildPhases = (
+				AAE50D68B1C9317A5F585291 /* Sources */,
+				B82FE8EDFBB7107A743747CF /* Frameworks */,
+				8ACF9F11C9669C1DF2AF3CC6 /* Swiftformat & Swiftlint */,
+			);
+			buildRules = (
+				B0CF47206A6E02FF52F70D63 /* PBXBuildRule */,
+			);
+			dependencies = (
+			);
+			name = IceInterceptorClient;
+			productName = IceInterceptorClient;
+			productReference = 634F4F283DB76162164924F9 /* IceInterceptorClient */;
+			productType = "com.apple.product-type.tool";
+		};
+		E9CFD638AD4E2EBE3E1F95DB /* IceMinimalServer */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 33D371A007F066CDA00D507F /* Build configuration list for PBXNativeTarget "IceMinimalServer" */;
+			buildPhases = (
+				0CB172BAD3BBB59E4031E34D /* Sources */,
+				E2AAB758850E6B43606390E4 /* Frameworks */,
+				4CB6AF4AEF41C4C7B9C904BC /* Swiftformat & Swiftlint */,
+			);
+			buildRules = (
+				9E3E75B18CDD6930E072CF5A /* PBXBuildRule */,
+			);
+			dependencies = (
+			);
+			name = IceMinimalServer;
+			productName = IceMinimalServer;
+			productReference = E66EB015682EA85EB843D95F /* IceMinimalServer */;
+			productType = "com.apple.product-type.tool";
+		};
+		F4A581497FDEB379F7675C88 /* IceAsyncClient */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 9804B75F73A52AB858FD5236 /* Build configuration list for PBXNativeTarget "IceAsyncClient" */;
+			buildPhases = (
+				E7F14E1A64FBE800E9498876 /* Sources */,
+				4792586039B9C7EFE338E22D /* Frameworks */,
+				7164B22F35FFEA9545ED167A /* Swiftformat & Swiftlint */,
+			);
+			buildRules = (
+				334E503AA663C149C61B5779 /* PBXBuildRule */,
+			);
+			dependencies = (
+			);
+			name = IceAsyncClient;
+			productName = IceAsyncClient;
+			productReference = BCC203491E7CE00E9819A24D /* IceAsyncClient */;
+			productType = "com.apple.product-type.tool";
+		};
+		F658A5FB5551039F774F74EF /* ManualPrinterClient */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 807A02B429BE2DDF4D2C1D8B /* Build configuration list for PBXNativeTarget "ManualPrinterClient" */;
+			buildPhases = (
+				AD9D7A63897F93597E3163A0 /* Sources */,
+				FC7C91626171C52C60A56727 /* Frameworks */,
+				E94DD20C88CA6E798FABA974 /* Swiftformat & Swiftlint */,
+			);
+			buildRules = (
+				D64BD7B7854DD9B0DAE6DB3D /* PBXBuildRule */,
+			);
+			dependencies = (
+			);
+			name = ManualPrinterClient;
+			productName = ManualPrinterClient;
+			productReference = E6C2A46A1A9A6BC1A795FD94 /* ManualPrinterClient */;
 			productType = "com.apple.product-type.tool";
 		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
-		EB97194894496C5DB10325DC /* Project object */ = {
+		ED7A4595F994579960C2BA8E /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 1100;
-				LastUpgradeCheck = 1100;
+				LastSwiftUpdateCheck = 1240;
+				LastUpgradeCheck = 1240;
 				TargetAttributes = {
-					0040AFB2BDF7A4FC5F2A6D3C = {
+					010C5E8438CC6EBBB1D05568 = {
 						ProvisioningStyle = Automatic;
 					};
-					08FFABF181D09958170A8064 = {
+					07CAFE2F01A2B040FC16287C = {
 						ProvisioningStyle = Automatic;
 					};
-					1687F343DF79EA8213972141 = {
+					0AE8C7670A42B03A39CDA3C5 = {
 						ProvisioningStyle = Automatic;
 					};
-					17295EE8D54F50AC8BC95360 = {
+					0BF52782AF7FCCEF27A337AE = {
 						ProvisioningStyle = Automatic;
 					};
-					1CEA3A13E08931B50C514BD0 = {
+					0EDB6F8830769A463C145F4E = {
 						ProvisioningStyle = Automatic;
 					};
-					1FD7893AE80DF5B104A80BA6 = {
+					0F333E1C9E6C91C3396F59A2 = {
 						ProvisioningStyle = Automatic;
 					};
-					2EC0D18A54E54780FF0CA0C0 = {
+					10114A97EDF918D7074BC9E8 = {
 						ProvisioningStyle = Automatic;
 					};
-					31999E35AD68722C990CAFDD = {
+					1D324440A0F5469DC7B3CE68 = {
 						ProvisioningStyle = Automatic;
 					};
-					3455DFD133AC5C33DE41401D = {
+					1E2F71AC52A0BDDD354133D0 = {
 						ProvisioningStyle = Automatic;
 					};
-					3487D0246103973B15740CF3 = {
+					21FA6A38274DBCD88814D274 = {
 						ProvisioningStyle = Automatic;
 					};
-					365E2519E773257B91EA2017 = {
+					22B9E10BE8EB9E6CF5B5DDDC = {
 						ProvisioningStyle = Automatic;
 					};
-					3D0479F643E6EBFDE4F41251 = {
+					2B975A6278F9D6CCE53F5E35 = {
 						ProvisioningStyle = Automatic;
 					};
-					445F4A8EEC5CA2028C536DAE = {
+					2EE15C61DC2F49143CC9488C = {
 						ProvisioningStyle = Automatic;
 					};
-					4E426E1AF0E71376C9E873BB = {
+					4159934A7B7D66A462AA96E3 = {
 						ProvisioningStyle = Automatic;
 					};
-					50404C35B730F02C93AF4914 = {
+					42561EDFCCB220DEAFE26FA5 = {
 						ProvisioningStyle = Automatic;
 					};
-					50C7DC4E4B424490F7F59AE9 = {
+					456CC1D6828C3983EF2241D5 = {
 						ProvisioningStyle = Automatic;
 					};
-					58E3C656CAC60E5D4435A63A = {
+					5DA2E0F891AB6C1C5B232CE4 = {
 						ProvisioningStyle = Automatic;
 					};
-					5B5E6A9FEB4E4E67A418460C = {
+					60AFAA9D313FD61836B69D3F = {
 						ProvisioningStyle = Automatic;
 					};
-					5C6AA42A0C3A9B8309B6C879 = {
+					62CD0C57C3183B4C1ACFB7E7 = {
 						ProvisioningStyle = Automatic;
 					};
-					5DEB7AA4511B4B1F1983ECA8 = {
+					659409F48B20801489DA468F = {
 						ProvisioningStyle = Automatic;
 					};
-					7B111AE4525C41AA7E021233 = {
+					68AAF193626BC30C4CD8884F = {
 						ProvisioningStyle = Automatic;
 					};
-					7E534192D654D74C4E38373F = {
+					6C69582EEABAE4429977B37A = {
 						ProvisioningStyle = Automatic;
 					};
-					7F125170B599E70103C6F1A4 = {
+					6D9EBD901A955C9B5D5C1AE3 = {
 						ProvisioningStyle = Automatic;
 					};
-					838136AD0308E0D7D7EC2582 = {
+					75886DD9A8F4E2B5F19D1A9A = {
 						ProvisioningStyle = Automatic;
 					};
-					86A3F4B19E9DAF9E4B15533A = {
+					764B259011A33FA3A95412E9 = {
 						ProvisioningStyle = Automatic;
 					};
-					9B342C4AF32DBB323A3A0BBA = {
+					7B02D53AC9CADE3781497FE2 = {
 						ProvisioningStyle = Automatic;
 					};
-					A02EBE57139105D20DA043C0 = {
+					8421E27006F16414C9BB2D92 = {
 						ProvisioningStyle = Automatic;
 					};
-					A16D90A9F6AFEC8E5F36B277 = {
+					8DEC3881159900B77EBC1E89 = {
 						ProvisioningStyle = Automatic;
 					};
-					A61365A18C78646CBE55C376 = {
+					90C4A14E104360C2D66BE95A = {
 						ProvisioningStyle = Automatic;
 					};
-					A6F15048BA62D0740B115770 = {
+					9514BAF35E560E29ACF6770A = {
 						ProvisioningStyle = Automatic;
 					};
-					A8AC5929B89E3A59CD81EB3D = {
+					9575E4AABF609C87FECCF75E = {
 						ProvisioningStyle = Automatic;
 					};
-					ACB5ECC440F9694952C7B84C = {
+					99EA7DE41DE8CC2A65D1B2C8 = {
 						ProvisioningStyle = Automatic;
 					};
-					BC411A1038EBE1215648035D = {
+					A52F7C41BC31497EF70154BB = {
 						ProvisioningStyle = Automatic;
 					};
-					C55F08EC4140C753CCD40E6B = {
+					AED3746019CE470B01C4CD89 = {
 						ProvisioningStyle = Automatic;
 					};
-					CBE5A662859EB3A829D935EB = {
+					BD669BA1D9DFD486901D342F = {
 						ProvisioningStyle = Automatic;
 					};
-					D8B2F755F5313CF3ED40667F = {
+					C389294E4BB98ADFCDF8F54E = {
 						ProvisioningStyle = Automatic;
 					};
-					E3DF7A1C971AE032647A29C2 = {
+					CBAB61F561408159107E5665 = {
 						ProvisioningStyle = Automatic;
 					};
-					E542D48F2448F7F27D80BDD0 = {
+					E24362D5509CD78EA3C2E846 = {
 						ProvisioningStyle = Automatic;
 					};
-					E7FF091AC675DE1B5A97F3BB = {
+					E9CFD638AD4E2EBE3E1F95DB = {
 						ProvisioningStyle = Automatic;
 					};
-					F278530FC73733F84C3B351A = {
+					F4A581497FDEB379F7675C88 = {
 						ProvisioningStyle = Automatic;
 					};
-					FB515029F564EEC25346D66A = {
+					F658A5FB5551039F774F74EF = {
 						ProvisioningStyle = Automatic;
 					};
 				};
 			};
-			buildConfigurationList = 801B535E78133B1A9EDE9CB6 /* Build configuration list for PBXProject "demos" */;
+			buildConfigurationList = C03E065DF91CAC20DF8C5BC2 /* Build configuration list for PBXProject "demos" */;
 			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
@@ -3466,643 +3442,85 @@
 				Base,
 				en,
 			);
-			mainGroup = 326B250017C8445D4E11AC63;
-			productRefGroup = 5CB20F0B413543DEFFF51B6F /* Products */;
+			mainGroup = D6BED64FECAE1D163F003897;
+			productRefGroup = 3646BECCE042C748D166DB4A /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				50404C35B730F02C93AF4914 /* allDemos iOS */,
-				31999E35AD68722C990CAFDD /* allDemos macOS */,
-				2EC0D18A54E54780FF0CA0C0 /* Glacier2CallbackClient */,
-				17295EE8D54F50AC8BC95360 /* Glacier2CallbackServer */,
-				1687F343DF79EA8213972141 /* IceAsyncClient */,
-				BC411A1038EBE1215648035D /* IceAsyncInvocationClient */,
-				E3DF7A1C971AE032647A29C2 /* IceAsyncInvocationServer */,
-				838136AD0308E0D7D7EC2582 /* IceAsyncServer */,
-				4E426E1AF0E71376C9E873BB /* IceBidirClient */,
-				5B5E6A9FEB4E4E67A418460C /* IceBidirServer */,
-				C55F08EC4140C753CCD40E6B /* IceContextClient */,
-				A16D90A9F6AFEC8E5F36B277 /* IceContextServer */,
-				0040AFB2BDF7A4FC5F2A6D3C /* IceDiscoveryHelloClient */,
-				A8AC5929B89E3A59CD81EB3D /* IceDiscoveryHelloServer */,
-				9B342C4AF32DBB323A3A0BBA /* IceDiscoveryReplicationClient */,
-				5C6AA42A0C3A9B8309B6C879 /* IceDiscoveryReplicationServer */,
-				86A3F4B19E9DAF9E4B15533A /* IceGridSimpleClient */,
-				E542D48F2448F7F27D80BDD0 /* IceGridSimpleServer */,
-				E7FF091AC675DE1B5A97F3BB /* IceHelloClient */,
-				FB515029F564EEC25346D66A /* IceHelloServer */,
-				3487D0246103973B15740CF3 /* IceInterceptorClient */,
-				58E3C656CAC60E5D4435A63A /* IceInterceptorServer */,
-				445F4A8EEC5CA2028C536DAE /* IceInvokeClient */,
-				08FFABF181D09958170A8064 /* IceInvokeServer */,
-				F278530FC73733F84C3B351A /* IceLatencyClient */,
-				ACB5ECC440F9694952C7B84C /* IceLatencyServer */,
-				1CEA3A13E08931B50C514BD0 /* IceMinimalClient */,
-				A02EBE57139105D20DA043C0 /* IceMinimalServer */,
-				7B111AE4525C41AA7E021233 /* IceOptionalClient */,
-				3D0479F643E6EBFDE4F41251 /* IceOptionalServer */,
-				5DEB7AA4511B4B1F1983ECA8 /* IceStormClockPublisher */,
-				1FD7893AE80DF5B104A80BA6 /* IceStormClockSubscriber */,
-				CBE5A662859EB3A829D935EB /* IceThroughputClient */,
-				D8B2F755F5313CF3ED40667F /* IceThroughputServer */,
-				A6F15048BA62D0740B115770 /* IOSChat */,
-				7E534192D654D74C4E38373F /* IOSHello */,
-				A61365A18C78646CBE55C376 /* IOSLibrary */,
-				7F125170B599E70103C6F1A4 /* ManualPrinterClient */,
-				50C7DC4E4B424490F7F59AE9 /* ManualPrinterServer */,
-				365E2519E773257B91EA2017 /* ManualSimpleFilesystemClient */,
-				3455DFD133AC5C33DE41401D /* ManualSimpleFilesystemServer */,
+				22B9E10BE8EB9E6CF5B5DDDC /* allDemos iOS */,
+				659409F48B20801489DA468F /* allDemos macOS */,
+				0BF52782AF7FCCEF27A337AE /* Chat */,
+				8421E27006F16414C9BB2D92 /* Glacier2CallbackClient */,
+				62CD0C57C3183B4C1ACFB7E7 /* Glacier2CallbackServer */,
+				F4A581497FDEB379F7675C88 /* IceAsyncClient */,
+				CBAB61F561408159107E5665 /* IceAsyncInvocationClient */,
+				60AFAA9D313FD61836B69D3F /* IceAsyncInvocationServer */,
+				68AAF193626BC30C4CD8884F /* IceAsyncServer */,
+				10114A97EDF918D7074BC9E8 /* IceBidirClient */,
+				9514BAF35E560E29ACF6770A /* IceBidirServer */,
+				AED3746019CE470B01C4CD89 /* IceContextClient */,
+				9575E4AABF609C87FECCF75E /* IceContextServer */,
+				0AE8C7670A42B03A39CDA3C5 /* IceDiscoveryHelloClient */,
+				0F333E1C9E6C91C3396F59A2 /* IceDiscoveryHelloServer */,
+				5DA2E0F891AB6C1C5B232CE4 /* IceDiscoveryHelloUI */,
+				1E2F71AC52A0BDDD354133D0 /* IceDiscoveryReplicationClient */,
+				2EE15C61DC2F49143CC9488C /* IceDiscoveryReplicationServer */,
+				C389294E4BB98ADFCDF8F54E /* IceGridSimpleClient */,
+				90C4A14E104360C2D66BE95A /* IceGridSimpleServer */,
+				8DEC3881159900B77EBC1E89 /* IceHelloClient */,
+				4159934A7B7D66A462AA96E3 /* IceHelloServer */,
+				6D9EBD901A955C9B5D5C1AE3 /* IceHelloUI */,
+				E24362D5509CD78EA3C2E846 /* IceInterceptorClient */,
+				BD669BA1D9DFD486901D342F /* IceInterceptorServer */,
+				99EA7DE41DE8CC2A65D1B2C8 /* IceInvokeClient */,
+				764B259011A33FA3A95412E9 /* IceInvokeServer */,
+				2B975A6278F9D6CCE53F5E35 /* IceLatencyClient */,
+				1D324440A0F5469DC7B3CE68 /* IceLatencyServer */,
+				75886DD9A8F4E2B5F19D1A9A /* IceMinimalClient */,
+				E9CFD638AD4E2EBE3E1F95DB /* IceMinimalServer */,
+				6C69582EEABAE4429977B37A /* IceOptionalClient */,
+				010C5E8438CC6EBBB1D05568 /* IceOptionalServer */,
+				7B02D53AC9CADE3781497FE2 /* IceStormClockPublisher */,
+				42561EDFCCB220DEAFE26FA5 /* IceStormClockSubscriber */,
+				456CC1D6828C3983EF2241D5 /* IceThroughputClient */,
+				07CAFE2F01A2B040FC16287C /* IceThroughputServer */,
+				F658A5FB5551039F774F74EF /* ManualPrinterClient */,
+				21FA6A38274DBCD88814D274 /* ManualPrinterServer */,
+				0EDB6F8830769A463C145F4E /* ManualSimpleFilesystemClient */,
+				A52F7C41BC31497EF70154BB /* ManualSimpleFilesystemServer */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
-		17F9B4EF18B4BE1BBD9EAC38 /* Resources */ = {
+		3B978A20C34FE60E5CE2C00D /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				AB2D1B182CC0FF6975FF862E /* certs in Resources */,
+				76E3A938B1A497F53231DF62 /* certs in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		18667D3BD9A46A189545E47C /* Resources */ = {
+		3F1E3B787B591D06C5529B09 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				6BF4EAEBF2B2FB8FD273696D /* config.client in Resources */,
+				86331B876DDB5CA43E43D758 /* certs in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		95F64D70096EA8F19F011F64 /* Resources */ = {
+		FBFF38BF51A1B617CCDA77EB /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				7D3AD9F611E8CD7F0AE861C7 /* config.client in Resources */,
+				483D42A25BD4EC198EEA0528 /* config.client in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		1A65F5B4FE36E90BC8B58E9E /* Swiftformat & Swiftlint */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = "Swiftformat & Swiftlint";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --path \"$SRCROOT/Ice/hello/Sources/Server\" --config \"$SRCROOT/.swiftlint.yml\"\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
-		};
-		1CC1AC9B4859B18CBBE853F0 /* Swiftformat & Swiftlint */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = "Swiftformat & Swiftlint";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --path \"$SRCROOT/Manual/simpleFilesystem/Sources/Client\" --config \"$SRCROOT/.swiftlint.yml\"\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
-		};
-		240A9E84510E242EED9E296D /* Swiftformat & Swiftlint */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = "Swiftformat & Swiftlint";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --path \"$SRCROOT/Ice/minimal/Sources/Server\" --config \"$SRCROOT/.swiftlint.yml\"\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
-		};
-		2758A849B9DF19D5D4986531 /* Swiftformat & Swiftlint */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = "Swiftformat & Swiftlint";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --path \"$SRCROOT/Ice/context/Sources/Client\" --config \"$SRCROOT/.swiftlint.yml\"\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
-		};
-		28E5DE62DE1562551B40F76E /* Swiftformat & Swiftlint */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = "Swiftformat & Swiftlint";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --path \"$SRCROOT/Ice/minimal/Sources/Client\" --config \"$SRCROOT/.swiftlint.yml\"\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
-		};
-		304532B794370B25F4479D83 /* Swiftformat & Swiftlint */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = "Swiftformat & Swiftlint";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --path \"$SRCROOT/IceDiscovery/replication/Sources/Client\" --config \"$SRCROOT/.swiftlint.yml\"\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
-		};
-		32B27A33621C560AEEED89A5 /* Swiftformat & Swiftlint */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = "Swiftformat & Swiftlint";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --path \"$SRCROOT/Ice/context/Sources/Server\" --config \"$SRCROOT/.swiftlint.yml\"\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
-		};
-		338F79C59057B0DC12254715 /* Swiftformat & Swiftlint */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = "Swiftformat & Swiftlint";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --path \"$SRCROOT/Ice/invoke/Sources/Server\" --config \"$SRCROOT/.swiftlint.yml\"\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
-		};
-		374CB7719159FEA730B50AF5 /* Swiftformat & Swiftlint */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = "Swiftformat & Swiftlint";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --path \"$SRCROOT/Manual/simpleFilesystem/Sources/Server\" --config \"$SRCROOT/.swiftlint.yml\"\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
-		};
-		38C9822816608FAC34AAC0B6 /* Swiftformat & Swiftlint */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = "Swiftformat & Swiftlint";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --path \"$SRCROOT/IceDiscovery/hello/Sources/Client\" --config \"$SRCROOT/.swiftlint.yml\"\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
-		};
-		46278A7426E3C6C00798FD2C /* Swiftformat & Swiftlint */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = "Swiftformat & Swiftlint";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --path \"$SRCROOT/IceGrid/simple/Sources/Client\" --config \"$SRCROOT/.swiftlint.yml\"\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
-		};
-		5748CE40F3793780000C1576 /* Swiftformat & Swiftlint */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = "Swiftformat & Swiftlint";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --path \"$SRCROOT/IceStorm/clock/Sources/Subscriber\" --config \"$SRCROOT/.swiftlint.yml\"\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
-		};
-		5F4B50AFF623D55D5222860D /* Swiftformat & Swiftlint */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = "Swiftformat & Swiftlint";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --path \"$SRCROOT/Ice/throughput/Sources/Client\" --config \"$SRCROOT/.swiftlint.yml\"\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
-		};
-		5F6B2788432347BA99F280F5 /* Swiftformat & Swiftlint */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = "Swiftformat & Swiftlint";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --path \"$SRCROOT/iOS/hello\" --config \"$SRCROOT/.swiftlint.yml\"\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
-		};
-		83BC64B247558709EC02A82F /* Swiftformat & Swiftlint */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = "Swiftformat & Swiftlint";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --path \"$SRCROOT/Ice/interceptor/Sources/Server\" --config \"$SRCROOT/.swiftlint.yml\"\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
-		};
-		845C014E0511D853B5D26BDE /* Swiftformat & Swiftlint */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = "Swiftformat & Swiftlint";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --path \"$SRCROOT/IceGrid/simple/Sources/Server\" --config \"$SRCROOT/.swiftlint.yml\"\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
-		};
-		852D21BE96ABE71CEDA9CCA2 /* Swiftformat & Swiftlint */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = "Swiftformat & Swiftlint";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --path \"$SRCROOT/Ice/optional/Sources/Client\" --config \"$SRCROOT/.swiftlint.yml\"\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
-		};
-		8F54E8B685C26F0B9D303753 /* Swiftformat & Swiftlint */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = "Swiftformat & Swiftlint";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --path \"$SRCROOT/Ice/asyncInvocation/Sources/Server\" --config \"$SRCROOT/.swiftlint.yml\"\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
-		};
-		950E937066F3A4D128951BC4 /* Swiftformat & Swiftlint */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = "Swiftformat & Swiftlint";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --path \"$SRCROOT/Glacier2/callback/Sources/Server\" --config \"$SRCROOT/.swiftlint.yml\"\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
-		};
-		97DF1DF68F195AC853982299 /* Swiftformat & Swiftlint */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = "Swiftformat & Swiftlint";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --path \"$SRCROOT/Ice/asyncInvocation/Sources/Client\" --config \"$SRCROOT/.swiftlint.yml\"\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
-		};
-		A641ACDB2E5579B28A23DDA9 /* Swiftformat & Swiftlint */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = "Swiftformat & Swiftlint";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --path \"$SRCROOT/Ice/async/Sources/Server\" --config \"$SRCROOT/.swiftlint.yml\"\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
-		};
-		B154F41F9A2C2FD5A439DD17 /* Swiftformat & Swiftlint */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = "Swiftformat & Swiftlint";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --path \"$SRCROOT/IceStorm/clock/Sources/Publisher\" --config \"$SRCROOT/.swiftlint.yml\"\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
-		};
-		B23B3C1FB6FF5D661B3C6BA5 /* Swiftformat & Swiftlint */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = "Swiftformat & Swiftlint";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --path \"$SRCROOT/Ice/hello/Sources/Client\" --config \"$SRCROOT/.swiftlint.yml\"\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
-		};
-		B607C54DD8F412A61E5576B3 /* Swiftformat & Swiftlint */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = "Swiftformat & Swiftlint";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --path \"$SRCROOT/Ice/bidir/Sources/Client\" --config \"$SRCROOT/.swiftlint.yml\"\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
-		};
-		B69D8AF9A5F77C6AE4A84128 /* Swiftformat & Swiftlint */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = "Swiftformat & Swiftlint";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --path \"$SRCROOT/Manual/printer/Sources/Server\" --config \"$SRCROOT/.swiftlint.yml\"\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
-		};
-		C0325B458C9B0AA13E83855F /* Swiftformat & Swiftlint */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = "Swiftformat & Swiftlint";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --path \"$SRCROOT/IceDiscovery/replication/Sources/Server\" --config \"$SRCROOT/.swiftlint.yml\"\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
-		};
-		C0F0295DA696DEC1F8456128 /* Swiftformat & Swiftlint */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = "Swiftformat & Swiftlint";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --path \"$SRCROOT/Ice/invoke/Sources/Client\" --config \"$SRCROOT/.swiftlint.yml\"\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
-		};
-		C1663C2F6CBF5BE10BABB96E /* Swiftformat & Swiftlint */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = "Swiftformat & Swiftlint";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --path \"$SRCROOT/Ice/latency/Sources/Server\" --config \"$SRCROOT/.swiftlint.yml\"\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
-		};
-		CBB702D75E17ECF45917C8DD /* Swiftformat & Swiftlint */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = "Swiftformat & Swiftlint";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --path \"$SRCROOT/IceDiscovery/hello/Sources/Server\" --config \"$SRCROOT/.swiftlint.yml\"\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
-		};
-		CDD1F5F7A451B0A6675BE467 /* Swiftformat & Swiftlint */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = "Swiftformat & Swiftlint";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --path \"$SRCROOT/Ice/optional/Sources/Server\" --config \"$SRCROOT/.swiftlint.yml\"\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
-		};
-		CE5684F5FF89AFF9172759C9 /* Swiftformat & Swiftlint */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = "Swiftformat & Swiftlint";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --path \"$SRCROOT/Ice/latency/Sources/Client\" --config \"$SRCROOT/.swiftlint.yml\"\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
-		};
-		E394CCE7479FF09D72E83251 /* Swiftformat & Swiftlint */ = {
+		074332BB1B51BD8B18FD1B0B /* Swiftformat & Swiftlint */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -4120,7 +3538,7 @@
 			shellPath = /bin/sh;
 			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --path \"$SRCROOT/Ice/bidir/Sources/Server\" --config \"$SRCROOT/.swiftlint.yml\"\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
 		};
-		E3A640C872EE801513DB944B /* Swiftformat & Swiftlint */ = {
+		074B7968509665F8CA399FD1 /* Swiftformat & Swiftlint */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -4136,9 +3554,9 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --path \"$SRCROOT/iOS/library\" --config \"$SRCROOT/.swiftlint.yml\"\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --path \"$SRCROOT/Ice/context/Sources/Client\" --config \"$SRCROOT/.swiftlint.yml\"\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
 		};
-		E56B836B5EA5E841B5E21E20 /* Swiftformat & Swiftlint */ = {
+		09FF58AF88522B2053DC19CC /* Swiftformat & Swiftlint */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -4154,9 +3572,9 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --path \"$SRCROOT/Ice/interceptor/Sources/Client\" --config \"$SRCROOT/.swiftlint.yml\"\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --path \"$SRCROOT/IceDiscovery/replication/Sources/Client\" --config \"$SRCROOT/.swiftlint.yml\"\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
 		};
-		E7801F619963B46D569508AE /* Swiftformat & Swiftlint */ = {
+		0AC753DDB2692168A84668D4 /* Swiftformat & Swiftlint */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -4172,9 +3590,9 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --path \"$SRCROOT/Ice/throughput/Sources/Server\" --config \"$SRCROOT/.swiftlint.yml\"\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --path \"$SRCROOT/Ice/interceptor/Sources/Server\" --config \"$SRCROOT/.swiftlint.yml\"\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
 		};
-		F5C2DCD75F0532DE5B7D0105 /* Swiftformat & Swiftlint */ = {
+		0B27BA635A1FDB0EBE1ABC88 /* Swiftformat & Swiftlint */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -4190,9 +3608,9 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --path \"$SRCROOT/Ice/async/Sources/Client\" --config \"$SRCROOT/.swiftlint.yml\"\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --path \"$SRCROOT/Manual/printer/Sources/Server\" --config \"$SRCROOT/.swiftlint.yml\"\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
 		};
-		F9D8F88D81EE76435F04F581 /* Swiftformat & Swiftlint */ = {
+		111166342EE7EAABAE5EF788 /* Swiftformat & Swiftlint */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -4208,9 +3626,9 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --path \"$SRCROOT/Manual/printer/Sources/Client\" --config \"$SRCROOT/.swiftlint.yml\"\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --path \"$SRCROOT/Ice/hello/Sources/Server\" --config \"$SRCROOT/.swiftlint.yml\"\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
 		};
-		F9E781170CCEFE9152BF9D0E /* Swiftformat & Swiftlint */ = {
+		1614C1996D15A39DB8223A3B /* Swiftformat & Swiftlint */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -4226,9 +3644,171 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --path \"$SRCROOT/iOS/chat\" --config \"$SRCROOT/.swiftlint.yml\"\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --path \"$SRCROOT/Ice/hello/Sources/Client\" --config \"$SRCROOT/.swiftlint.yml\"\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
 		};
-		F9FFC7590DF15BCC0F5FDF60 /* Swiftformat & Swiftlint */ = {
+		1685E94ADB605C5E0CF2FB4B /* Swiftformat & Swiftlint */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Swiftformat & Swiftlint";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --path \"$SRCROOT/IceDiscovery/hello/Sources/Server\" --config \"$SRCROOT/.swiftlint.yml\"\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+		};
+		186181244A994F16E495080F /* Swiftformat & Swiftlint */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Swiftformat & Swiftlint";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --path \"$SRCROOT/Ice/latency/Sources/Server\" --config \"$SRCROOT/.swiftlint.yml\"\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+		};
+		38A134A7CC14D2A83C5D2464 /* Swiftformat & Swiftlint */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Swiftformat & Swiftlint";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --path \"$SRCROOT/IceDiscovery/hello/Sources/Client\" --config \"$SRCROOT/.swiftlint.yml\"\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+		};
+		4B5D516EF0474BD40D33AB69 /* Swiftformat & Swiftlint */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Swiftformat & Swiftlint";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --path \"$SRCROOT/Ice/optional/Sources/Client\" --config \"$SRCROOT/.swiftlint.yml\"\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+		};
+		4CB6AF4AEF41C4C7B9C904BC /* Swiftformat & Swiftlint */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Swiftformat & Swiftlint";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --path \"$SRCROOT/Ice/minimal/Sources/Server\" --config \"$SRCROOT/.swiftlint.yml\"\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+		};
+		571ACB992B2632820870AFBE /* Swiftformat & Swiftlint */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Swiftformat & Swiftlint";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --path \"$SRCROOT/IceStorm/clock/Sources/Publisher\" --config \"$SRCROOT/.swiftlint.yml\"\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+		};
+		59F728ED77F67D0FDD7361C8 /* Swiftformat & Swiftlint */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Swiftformat & Swiftlint";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --path \"$SRCROOT/Manual/simpleFilesystem/Sources/Server\" --config \"$SRCROOT/.swiftlint.yml\"\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+		};
+		5EAAD2B27A2E1F71519C23DE /* Swiftformat & Swiftlint */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Swiftformat & Swiftlint";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --path \"$SRCROOT/IceGrid/simple/Sources/Client\" --config \"$SRCROOT/.swiftlint.yml\"\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+		};
+		6266996BD7A76F7F5EB46FC5 /* Swiftformat & Swiftlint */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Swiftformat & Swiftlint";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --path \"$SRCROOT/Manual/simpleFilesystem/Sources/Client\" --config \"$SRCROOT/.swiftlint.yml\"\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+		};
+		6E3633A945CCBB16FA3B74A8 /* Swiftformat & Swiftlint */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -4246,635 +3826,1073 @@
 			shellPath = /bin/sh;
 			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --path \"$SRCROOT/Glacier2/callback/Sources/Client\" --config \"$SRCROOT/.swiftlint.yml\"\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
 		};
+		7164B22F35FFEA9545ED167A /* Swiftformat & Swiftlint */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Swiftformat & Swiftlint";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --path \"$SRCROOT/Ice/async/Sources/Client\" --config \"$SRCROOT/.swiftlint.yml\"\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+		};
+		7A0FA879A8A2AD40F23E081D /* Swiftformat & Swiftlint */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Swiftformat & Swiftlint";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --path \"$SRCROOT/Ice/helloUI\" --config \"$SRCROOT/.swiftlint.yml\"\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+		};
+		8ACF9F11C9669C1DF2AF3CC6 /* Swiftformat & Swiftlint */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Swiftformat & Swiftlint";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --path \"$SRCROOT/Ice/interceptor/Sources/Client\" --config \"$SRCROOT/.swiftlint.yml\"\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+		};
+		9AD390633432C29AB2DFFD0A /* Swiftformat & Swiftlint */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Swiftformat & Swiftlint";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --path \"$SRCROOT/Ice/minimal/Sources/Client\" --config \"$SRCROOT/.swiftlint.yml\"\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+		};
+		A0E6E8A09C955328C69D7376 /* Swiftformat & Swiftlint */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Swiftformat & Swiftlint";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --path \"$SRCROOT/Ice/throughput/Sources/Client\" --config \"$SRCROOT/.swiftlint.yml\"\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+		};
+		AAE21862CBE2488DACD39C13 /* Swiftformat & Swiftlint */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Swiftformat & Swiftlint";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --path \"$SRCROOT/Ice/asyncInvocation/Sources/Client\" --config \"$SRCROOT/.swiftlint.yml\"\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+		};
+		BA06224E831CFEFE310F6236 /* Swiftformat & Swiftlint */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Swiftformat & Swiftlint";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --path \"$SRCROOT/IceStorm/clock/Sources/Subscriber\" --config \"$SRCROOT/.swiftlint.yml\"\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+		};
+		BE4AEF385A16C089B6563E63 /* Swiftformat & Swiftlint */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Swiftformat & Swiftlint";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --path \"$SRCROOT/IceDiscovery/helloUI\" --config \"$SRCROOT/.swiftlint.yml\"\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+		};
+		C7DDB851EE642AAE347CDC6C /* Swiftformat & Swiftlint */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Swiftformat & Swiftlint";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --path \"$SRCROOT/Ice/context/Sources/Server\" --config \"$SRCROOT/.swiftlint.yml\"\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+		};
+		C80A8B0308A3E7B730045131 /* Swiftformat & Swiftlint */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Swiftformat & Swiftlint";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --path \"$SRCROOT/Glacier2/callback/Sources/Server\" --config \"$SRCROOT/.swiftlint.yml\"\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+		};
+		CC3CAE0029D25CE8EDB4E2D3 /* Swiftformat & Swiftlint */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Swiftformat & Swiftlint";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --path \"$SRCROOT/Ice/optional/Sources/Server\" --config \"$SRCROOT/.swiftlint.yml\"\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+		};
+		CE03AE8E2D2776E1F0B2D85A /* Swiftformat & Swiftlint */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Swiftformat & Swiftlint";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --path \"$SRCROOT/Ice/invoke/Sources/Client\" --config \"$SRCROOT/.swiftlint.yml\"\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+		};
+		D285BAAF4351941FEA9ECC9F /* Swiftformat & Swiftlint */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Swiftformat & Swiftlint";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --path \"$SRCROOT/Chat\" --config \"$SRCROOT/.swiftlint.yml\"\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+		};
+		D28E5EE0F12247F549B480C1 /* Swiftformat & Swiftlint */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Swiftformat & Swiftlint";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --path \"$SRCROOT/Ice/asyncInvocation/Sources/Server\" --config \"$SRCROOT/.swiftlint.yml\"\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+		};
+		DA890368934E22E7963B6241 /* Swiftformat & Swiftlint */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Swiftformat & Swiftlint";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --path \"$SRCROOT/Ice/async/Sources/Server\" --config \"$SRCROOT/.swiftlint.yml\"\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+		};
+		DC93217B66C09033F9FDACE9 /* Swiftformat & Swiftlint */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Swiftformat & Swiftlint";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --path \"$SRCROOT/Ice/bidir/Sources/Client\" --config \"$SRCROOT/.swiftlint.yml\"\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+		};
+		DDAB4463ABF1902EF133000F /* Swiftformat & Swiftlint */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Swiftformat & Swiftlint";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --path \"$SRCROOT/Ice/throughput/Sources/Server\" --config \"$SRCROOT/.swiftlint.yml\"\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+		};
+		E11B198A029559C7D8F2FDA0 /* Swiftformat & Swiftlint */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Swiftformat & Swiftlint";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --path \"$SRCROOT/IceGrid/simple/Sources/Server\" --config \"$SRCROOT/.swiftlint.yml\"\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+		};
+		E94DD20C88CA6E798FABA974 /* Swiftformat & Swiftlint */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Swiftformat & Swiftlint";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --path \"$SRCROOT/Manual/printer/Sources/Client\" --config \"$SRCROOT/.swiftlint.yml\"\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+		};
+		F11DA04FC27ED8BEF12AD50B /* Swiftformat & Swiftlint */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Swiftformat & Swiftlint";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --path \"$SRCROOT/IceDiscovery/replication/Sources/Server\" --config \"$SRCROOT/.swiftlint.yml\"\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+		};
+		F48821D5B313F36E4531A4E8 /* Swiftformat & Swiftlint */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Swiftformat & Swiftlint";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --path \"$SRCROOT/Ice/invoke/Sources/Server\" --config \"$SRCROOT/.swiftlint.yml\"\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+		};
+		FD8390D3E5FD21AD72A652BE /* Swiftformat & Swiftlint */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Swiftformat & Swiftlint";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --path \"$SRCROOT/Ice/latency/Sources/Client\" --config \"$SRCROOT/.swiftlint.yml\"\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-		0F4D55D8494421FCBD27FEFC /* Sources */ = {
+		0001A26A2CCABABAD28D9071 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3B02135314675381F031D66D /* Hello.ice in Sources */,
-				3D14CB80099CE2B13789175C /* main.swift in Sources */,
+				E21E9807B2E9F06409851025 /* Clock.ice in Sources */,
+				9EF0C7C9DB7B4DB15F63FB9D /* main.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		1783026E7056DE9278D3F0D2 /* Sources */ = {
+		063AEB6ACDFA2EFB31AB3A33 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B60E1F70B46C71B3C682A36B /* Contact.ice in Sources */,
-				EFE942394337C84255AD3659 /* ContactDBI.swift in Sources */,
-				F87C03A2BC97530D3A01D6E0 /* main.swift in Sources */,
+				D52C1CE0AF793528DFB3A0CD /* Hello.ice in Sources */,
+				E0188129EA84B88DF496A38C /* main.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		2FF832FDE3A741A109A8C649 /* Sources */ = {
+		06DA11216975B5A583977131 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				4F5D7905876A913D13DD1DBF /* Hello.ice in Sources */,
-				112E3B4FF1F871DBBCC5DF1B /* main.swift in Sources */,
+				3A6D45ED3489FB897963352C /* Hello.ice in Sources */,
+				939CA4225665DBDB3B860B94 /* main.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		31BA747D0E68368FA615A3ED /* Sources */ = {
+		0B4751B0AF14F0958D7F1ED5 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D67A37BECDC2ACB03B220642 /* Interceptor.ice in Sources */,
-				6DB02A868A938C084D3C4B8F /* main.swift in Sources */,
+				3FAA6C67375BCD6B55453C12 /* Hello.ice in Sources */,
+				76B1ECD89A0E609F061CFCCC /* main.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		3A9A4B032E66852D2F81E772 /* Sources */ = {
+		0CB172BAD3BBB59E4031E34D /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				775A2A6D3389024DA1261280 /* Hello.ice in Sources */,
-				1A81751D6FC13419374B6429 /* main.swift in Sources */,
+				40A958490377D6241B518073 /* Hello.ice in Sources */,
+				95545ACAD037E4111F97F7FF /* main.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		3C9EF7E67751B7517A4B14C0 /* Sources */ = {
+		14A1C3BECB9C312B9A243012 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3E9E4613BD8A3E2323C541D1 /* Hello.ice in Sources */,
-				3498E8508C2A552C7FF1638C /* main.swift in Sources */,
+				4BBB7D0D7A2F512CB5E64149 /* Clock.ice in Sources */,
+				45F0A5D99C59FCD2ED89B4D2 /* main.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		3F9AFDCD7C19B31A0CE13271 /* Sources */ = {
+		1A29E654F9E5289533A97844 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				93A93C754F7560DA90E3349E /* Hello.ice in Sources */,
-				A1F28213EC586464006A8F3D /* main.swift in Sources */,
+				88C95645A9DC43D0B71F25FF /* Callback.ice in Sources */,
+				9CE0C99C1ADA5C3C7D3CEC5D /* main.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		46996F4A55BD2D439A58CF2F /* Sources */ = {
+		208ADC79C0274D38BA5145E1 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				2F186674718752E7EA886C86 /* main.swift in Sources */,
-				7D3D5CD70EE4ADE2A22FFB55 /* Printer.ice in Sources */,
-				1B9C9E0C4DB51B04A6A3F136 /* PrinterI.swift in Sources */,
+				49677CFB031726757DCDF84D /* Callback.ice in Sources */,
+				AB7AE64DF5B723C3EB950CBA /* main.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		508142D70C3213D1D85C15BD /* Sources */ = {
+		270AC6C8963FA07EC13875E6 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				50DA129B13907FCF6A5F813A /* Contact.ice in Sources */,
-				705CDAD2418B540A39EC6A61 /* main.swift in Sources */,
+				1DBC1DC65F6FF8ED943B3DC8 /* Hello.ice in Sources */,
+				BC3C94B01121223DA9B98199 /* main.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		523AA0DDF82C04ABF82DF7FE /* Sources */ = {
+		284820F452A9FAEC278DFB96 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				400676150E41886CDC538B15 /* Hello.ice in Sources */,
-				0EE2A7BC3A329D5940D3DEDD /* main.swift in Sources */,
+				1FA334AB2BDDA68C3D415B03 /* ButtonView.swift in Sources */,
+				4834E56B747F47DB3DCAA453 /* Client.swift in Sources */,
+				E2AD5885F69F89D79B003D07 /* FormView.swift in Sources */,
+				69A5830532752C7732817336 /* Hello.ice in Sources */,
+				7025C0AA1DB299B090FB7093 /* HelloApp.swift in Sources */,
+				6D8B027CA77AC684AB3FF403 /* Images.xcassets in Sources */,
+				A63243EE764ACC994C5691EC /* ProxySettings.swift in Sources */,
+				68AB3DC5A5A2230F0F748AFA /* ProxySettingsView.swift in Sources */,
+				FEBDEBCF5F945337164FE811 /* StatusView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		5443A1B9A0D7C2977AA65469 /* Sources */ = {
+		2DC9AB326C416A15A1410DBF /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				6ABE0273F66CD4180A22CA27 /* Hello.ice in Sources */,
-				6B3CA6C95C71045A113D4802 /* main.swift in Sources */,
+				A75BFB3CAC44EEF135CDE8F8 /* AuthenticatorI.swift in Sources */,
+				8728ED93B0D9016298D5AF74 /* Interceptor.ice in Sources */,
+				AA7E5435E00604C6A6ADD429 /* InterceptorI.swift in Sources */,
+				E5B55A70045ABFC26AA2764D /* main.swift in Sources */,
+				CB3A3D25696BC9C46EB1520D /* ThermostatI.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		59BFD03CE1E9E83B753FF788 /* Sources */ = {
+		3625CF5031A6B868E02DA677 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				AEE551DA1FA05F73A61D4DCF /* Context.ice in Sources */,
-				B424D557AC8D811DEE249812 /* ContextI.swift in Sources */,
-				DF710555BF41835553B71071 /* main.swift in Sources */,
+				BB1512D30C5971A05445631E /* Filesystem.ice in Sources */,
+				21B0948AE347809A0EC55033 /* main.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		6472542E4B5C6120841D698F /* Sources */ = {
+		38024EC4C56B675635E221A3 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				4ACBAC8E58E91869B15ED860 /* Hello.ice in Sources */,
-				2EDB13AC30D1B2BAB8486797 /* main.swift in Sources */,
+				4AAA416EF1039BD4331C0771 /* main.swift in Sources */,
+				62EBFB243C7838D2175D4869 /* Throughput.ice in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		64B644B1FE867D3E4B51B029 /* Sources */ = {
+		3A84249CAFBC691ACD3E2124 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D85AC2902178B3AC1FC299D1 /* Callback.ice in Sources */,
-				BB28C11F53882B35B5315BC4 /* main.swift in Sources */,
+				046C9EB84A64E2A0B1F7CA60 /* Hello.ice in Sources */,
+				73F304B30AE907FD03C6717E /* main.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		6753F6B6F20DF4EE26AAF02B /* Sources */ = {
+		3F25FCD0489CF56EA0F6D01D /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				468989FA8DFC289779572BA4 /* main.swift in Sources */,
-				75AE6402086F569488A13C01 /* Printer.ice in Sources */,
+				B42AD43E65B9B5DFB6D8CFA6 /* Latency.ice in Sources */,
+				D52C330B43A43B65D9C5C088 /* main.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		67A6BC00D02B5C71A86096A2 /* Sources */ = {
+		48A8ED0A4B002EE5F63377AC /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				2EE0B1D1A32AFC2ED595953E /* AppDelegate.swift in Sources */,
-				1F3517AEDC557C489BCDF1DF /* Hello.ice in Sources */,
-				A79DD7D200CA7A5B2F70B027 /* Images.xcassets in Sources */,
-				532F3CD26CB44774FFF3D9D9 /* LaunchScreen.storyboard in Sources */,
-				15CA12B9AFA3979AD3405EE1 /* Main.storyboard in Sources */,
-				AB415AA349C41D7262B0151B /* ViewController.swift in Sources */,
+				59E7175B2F77E2CC6BE9E3EC /* ButtonView.swift in Sources */,
+				B03E35F981104CA48E54E19F /* Client.swift in Sources */,
+				1DD2C03CA0B4DCECD5AD630E /* FormView.swift in Sources */,
+				853B4420854A636C48B4AA05 /* Hello.ice in Sources */,
+				AF3368D5FEC2DE720FCD8DCC /* HelloApp.swift in Sources */,
+				0B84FC7A1DBD12395CD05704 /* Images.xcassets in Sources */,
+				175365065B824E1063E7047F /* ProxySettings.swift in Sources */,
+				B9044FEB14C2A7B255978C93 /* ProxySettingsView.swift in Sources */,
+				D9AD135AF860DF831FB6A69E /* StatusView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		7577CED21E25CFCDE3358E32 /* Sources */ = {
+		4FEFFC8D3E4ED2998498AC1C /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				012744D82CE3F807640D2CFB /* Latency.ice in Sources */,
-				E19E5D5DD7E8770858F5E040 /* main.swift in Sources */,
+				214B68CB2F063337F09799A7 /* main.swift in Sources */,
+				C326729084F3BDF2B89032EB /* Printer.ice in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		7B49BB8710DBCF9B1D70593D /* Sources */ = {
+		54E6600DA7127307E591BB29 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				1F3B340EF766BA61F0B08CD2 /* Calculator.ice in Sources */,
-				23BB952CB080EB7669E7CA4B /* main.swift in Sources */,
+				F4587C50C2B3904121616A4C /* Callback.ice in Sources */,
+				9E587A7C05E39504A02E2A3F /* main.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		9644172CD096511C0A9EBADB /* Sources */ = {
+		602E3D7ACFEADA9C5E3A2B37 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				65B3E44AA5FA99BAF02DF56C /* main.swift in Sources */,
-				DAB863F961828C6E952AE8C5 /* Throughput.ice in Sources */,
+				9540FFBFAFE9D0F115F84D9C /* main.swift in Sources */,
+				69B3A9BAF94BF1D751AE173E /* Printer.ice in Sources */,
+				1C0050361F80EBD3F7DFC289 /* PrinterI.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		9B623055C93DB8E2D5B404C0 /* Sources */ = {
+		68ECB9131F0699AA196B6E2C /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				5E29756E2FF8DCD9F3375442 /* Clock.ice in Sources */,
-				189CC8E44C24B682E5B73B74 /* main.swift in Sources */,
+				C0008F417272E71FDD109C76 /* Contact.ice in Sources */,
+				86DD836836F8AAB208932965 /* main.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		A06425E3FEE942A5CBC3972B /* Sources */ = {
+		749F8AE1D113D4F4DA757F9A /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				273F47D0B153EC4DDC78EDD3 /* Calculator.ice in Sources */,
-				653C099B7C3B794B537D571E /* CalculatorI.swift in Sources */,
-				98FD99B2F95B728BABE886F2 /* main.swift in Sources */,
+				AE12B6685B006CF9F842809A /* Context.ice in Sources */,
+				DF57179F6952B1AF8C6268A7 /* ContextI.swift in Sources */,
+				5C3097B6D1B70FFB10073BFB /* main.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		A3918551C47C9B3EA0AFE69A /* Sources */ = {
+		7701E494882A290A6A90495F /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				439A5E7ECBB679919168E539 /* Hello.ice in Sources */,
-				C377BA1A96FF04FCEA92B469 /* main.swift in Sources */,
+				575D4A471155DCC43F0AF05C /* main.swift in Sources */,
+				9A8FA35CE6DF40B6D09916EF /* Throughput.ice in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		A55316A3F68FF56A8215BC00 /* Sources */ = {
+		7885C3ED5CBE41E64145B22F /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				96D4B6C4488BCA084AF4F6E8 /* main.swift in Sources */,
-				7353A648ECE4170F2E3982DB /* Throughput.ice in Sources */,
+				EFA669665A876BC4B9C17125 /* main.swift in Sources */,
+				D7B518045A8118EF63C0227F /* Printer.ice in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		B112D34B537C9F98D9D8200E /* Sources */ = {
+		7A23A4DEA118C7E7A87C1895 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				8F6FA82CEBDE0485B1D5A1D0 /* AddController.swift in Sources */,
-				2B9B3A87867530BD576120D0 /* AppDelegate.swift in Sources */,
-				A04A73365BE3993CF823B9A6 /* DetailController.swift in Sources */,
-				1B94DF311587E4C491B9C4B5 /* EditController.swift in Sources */,
-				FA0054A3FA0195F08D029C2E /* Glacier2Session.ice in Sources */,
-				628C34FA5FB884EF359DECEA /* Images.xcassets in Sources */,
-				BAC92AB7609E9A9402DCC9E6 /* LaunchScreen.storyboard in Sources */,
-				420E92FAB38094109B605E30 /* Library.ice in Sources */,
-				DB4C136A042C43441582BE38 /* LoginController.swift in Sources */,
-				696DF9C8A7E0EE94DA879672 /* Main.storyboard in Sources */,
-				658346FE10B77C5117F52905 /* MainController.swift in Sources */,
-				4E3A78D8A36A5671A7457522 /* Session.ice in Sources */,
+				91CDC2168F770FEED8E0FBB2 /* Context.ice in Sources */,
+				1265ECC72E822B50E61E6F04 /* main.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		B2B8BAABF7D0A25B4F2AC6FA /* Sources */ = {
+		7D04FC5C8B953CDA1C78601A /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				6E55D812FAB3E318566807FC /* Hello.ice in Sources */,
-				CF5D1035546F54AA16508EC7 /* main.swift in Sources */,
+				13B0C3F042D348005E3D46A5 /* Callback.ice in Sources */,
+				5947EF25FEF1852AFFA67C54 /* main.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		B4FA90133DE94D6CB2818AB0 /* Sources */ = {
+		8BD52FF86ECA3B23C8E68735 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				971C57C680EAC169FC02EB07 /* ChatApp.swift in Sources */,
-				FBFDD84EB23AAB23A4EA92B3 /* Chat.ice in Sources */,
-				79FC71B6C00515F6554F4D00 /* ChatController.swift in Sources */,
-				D520CD53A7272E3F76CFDEF8 /* ChatLayoutController.swift in Sources */,
-				3EDD9E4DE42C8D14C9FB73FD /* ChatMessage.swift in Sources */,
-				E40AAF9ECDB1DC1BD3038324 /* ChatSession.ice in Sources */,
-				542EAE25A13DA2240AF9C95E /* ChatUser.swift in Sources */,
-				76B0CC9749A0FD2086659FC3 /* Images.xcassets in Sources */,
-				A768655D27B3134D00E41232 /* LoginViewModel.swift in Sources */,
-				A768655B27B30C1400E41232 /* LoginView.swift in Sources */,
-				4D7FC87F7E92C427A0E2138E /* LaunchScreen.storyboard in Sources */,
-				21FC9E3C3F7CE1ED1AD557EE /* LoadingButton.swift in Sources */,
-				B48BED02CF9B848D55509544 /* LoginController.swift in Sources */,
-				816026404829D5A35EACCAB0 /* Main.storyboard in Sources */,
-				773CD9BD405602CC4D9E75EB /* UserController.swift in Sources */,
+				8CA95FBC0E4F686B42102558 /* Calculator.ice in Sources */,
+				7EA8FB037E3B6C3AED9E901D /* main.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		B661DB9A2C6DD169758116CB /* Sources */ = {
+		A0F798223E419C6C6BF91408 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				AC921078F74F097A83C382A1 /* Callback.ice in Sources */,
-				37C24239D197F413D4ECF065 /* main.swift in Sources */,
+				1B6371D511B784A96940484F /* Contact.ice in Sources */,
+				3C1A28F7E5FC5394E9ABEC8F /* ContactDBI.swift in Sources */,
+				16C1995FFBFE5A81D1268DD0 /* main.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		B7C5AF90DE4BA4CE3A355D76 /* Sources */ = {
+		A49C138998A46E8E183B57D9 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3A0DC095BA2E9C7244937739 /* main.swift in Sources */,
-				DF08480B7D2D2F3DAD99C17D /* Printer.ice in Sources */,
+				60CCC075B62A54A01A9D63D9 /* Hello.ice in Sources */,
+				F89948908CC42B7B4F1FD3AC /* main.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		BBF810073B51EA212D1AC7D3 /* Sources */ = {
+		AAE50D68B1C9317A5F585291 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D3A577BC7CEF918650C61888 /* Filesystem.ice in Sources */,
-				58071923E4C69FFB2574B507 /* main.swift in Sources */,
+				3CC84245E2B1F7F824D2EA74 /* Interceptor.ice in Sources */,
+				00F554D0DB7E35ACC7EF56CA /* main.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		C1EEC7E0AA00B36401390753 /* Sources */ = {
+		AD9D7A63897F93597E3163A0 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E5573B13B5795295AC3DF847 /* Hello.ice in Sources */,
-				27495FC8BBD356C1986E5C9C /* main.swift in Sources */,
+				7C4035897CE368F0DF488028 /* main.swift in Sources */,
+				9966CAF7B2CC58AEB0AEC923 /* Printer.ice in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		C97EE7DFEA138DE5CB32D73E /* Sources */ = {
+		BBFB30DA0A83A63910B9308E /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E10589D62D38D85C70649931 /* Latency.ice in Sources */,
-				2F68EBF269EFB214472DED67 /* main.swift in Sources */,
+				36004CB4D5B856B14A3E889A /* Calculator.ice in Sources */,
+				6121241C8714AF7E773741E4 /* CalculatorI.swift in Sources */,
+				60AB6E4A0349D347225A13AA /* main.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		CA16CC530E3D90E1BB5B33DD /* Sources */ = {
+		BEC58BA0163CD9AEC40DA224 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				0F0E266C863347E471DF073D /* Callback.ice in Sources */,
-				04BFD2897CE795156CA4484F /* main.swift in Sources */,
+				EF7F03E90E0B5B7A2E708BFB /* Latency.ice in Sources */,
+				DEAD603C28B5B937A7C9FE52 /* main.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		CF89B487D0F59617290EFB1B /* Sources */ = {
+		C2AFF7E114034DD15D760C56 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				04B7C8E052A627FA98A73090 /* AuthenticatorI.swift in Sources */,
-				687B1ADE5368310A18CB30E0 /* Interceptor.ice in Sources */,
-				B06D18012CA6C84AE560F0EF /* InterceptorI.swift in Sources */,
-				D5B38FD0965B231BFCA35FAC /* main.swift in Sources */,
-				7CB3535DD7D6FA84A89D1C95 /* ThermostatI.swift in Sources */,
+				2E36354DF6812EF628C19038 /* Hello.ice in Sources */,
+				627515A621F1BA62F1CD6ECF /* main.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		D28962DA0F3BE31F9BCB0B8C /* Sources */ = {
+		DC3B4132043C84955037EF33 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B48CA0948BD515FC09B1E9E1 /* Callback.ice in Sources */,
-				9EF25EF302D1ABC9E3BAB900 /* main.swift in Sources */,
+				CC84EF4225A42C39840D22BB /* Hello.ice in Sources */,
+				B96EE41312E856DC5672E7D8 /* main.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		DECDEB8818E0946DA78818FF /* Sources */ = {
+		E4D9818D14FD9450FCFEC081 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				15901BA8CE490342871BB691 /* Clock.ice in Sources */,
-				4A845BF3450D904C2282B13B /* main.swift in Sources */,
+				DCF636456F36001A6EA7C34A /* Hello.ice in Sources */,
+				9A93844AD18C53965BFAA34A /* main.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		E0C081321BCB9F1B77A85C62 /* Sources */ = {
+		E7F14E1A64FBE800E9498876 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3BDB6BCD538D6558C0A3C2B6 /* Hello.ice in Sources */,
-				F864B4DFE6BC8FF86450C43F /* main.swift in Sources */,
+				A4A84A7AF129A92CFEA02EFE /* Hello.ice in Sources */,
+				82A76BD99F4C717CC5C8D845 /* main.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		E6B5183C96E544B2503BA43C /* Sources */ = {
+		F0AE8FB038522A98FD1C8A52 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				76FAE53B0DCB8497E129C238 /* Filesystem.ice in Sources */,
-				D1B981738EDC4A5E05085E5B /* main.swift in Sources */,
+				5E2F18583109C2BD7BD1A9C6 /* Hello.ice in Sources */,
+				2CA203928AFA063EBBA9F85D /* main.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		E708D1D0FBF7F4CB157BBB3D /* Sources */ = {
+		F2397CD6E1716C3AF63143F9 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				4E74FA37692914846608E9B3 /* main.swift in Sources */,
-				A22582AC862B7043984455EB /* Printer.ice in Sources */,
+				1729EFFCB0FE273A9B3B8951 /* Chat.ice in Sources */,
+				8E1C8D210C07D4CA5DE948DC /* ChatApp.swift in Sources */,
+				9A225E418433F86974FECD0D /* ChatMessage.swift in Sources */,
+				7E4AF05B39992CDFC83F7009 /* ChatSession.ice in Sources */,
+				558DEDB163066F9D8C84E61C /* ChatUser.swift in Sources */,
+				FB6D97DE5F0214392DC5CDEE /* Client.swift in Sources */,
+				961F7B866A9C98232B527C7F /* Images.xcassets in Sources */,
+				7012BE8703C2C3CC6CB35F4C /* LoginView.swift in Sources */,
+				00F3CF5A0B1DD007F8592D19 /* LoginViewModel.swift in Sources */,
+				5A66EC165731718CF499A31C /* MessageView.swift in Sources */,
+				F224573363F1E92C07784182 /* UsersView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		FA5F1D0A1D02DA68D0C4B363 /* Sources */ = {
+		FE813AE76FF06FA4229330DE /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				2C9DA92045119442FC6B8234 /* Context.ice in Sources */,
-				3680F02DE13628156E750A59 /* main.swift in Sources */,
+				BD29E4F73D90A28F709C1207 /* Filesystem.ice in Sources */,
+				3666EDE056135C2DE0579617 /* main.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		00B75381BE2E52F48EBC5140 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = IceDiscoveryHelloClient;
-			target = 0040AFB2BDF7A4FC5F2A6D3C /* IceDiscoveryHelloClient */;
-			targetProxy = 32580EE14DCB3BCF2F65AE30 /* PBXContainerItemProxy */;
-		};
-		038ED7F75A5BCFF70973AF20 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = IceGridSimpleClient;
-			target = 86A3F4B19E9DAF9E4B15533A /* IceGridSimpleClient */;
-			targetProxy = 6491F8D00990393771B8F183 /* PBXContainerItemProxy */;
-		};
-		08AEF213CAED9BF2856DEFB4 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = IceInvokeClient;
-			target = 445F4A8EEC5CA2028C536DAE /* IceInvokeClient */;
-			targetProxy = DE931F7C741B82B2FDB72FD8 /* PBXContainerItemProxy */;
-		};
-		0FCDFFCC3FAF47DE74413225 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = ManualPrinterServer;
-			target = 50C7DC4E4B424490F7F59AE9 /* ManualPrinterServer */;
-			targetProxy = 8E2311577DAE7E84D5AA1B42 /* PBXContainerItemProxy */;
-		};
-		1577F9299978B3890A54E257 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = ManualSimpleFilesystemServer;
-			target = 3455DFD133AC5C33DE41401D /* ManualSimpleFilesystemServer */;
-			targetProxy = 4DB1ABC150490B92360C177F /* PBXContainerItemProxy */;
-		};
-		18347D6FA0FECAC333A54628 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = IceMinimalServer;
-			target = A02EBE57139105D20DA043C0 /* IceMinimalServer */;
-			targetProxy = B545F81D50CB3D7B9A451E89 /* PBXContainerItemProxy */;
-		};
-		1BD6BCFE0865FBFFD3BCCD7E /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = IceThroughputClient;
-			target = CBE5A662859EB3A829D935EB /* IceThroughputClient */;
-			targetProxy = D6F219FF84D3918D6583F27C /* PBXContainerItemProxy */;
-		};
-		23D414EA07E1AFD5004D88D6 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = IceInterceptorClient;
-			target = 3487D0246103973B15740CF3 /* IceInterceptorClient */;
-			targetProxy = AD0AE6C0E54FE4BFB06C2697 /* PBXContainerItemProxy */;
-		};
-		24AACACA2C3C1F5D5A6CF027 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = IceContextServer;
-			target = A16D90A9F6AFEC8E5F36B277 /* IceContextServer */;
-			targetProxy = 496E4631D7AF70ED5C5371CF /* PBXContainerItemProxy */;
-		};
-		250E3F02C2BE3DB314C33E9D /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = IceDiscoveryReplicationClient;
-			target = 9B342C4AF32DBB323A3A0BBA /* IceDiscoveryReplicationClient */;
-			targetProxy = F7F0CED654AF02F62EB32D4E /* PBXContainerItemProxy */;
-		};
-		274B653A9DCD88E484951978 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = IceInvokeServer;
-			target = 08FFABF181D09958170A8064 /* IceInvokeServer */;
-			targetProxy = 925AB48A70315B4700A85490 /* PBXContainerItemProxy */;
-		};
-		29C15E18FACE12B826CC602A /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = IceGridSimpleServer;
-			target = E542D48F2448F7F27D80BDD0 /* IceGridSimpleServer */;
-			targetProxy = 9CD7BC101525588F9A305BC2 /* PBXContainerItemProxy */;
-		};
-		39FECAC6848FBBB8781C14DB /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = IceBidirClient;
-			target = 4E426E1AF0E71376C9E873BB /* IceBidirClient */;
-			targetProxy = 0D5EC3148FBA8C2B030FED9B /* PBXContainerItemProxy */;
-		};
-		3A4EC9DEF376C8A2C2E2457A /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = IceAsyncServer;
-			target = 838136AD0308E0D7D7EC2582 /* IceAsyncServer */;
-			targetProxy = B58269CF98B8FF7734EF3245 /* PBXContainerItemProxy */;
-		};
-		3E8863DF944743A87E76EB2C /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = IceStormClockSubscriber;
-			target = 1FD7893AE80DF5B104A80BA6 /* IceStormClockSubscriber */;
-			targetProxy = 79DF54AEFCFCBD27E7722B49 /* PBXContainerItemProxy */;
-		};
-		4359A7D36CEC11510E4E18D3 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = IceOptionalServer;
-			target = 3D0479F643E6EBFDE4F41251 /* IceOptionalServer */;
-			targetProxy = 46C321BF94C54FC8E80C981E /* PBXContainerItemProxy */;
-		};
-		4B11F505145FD07325AE4D3B /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = IceAsyncInvocationServer;
-			target = E3DF7A1C971AE032647A29C2 /* IceAsyncInvocationServer */;
-			targetProxy = 4C7B9532FD369B0CD4F2BA0E /* PBXContainerItemProxy */;
-		};
-		50BB4A971C2479A9227AE981 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = IceLatencyServer;
-			target = ACB5ECC440F9694952C7B84C /* IceLatencyServer */;
-			targetProxy = 6B2CE321A1AF81EC076EE1B6 /* PBXContainerItemProxy */;
-		};
-		51FFF76CF4FAAF2BD34E6C32 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = IceHelloClient;
-			target = E7FF091AC675DE1B5A97F3BB /* IceHelloClient */;
-			targetProxy = 0C326F9191A3BC5085FEDAAB /* PBXContainerItemProxy */;
-		};
-		612164092DAD6EE1D0AB8B85 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = IceHelloServer;
-			target = FB515029F564EEC25346D66A /* IceHelloServer */;
-			targetProxy = 90ECED75B4BCAAAD7AACD646 /* PBXContainerItemProxy */;
-		};
-		6EEE960E0AF569D8D84BF275 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = IOSLibrary;
-			target = A61365A18C78646CBE55C376 /* IOSLibrary */;
-			targetProxy = 9A271DC17146B86DA5DACEB2 /* PBXContainerItemProxy */;
-		};
-		8642B58056EEFCDE51A7487C /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = Glacier2CallbackClient;
-			target = 2EC0D18A54E54780FF0CA0C0 /* Glacier2CallbackClient */;
-			targetProxy = 9F0BB33D5C40039916D6C3A0 /* PBXContainerItemProxy */;
-		};
-		8C1BBD9E0AB1286274578416 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = IceOptionalClient;
-			target = 7B111AE4525C41AA7E021233 /* IceOptionalClient */;
-			targetProxy = 96E5E20EB84280144F4B6CB6 /* PBXContainerItemProxy */;
-		};
-		8F0AA37B537B93BE444DD675 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = IceMinimalClient;
-			target = 1CEA3A13E08931B50C514BD0 /* IceMinimalClient */;
-			targetProxy = B90DA744A66E504BD1D4E123 /* PBXContainerItemProxy */;
-		};
-		97C1AE5BB572FAC6FA23652C /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = IceBidirServer;
-			target = 5B5E6A9FEB4E4E67A418460C /* IceBidirServer */;
-			targetProxy = 36293BFD5862D1D023D4CB45 /* PBXContainerItemProxy */;
-		};
-		9B478DA634B9080BB3BF17B8 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = IceAsyncInvocationClient;
-			target = BC411A1038EBE1215648035D /* IceAsyncInvocationClient */;
-			targetProxy = 2F688196AAAF35FF9346B413 /* PBXContainerItemProxy */;
-		};
-		AC0ED34772EFEE4878163911 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = IOSChat;
-			target = A6F15048BA62D0740B115770 /* IOSChat */;
-			targetProxy = 0B8904A274FA8C175C4A41CD /* PBXContainerItemProxy */;
-		};
-		B422DFAA60337F3CD152DCC1 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = IceContextClient;
-			target = C55F08EC4140C753CCD40E6B /* IceContextClient */;
-			targetProxy = D3CB513EA8768662AA501F26 /* PBXContainerItemProxy */;
-		};
-		B7D276A5B0AB292D9C39BC99 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = IceAsyncClient;
-			target = 1687F343DF79EA8213972141 /* IceAsyncClient */;
-			targetProxy = 62429F39B0C45A9586D91065 /* PBXContainerItemProxy */;
-		};
-		B971437E6D70C55A12E1FDBC /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = IceDiscoveryHelloServer;
-			target = A8AC5929B89E3A59CD81EB3D /* IceDiscoveryHelloServer */;
-			targetProxy = E01866E3BCE5FC272665ADE2 /* PBXContainerItemProxy */;
-		};
-		C08105BB25A45067CAB1DE1B /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = ManualPrinterClient;
-			target = 7F125170B599E70103C6F1A4 /* ManualPrinterClient */;
-			targetProxy = 80721687FF88494EECD69774 /* PBXContainerItemProxy */;
-		};
-		C61207F300A72A690664152B /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = IceStormClockPublisher;
-			target = 5DEB7AA4511B4B1F1983ECA8 /* IceStormClockPublisher */;
-			targetProxy = 58654AD4C1F3A66A5A3F89A4 /* PBXContainerItemProxy */;
-		};
-		CDE843D008407AFEA297381C /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = Glacier2CallbackServer;
-			target = 17295EE8D54F50AC8BC95360 /* Glacier2CallbackServer */;
-			targetProxy = AC3C14F11F3C4BC182C89A3E /* PBXContainerItemProxy */;
-		};
-		D55DF6A601457DF20F0C0C0C /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = IceDiscoveryReplicationServer;
-			target = 5C6AA42A0C3A9B8309B6C879 /* IceDiscoveryReplicationServer */;
-			targetProxy = 876D1AD5C3397DF0EF0D741F /* PBXContainerItemProxy */;
-		};
-		E6AAA4689E95C4E7FEF48CE9 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = IOSHello;
-			target = 7E534192D654D74C4E38373F /* IOSHello */;
-			targetProxy = E7FD8E9F0157ADF9CEDE027A /* PBXContainerItemProxy */;
-		};
-		E9F172792E6793986D995EFF /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = IceLatencyClient;
-			target = F278530FC73733F84C3B351A /* IceLatencyClient */;
-			targetProxy = 3BE12E835AE5543B5C79C159 /* PBXContainerItemProxy */;
-		};
-		F31F06743418391112B9156A /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = ManualSimpleFilesystemClient;
-			target = 365E2519E773257B91EA2017 /* ManualSimpleFilesystemClient */;
-			targetProxy = 40E8EBE9EF91F747A6E3CA0E /* PBXContainerItemProxy */;
-		};
-		F91F7471A68B14B4E740FE87 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = IceThroughputServer;
-			target = D8B2F755F5313CF3ED40667F /* IceThroughputServer */;
-			targetProxy = F022B798F9FE24514D10A1EE /* PBXContainerItemProxy */;
-		};
-		FD5858CA3B99530B41B9A412 /* PBXTargetDependency */ = {
+		01DD30D29654DEED9C4A7C89 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = IceInterceptorServer;
-			target = 58E3C656CAC60E5D4435A63A /* IceInterceptorServer */;
-			targetProxy = 1D4D47606BCAE753A4E145F1 /* PBXContainerItemProxy */;
+			target = BD669BA1D9DFD486901D342F /* IceInterceptorServer */;
+			targetProxy = EE190BFC55A3A86826C1867C /* PBXContainerItemProxy */;
+		};
+		037B66B1DF156544A0C981E2 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = IceStormClockSubscriber;
+			target = 42561EDFCCB220DEAFE26FA5 /* IceStormClockSubscriber */;
+			targetProxy = 12BC6DBA93A63CE93CFAEC1C /* PBXContainerItemProxy */;
+		};
+		0B15DF218F143DA698BB5B4C /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = IceLatencyServer;
+			target = 1D324440A0F5469DC7B3CE68 /* IceLatencyServer */;
+			targetProxy = FB3D45D8E6A951CB97876B42 /* PBXContainerItemProxy */;
+		};
+		0E9C60E366FA1091486E9FB9 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = IceGridSimpleServer;
+			target = 90C4A14E104360C2D66BE95A /* IceGridSimpleServer */;
+			targetProxy = 459C995D4CBF28C828BA4500 /* PBXContainerItemProxy */;
+		};
+		168B9AF410BA123F0331368B /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = ManualSimpleFilesystemClient;
+			target = 0EDB6F8830769A463C145F4E /* ManualSimpleFilesystemClient */;
+			targetProxy = B922C62E381FA912414D5E6F /* PBXContainerItemProxy */;
+		};
+		1732FC86934641DD7C82ED54 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = IceOptionalClient;
+			target = 6C69582EEABAE4429977B37A /* IceOptionalClient */;
+			targetProxy = AABCC613B7BDD2ACEB26957D /* PBXContainerItemProxy */;
+		};
+		2ACFC4CA2E9E4A7818C42288 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = IceInvokeClient;
+			target = 99EA7DE41DE8CC2A65D1B2C8 /* IceInvokeClient */;
+			targetProxy = B212E327713138C5FD46DF62 /* PBXContainerItemProxy */;
+		};
+		32D404291A138CBF7445457D /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = IceHelloUI;
+			target = 6D9EBD901A955C9B5D5C1AE3 /* IceHelloUI */;
+			targetProxy = CF99885B13A30AECF185306A /* PBXContainerItemProxy */;
+		};
+		4082A1D396FDAC8BF191CBDE /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = IceDiscoveryHelloServer;
+			target = 0F333E1C9E6C91C3396F59A2 /* IceDiscoveryHelloServer */;
+			targetProxy = 6C50C7437414AA4024DCC632 /* PBXContainerItemProxy */;
+		};
+		42F7418347052AC796518BE4 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = IceHelloClient;
+			target = 8DEC3881159900B77EBC1E89 /* IceHelloClient */;
+			targetProxy = 2B4201EE481CA31C1F87C519 /* PBXContainerItemProxy */;
+		};
+		49EF65C7366CE4013C26ACB2 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = ManualPrinterServer;
+			target = 21FA6A38274DBCD88814D274 /* ManualPrinterServer */;
+			targetProxy = 1B595A8F668E5DE4E3AA841B /* PBXContainerItemProxy */;
+		};
+		579022A6C784181BEA957D2F /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = IceContextClient;
+			target = AED3746019CE470B01C4CD89 /* IceContextClient */;
+			targetProxy = 88A1582DED14101E99B6812E /* PBXContainerItemProxy */;
+		};
+		57BAB662204CF9021499D0F3 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = IceAsyncServer;
+			target = 68AAF193626BC30C4CD8884F /* IceAsyncServer */;
+			targetProxy = 23329BBA8240C37E6D0CB6EC /* PBXContainerItemProxy */;
+		};
+		582F0A2D6DE95524F1F3D962 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = IceHelloServer;
+			target = 4159934A7B7D66A462AA96E3 /* IceHelloServer */;
+			targetProxy = 586A12EA69F5986ECADC392A /* PBXContainerItemProxy */;
+		};
+		5E9EBDF97052E70FC2CCEC1B /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = IceDiscoveryReplicationClient;
+			target = 1E2F71AC52A0BDDD354133D0 /* IceDiscoveryReplicationClient */;
+			targetProxy = 4A17D782CD94AEDD43B56621 /* PBXContainerItemProxy */;
+		};
+		637E05839E642841783A90D3 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = IceDiscoveryReplicationServer;
+			target = 2EE15C61DC2F49143CC9488C /* IceDiscoveryReplicationServer */;
+			targetProxy = 693851ED711E0AA8C57F836C /* PBXContainerItemProxy */;
+		};
+		6560E1FBF39DB646E9AB8B3E /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = IceMinimalClient;
+			target = 75886DD9A8F4E2B5F19D1A9A /* IceMinimalClient */;
+			targetProxy = 76162E42F6EA83C50C4CD30B /* PBXContainerItemProxy */;
+		};
+		689CE6F4DF1663CB744F9ACA /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = ManualPrinterClient;
+			target = F658A5FB5551039F774F74EF /* ManualPrinterClient */;
+			targetProxy = 0D4B87CAF2AB5ED21484FE00 /* PBXContainerItemProxy */;
+		};
+		7089618FD8A699A719F28D5F /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Glacier2CallbackClient;
+			target = 8421E27006F16414C9BB2D92 /* Glacier2CallbackClient */;
+			targetProxy = DC0A32D69BA2E81EE1521147 /* PBXContainerItemProxy */;
+		};
+		7247F613DE578A0B4069F821 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = IceStormClockPublisher;
+			target = 7B02D53AC9CADE3781497FE2 /* IceStormClockPublisher */;
+			targetProxy = 41B1C5D8558987074E8CCBC9 /* PBXContainerItemProxy */;
+		};
+		793754CF654E1426BD7E66FB /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = IceAsyncClient;
+			target = F4A581497FDEB379F7675C88 /* IceAsyncClient */;
+			targetProxy = 1E59D26711F97FF5AA590F38 /* PBXContainerItemProxy */;
+		};
+		8B44D35DB33B5415B29E52A3 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = IceAsyncInvocationClient;
+			target = CBAB61F561408159107E5665 /* IceAsyncInvocationClient */;
+			targetProxy = 3C2B6E1A2CBF84BDE6D1889A /* PBXContainerItemProxy */;
+		};
+		951D1991CEAC4320B6D10942 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = IceThroughputServer;
+			target = 07CAFE2F01A2B040FC16287C /* IceThroughputServer */;
+			targetProxy = 825CF42FBA0BB797CFC97167 /* PBXContainerItemProxy */;
+		};
+		98D3E2467E544C3CDCCBD2BE /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = IceGridSimpleClient;
+			target = C389294E4BB98ADFCDF8F54E /* IceGridSimpleClient */;
+			targetProxy = 2C77E4A4622047D8F9B53150 /* PBXContainerItemProxy */;
+		};
+		A5F2B36B1AE7D7B006420AA1 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = IceMinimalServer;
+			target = E9CFD638AD4E2EBE3E1F95DB /* IceMinimalServer */;
+			targetProxy = 872D375B18F897D681C365E6 /* PBXContainerItemProxy */;
+		};
+		B8E6F4C7424A84ED74B88335 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = IceDiscoveryHelloClient;
+			target = 0AE8C7670A42B03A39CDA3C5 /* IceDiscoveryHelloClient */;
+			targetProxy = CBA2AC9F58B2138EE35A9A9E /* PBXContainerItemProxy */;
+		};
+		BF8CF25EA66E3620D7053049 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = IceBidirClient;
+			target = 10114A97EDF918D7074BC9E8 /* IceBidirClient */;
+			targetProxy = CFFFE07FC37E166E6D9702E4 /* PBXContainerItemProxy */;
+		};
+		C3CAB674ECB6C48279B430AB /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = IceLatencyClient;
+			target = 2B975A6278F9D6CCE53F5E35 /* IceLatencyClient */;
+			targetProxy = 9FE6D59A8B101A8FB42E49D5 /* PBXContainerItemProxy */;
+		};
+		C4DEF31513B56972675327B8 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = IceAsyncInvocationServer;
+			target = 60AFAA9D313FD61836B69D3F /* IceAsyncInvocationServer */;
+			targetProxy = 85E9E22044F8C7EFC493A2EB /* PBXContainerItemProxy */;
+		};
+		D22999AB39F8CDC111B6000A /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = IceContextServer;
+			target = 9575E4AABF609C87FECCF75E /* IceContextServer */;
+			targetProxy = A941037954E59C14479BCF89 /* PBXContainerItemProxy */;
+		};
+		D7DC377DE69F289B38B05FB5 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = IceInvokeServer;
+			target = 764B259011A33FA3A95412E9 /* IceInvokeServer */;
+			targetProxy = 019C952AD7D957641982816E /* PBXContainerItemProxy */;
+		};
+		D8C278C6C249D8CD61E50127 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = IceInterceptorClient;
+			target = E24362D5509CD78EA3C2E846 /* IceInterceptorClient */;
+			targetProxy = 8439A11095CF8CA0A9C2781F /* PBXContainerItemProxy */;
+		};
+		DA25943E0D914247B65BA4A1 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = IceThroughputClient;
+			target = 456CC1D6828C3983EF2241D5 /* IceThroughputClient */;
+			targetProxy = 8211C3572D64C32021F0A6C2 /* PBXContainerItemProxy */;
+		};
+		EA5671547B692482337FD413 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Glacier2CallbackServer;
+			target = 62CD0C57C3183B4C1ACFB7E7 /* Glacier2CallbackServer */;
+			targetProxy = AD6C40A15EE50A6155CC4003 /* PBXContainerItemProxy */;
+		};
+		EA8278621D3263AB19531A65 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = ManualSimpleFilesystemServer;
+			target = A52F7C41BC31497EF70154BB /* ManualSimpleFilesystemServer */;
+			targetProxy = 6BF0C8C662B26EB383206C40 /* PBXContainerItemProxy */;
+		};
+		F9CA7967F0940009623A811F /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = IceOptionalServer;
+			target = 010C5E8438CC6EBBB1D05568 /* IceOptionalServer */;
+			targetProxy = 2E0E6DF0C05D1FDC6DBACE80 /* PBXContainerItemProxy */;
+		};
+		F9F8D085703B8CAC45BF9243 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = IceDiscoveryHelloUI;
+			target = 5DA2E0F891AB6C1C5B232CE4 /* IceDiscoveryHelloUI */;
+			targetProxy = 41E3CB0D985C31D3E71B9D80 /* PBXContainerItemProxy */;
+		};
+		FA71B179D01BD4D9F0637DE8 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Chat;
+			target = 0BF52782AF7FCCEF27A337AE /* Chat */;
+			targetProxy = 3D9D5FFA64F8FBC4FAA88852 /* PBXContainerItemProxy */;
+		};
+		FE3B17ECCECE2198CF0A6A3C /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = IceBidirServer;
+			target = 9514BAF35E560E29ACF6770A /* IceBidirServer */;
+			targetProxy = 8F70203498C72724369E6EB4 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
-		00B671CBA60F60B187379F7A /* Debug */ = {
+		028D86C9D76AB40A61813D18 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_STYLE = Automatic;
+				CONFIGURATION_BUILD_DIR = $SRCROOT/Ice/helloUI/Build;
+				CURRENT_PROJECT_VERSION = 3.7.7;
+				DYLIB_COMPATIBILITY_VERSION = 0;
+				DYLIB_CURRENT_VERSION = 3.7.7;
+				ENABLE_TESTABILITY = NO;
+				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
+				INFOPLIST_FILE = $SRCROOT/Ice/helloUI/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.helloui;
+				PRODUCT_NAME = helloui;
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		05ED89259B19CEC493DE14A9 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CONFIGURATION_BUILD_DIR = $SRCROOT/Ice/latency/Build;
+				CURRENT_PROJECT_VERSION = 3.7.7;
+				DYLIB_COMPATIBILITY_VERSION = 0;
+				DYLIB_CURRENT_VERSION = 3.7.7;
+				ENABLE_TESTABILITY = NO;
+				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.client;
+				PRODUCT_NAME = client;
+				SDKROOT = macosx;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		091F709A456B00D7A231A51D /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
@@ -4886,14 +4904,166 @@
 				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.subscriber;
-				PRODUCT_NAME = subscriber;
+				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.publisher;
+				PRODUCT_NAME = publisher;
+				SDKROOT = macosx;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		0EC620666B04344A291AB009 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CONFIGURATION_BUILD_DIR = $SRCROOT/Ice/minimal/Build;
+				CURRENT_PROJECT_VERSION = 3.7.7;
+				DYLIB_COMPATIBILITY_VERSION = 0;
+				DYLIB_CURRENT_VERSION = 3.7.7;
+				ENABLE_TESTABILITY = NO;
+				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.client;
+				PRODUCT_NAME = client;
 				SDKROOT = macosx;
 				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
-		034D67E8ADE2B4D70BA3AB38 /* Release */ = {
+		156C01803FA828D820217C1E /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CONFIGURATION_BUILD_DIR = $SRCROOT/Manual/printer/Build;
+				CURRENT_PROJECT_VERSION = 3.7.7;
+				DYLIB_COMPATIBILITY_VERSION = 0;
+				DYLIB_CURRENT_VERSION = 3.7.7;
+				ENABLE_TESTABILITY = NO;
+				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.client;
+				PRODUCT_NAME = client;
+				SDKROOT = macosx;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		15AB6A3DE2D1AD2371134914 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CONFIGURATION_BUILD_DIR = $SRCROOT/IceGrid/simple/Build;
+				CURRENT_PROJECT_VERSION = 3.7.7;
+				DYLIB_COMPATIBILITY_VERSION = 0;
+				DYLIB_CURRENT_VERSION = 3.7.7;
+				ENABLE_TESTABILITY = NO;
+				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.server;
+				PRODUCT_NAME = server;
+				SDKROOT = macosx;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		1DA209434B4975DBB048EE42 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CONFIGURATION_BUILD_DIR = $SRCROOT/IceDiscovery/hello/Build;
+				CURRENT_PROJECT_VERSION = 3.7.7;
+				DYLIB_COMPATIBILITY_VERSION = 0;
+				DYLIB_CURRENT_VERSION = 3.7.7;
+				ENABLE_TESTABILITY = NO;
+				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.server;
+				PRODUCT_NAME = server;
+				SDKROOT = macosx;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		2605856688B8FA5051969784 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CONFIGURATION_BUILD_DIR = $SRCROOT/Ice/throughput/Build;
+				CURRENT_PROJECT_VERSION = 3.7.7;
+				DYLIB_COMPATIBILITY_VERSION = 0;
+				DYLIB_CURRENT_VERSION = 3.7.7;
+				ENABLE_TESTABILITY = NO;
+				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.server;
+				PRODUCT_NAME = server;
+				SDKROOT = macosx;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		2A26B38787D72B11A8B39A88 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CONFIGURATION_BUILD_DIR = $SRCROOT/IceDiscovery/hello/Build;
+				CURRENT_PROJECT_VERSION = 3.7.7;
+				DYLIB_COMPATIBILITY_VERSION = 0;
+				DYLIB_CURRENT_VERSION = 3.7.7;
+				ENABLE_TESTABILITY = NO;
+				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.client;
+				PRODUCT_NAME = client;
+				SDKROOT = macosx;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		2A2C869CBE59D8A68D68718F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CONFIGURATION_BUILD_DIR = $SRCROOT/IceDiscovery/hello/Build;
+				CURRENT_PROJECT_VERSION = 3.7.7;
+				DYLIB_COMPATIBILITY_VERSION = 0;
+				DYLIB_CURRENT_VERSION = 3.7.7;
+				ENABLE_TESTABILITY = NO;
+				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.server;
+				PRODUCT_NAME = server;
+				SDKROOT = macosx;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		2A86F4E8459969ADA861B4A2 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CONFIGURATION_BUILD_DIR = $SRCROOT/Ice/invoke/Build;
+				CURRENT_PROJECT_VERSION = 3.7.7;
+				DYLIB_COMPATIBILITY_VERSION = 0;
+				DYLIB_CURRENT_VERSION = 3.7.7;
+				ENABLE_TESTABILITY = NO;
+				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.client;
+				PRODUCT_NAME = client;
+				SDKROOT = macosx;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		2FEB317A27B7CD52E6E89A6D /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
@@ -4912,7 +5082,562 @@
 			};
 			name = Release;
 		};
-		053C3B2A38A55047B9D10578 /* Debug */ = {
+		3113627ED588E986D3E126B3 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CONFIGURATION_BUILD_DIR = $SRCROOT/Ice/interceptor/Build;
+				CURRENT_PROJECT_VERSION = 3.7.7;
+				DYLIB_COMPATIBILITY_VERSION = 0;
+				DYLIB_CURRENT_VERSION = 3.7.7;
+				ENABLE_TESTABILITY = NO;
+				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.server;
+				PRODUCT_NAME = server;
+				SDKROOT = macosx;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		316485E8AE37725665C8BBD0 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CONFIGURATION_BUILD_DIR = $SRCROOT/Ice/async/Build;
+				CURRENT_PROJECT_VERSION = 3.7.7;
+				DYLIB_COMPATIBILITY_VERSION = 0;
+				DYLIB_CURRENT_VERSION = 3.7.7;
+				ENABLE_TESTABILITY = NO;
+				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.client;
+				PRODUCT_NAME = client;
+				SDKROOT = macosx;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		337FAE90BEBF00DA3A226BF3 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CONFIGURATION_BUILD_DIR = $SRCROOT/Ice/context/Build;
+				CURRENT_PROJECT_VERSION = 3.7.7;
+				DYLIB_COMPATIBILITY_VERSION = 0;
+				DYLIB_CURRENT_VERSION = 3.7.7;
+				ENABLE_TESTABILITY = NO;
+				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.client;
+				PRODUCT_NAME = client;
+				SDKROOT = macosx;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		33D54B152C19AEC682C2A44B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CONFIGURATION_BUILD_DIR = $SRCROOT/Ice/asyncInvocation/Build;
+				CURRENT_PROJECT_VERSION = 3.7.7;
+				DYLIB_COMPATIBILITY_VERSION = 0;
+				DYLIB_CURRENT_VERSION = 3.7.7;
+				ENABLE_TESTABILITY = NO;
+				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.client;
+				PRODUCT_NAME = client;
+				SDKROOT = macosx;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		390516ADE1A0416301049B1E /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CONFIGURATION_BUILD_DIR = $SRCROOT/Ice/invoke/Build;
+				CURRENT_PROJECT_VERSION = 3.7.7;
+				DYLIB_COMPATIBILITY_VERSION = 0;
+				DYLIB_CURRENT_VERSION = 3.7.7;
+				ENABLE_TESTABILITY = NO;
+				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.server;
+				PRODUCT_NAME = server;
+				SDKROOT = macosx;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		39E2B1F43D6AF024EA415FBB /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CONFIGURATION_BUILD_DIR = $SRCROOT/Glacier2/callback/Build;
+				CURRENT_PROJECT_VERSION = 3.7.7;
+				DYLIB_COMPATIBILITY_VERSION = 0;
+				DYLIB_CURRENT_VERSION = 3.7.7;
+				ENABLE_TESTABILITY = NO;
+				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.server;
+				PRODUCT_NAME = server;
+				SDKROOT = macosx;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		3A232A25B936A7AF4B0CBE42 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CONFIGURATION_BUILD_DIR = $SRCROOT/Glacier2/callback/Build;
+				CURRENT_PROJECT_VERSION = 3.7.7;
+				DYLIB_COMPATIBILITY_VERSION = 0;
+				DYLIB_CURRENT_VERSION = 3.7.7;
+				ENABLE_TESTABILITY = NO;
+				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.server;
+				PRODUCT_NAME = server;
+				SDKROOT = macosx;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		3F055D80CD85A102965BB95D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CONFIGURATION_BUILD_DIR = $SRCROOT/Ice/interceptor/Build;
+				CURRENT_PROJECT_VERSION = 3.7.7;
+				DYLIB_COMPATIBILITY_VERSION = 0;
+				DYLIB_CURRENT_VERSION = 3.7.7;
+				ENABLE_TESTABILITY = NO;
+				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.client;
+				PRODUCT_NAME = client;
+				SDKROOT = macosx;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		3F8CCA34BA576329381B4D10 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CONFIGURATION_BUILD_DIR = $SRCROOT/Ice/bidir/Build;
+				CURRENT_PROJECT_VERSION = 3.7.7;
+				DYLIB_COMPATIBILITY_VERSION = 0;
+				DYLIB_CURRENT_VERSION = 3.7.7;
+				ENABLE_TESTABILITY = NO;
+				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.client;
+				PRODUCT_NAME = client;
+				SDKROOT = macosx;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		4149BBCC742FD233D827A63D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CONFIGURATION_BUILD_DIR = $SRCROOT/Manual/simpleFilesystem/Build;
+				CURRENT_PROJECT_VERSION = 3.7.7;
+				DYLIB_COMPATIBILITY_VERSION = 0;
+				DYLIB_CURRENT_VERSION = 3.7.7;
+				ENABLE_TESTABILITY = NO;
+				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.server;
+				PRODUCT_NAME = server;
+				SDKROOT = macosx;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		41BBCEE2FC76DBDA507A5F02 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CONFIGURATION_BUILD_DIR = $SRCROOT/Ice/throughput/Build;
+				CURRENT_PROJECT_VERSION = 3.7.7;
+				DYLIB_COMPATIBILITY_VERSION = 0;
+				DYLIB_CURRENT_VERSION = 3.7.7;
+				ENABLE_TESTABILITY = NO;
+				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.client;
+				PRODUCT_NAME = client;
+				SDKROOT = macosx;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		49BFE8B6B3A09BD86E113E07 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CONFIGURATION_BUILD_DIR = $SRCROOT/Ice/context/Build;
+				CURRENT_PROJECT_VERSION = 3.7.7;
+				DYLIB_COMPATIBILITY_VERSION = 0;
+				DYLIB_CURRENT_VERSION = 3.7.7;
+				ENABLE_TESTABILITY = NO;
+				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.client;
+				PRODUCT_NAME = client;
+				SDKROOT = macosx;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		4FAA844BCC74DFD0FC944587 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CONFIGURATION_BUILD_DIR = $SRCROOT/IceDiscovery/hello/Build;
+				CURRENT_PROJECT_VERSION = 3.7.7;
+				DYLIB_COMPATIBILITY_VERSION = 0;
+				DYLIB_CURRENT_VERSION = 3.7.7;
+				ENABLE_TESTABILITY = NO;
+				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.client;
+				PRODUCT_NAME = client;
+				SDKROOT = macosx;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		500CFED525CB329756D98F91 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CONFIGURATION_BUILD_DIR = $SRCROOT/Manual/simpleFilesystem/Build;
+				CURRENT_PROJECT_VERSION = 3.7.7;
+				DYLIB_COMPATIBILITY_VERSION = 0;
+				DYLIB_CURRENT_VERSION = 3.7.7;
+				ENABLE_TESTABILITY = NO;
+				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.server;
+				PRODUCT_NAME = server;
+				SDKROOT = macosx;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		5038A500F9673E81A2484ADF /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CONFIGURATION_BUILD_DIR = $SRCROOT/Manual/simpleFilesystem/Build;
+				CURRENT_PROJECT_VERSION = 3.7.7;
+				DYLIB_COMPATIBILITY_VERSION = 0;
+				DYLIB_CURRENT_VERSION = 3.7.7;
+				ENABLE_TESTABILITY = NO;
+				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.client;
+				PRODUCT_NAME = client;
+				SDKROOT = macosx;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		55A6EF20796E6059A3C3C070 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+			};
+			name = Release;
+		};
+		58B073BF736BC6EF24EE4B24 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CONFIGURATION_BUILD_DIR = $SRCROOT/Ice/bidir/Build;
+				CURRENT_PROJECT_VERSION = 3.7.7;
+				DYLIB_COMPATIBILITY_VERSION = 0;
+				DYLIB_CURRENT_VERSION = 3.7.7;
+				ENABLE_TESTABILITY = NO;
+				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.server;
+				PRODUCT_NAME = server;
+				SDKROOT = macosx;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		5A909F7A0BD4EA2BB1DAE7D2 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CONFIGURATION_BUILD_DIR = $SRCROOT/Ice/optional/Build;
+				CURRENT_PROJECT_VERSION = 3.7.7;
+				DYLIB_COMPATIBILITY_VERSION = 0;
+				DYLIB_CURRENT_VERSION = 3.7.7;
+				ENABLE_TESTABILITY = NO;
+				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.server;
+				PRODUCT_NAME = server;
+				SDKROOT = macosx;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		5B9E7A3B7A9F948935D22DA5 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CONFIGURATION_BUILD_DIR = $SRCROOT/IceDiscovery/replication/Build;
+				CURRENT_PROJECT_VERSION = 3.7.7;
+				DYLIB_COMPATIBILITY_VERSION = 0;
+				DYLIB_CURRENT_VERSION = 3.7.7;
+				ENABLE_TESTABILITY = NO;
+				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.server;
+				PRODUCT_NAME = server;
+				SDKROOT = macosx;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		5F8BA6FA36DC4C102F431EE9 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CONFIGURATION_BUILD_DIR = $SRCROOT/Ice/minimal/Build;
+				CURRENT_PROJECT_VERSION = 3.7.7;
+				DYLIB_COMPATIBILITY_VERSION = 0;
+				DYLIB_CURRENT_VERSION = 3.7.7;
+				ENABLE_TESTABILITY = NO;
+				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.client;
+				PRODUCT_NAME = client;
+				SDKROOT = macosx;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		622B5FE7145597B27D7A80A2 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CONFIGURATION_BUILD_DIR = $SRCROOT/Ice/throughput/Build;
+				CURRENT_PROJECT_VERSION = 3.7.7;
+				DYLIB_COMPATIBILITY_VERSION = 0;
+				DYLIB_CURRENT_VERSION = 3.7.7;
+				ENABLE_TESTABILITY = NO;
+				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.server;
+				PRODUCT_NAME = server;
+				SDKROOT = macosx;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		6AF8E346CC87BF8648CBFB5D /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CONFIGURATION_BUILD_DIR = $SRCROOT/IceGrid/simple/Build;
+				CURRENT_PROJECT_VERSION = 3.7.7;
+				DYLIB_COMPATIBILITY_VERSION = 0;
+				DYLIB_CURRENT_VERSION = 3.7.7;
+				ENABLE_TESTABILITY = NO;
+				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.client;
+				PRODUCT_NAME = client;
+				SDKROOT = macosx;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		6C722A44FDA78ECCB27A591B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_STYLE = Automatic;
+				CONFIGURATION_BUILD_DIR = $SRCROOT/Chat/Build;
+				CURRENT_PROJECT_VERSION = 3.7.7;
+				DYLIB_COMPATIBILITY_VERSION = 0;
+				DYLIB_CURRENT_VERSION = 3.7.7;
+				ENABLE_TESTABILITY = NO;
+				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
+				INFOPLIST_FILE = $SRCROOT/Chat/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.chat;
+				PRODUCT_NAME = chat;
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		6D3C40E199710152DF80288D /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_STYLE = Automatic;
+				CONFIGURATION_BUILD_DIR = $SRCROOT/IceDiscovery/helloUI/Build;
+				CURRENT_PROJECT_VERSION = 3.7.7;
+				DYLIB_COMPATIBILITY_VERSION = 0;
+				DYLIB_CURRENT_VERSION = 3.7.7;
+				ENABLE_TESTABILITY = NO;
+				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
+				INFOPLIST_FILE = $SRCROOT/IceDiscovery/helloUI/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.helloui;
+				PRODUCT_NAME = helloui;
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		6D9B5C5F68E7F1E843B51C0B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+			};
+			name = Debug;
+		};
+		6E268A2A349787FA0408C7A1 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_STYLE = Automatic;
+				CONFIGURATION_BUILD_DIR = $SRCROOT/Ice/helloUI/Build;
+				CURRENT_PROJECT_VERSION = 3.7.7;
+				DYLIB_COMPATIBILITY_VERSION = 0;
+				DYLIB_CURRENT_VERSION = 3.7.7;
+				ENABLE_TESTABILITY = NO;
+				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
+				INFOPLIST_FILE = $SRCROOT/Ice/helloUI/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.helloui;
+				PRODUCT_NAME = helloui;
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		71A138B08578C7965D40AAF1 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CONFIGURATION_BUILD_DIR = $SRCROOT/Ice/hello/Build;
+				CURRENT_PROJECT_VERSION = 3.7.7;
+				DYLIB_COMPATIBILITY_VERSION = 0;
+				DYLIB_CURRENT_VERSION = 3.7.7;
+				ENABLE_TESTABILITY = NO;
+				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.server;
+				PRODUCT_NAME = server;
+				SDKROOT = macosx;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		76778A79C1B8B51402ED4F62 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CONFIGURATION_BUILD_DIR = $SRCROOT/Ice/optional/Build;
+				CURRENT_PROJECT_VERSION = 3.7.7;
+				DYLIB_COMPATIBILITY_VERSION = 0;
+				DYLIB_CURRENT_VERSION = 3.7.7;
+				ENABLE_TESTABILITY = NO;
+				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.server;
+				PRODUCT_NAME = server;
+				SDKROOT = macosx;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		769445F5EFC5894D6E707E10 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CONFIGURATION_BUILD_DIR = $SRCROOT/Ice/latency/Build;
+				CURRENT_PROJECT_VERSION = 3.7.7;
+				DYLIB_COMPATIBILITY_VERSION = 0;
+				DYLIB_CURRENT_VERSION = 3.7.7;
+				ENABLE_TESTABILITY = NO;
+				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.client;
+				PRODUCT_NAME = client;
+				SDKROOT = macosx;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		7711B1AB30D9554481C861D0 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
@@ -4931,11 +5656,68 @@
 			};
 			name = Debug;
 		};
-		0B0C24EB35FEBE60DD7E8569 /* Debug */ = {
+		78199483C24CF9D3992966DD /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CONFIGURATION_BUILD_DIR = $SRCROOT/Ice/context/Build;
+				CONFIGURATION_BUILD_DIR = $SRCROOT/IceDiscovery/replication/Build;
+				CURRENT_PROJECT_VERSION = 3.7.7;
+				DYLIB_COMPATIBILITY_VERSION = 0;
+				DYLIB_CURRENT_VERSION = 3.7.7;
+				ENABLE_TESTABILITY = NO;
+				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.client;
+				PRODUCT_NAME = client;
+				SDKROOT = macosx;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		79EA14AABEF3A708D9C669BB /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CONFIGURATION_BUILD_DIR = $SRCROOT/Ice/asyncInvocation/Build;
+				CURRENT_PROJECT_VERSION = 3.7.7;
+				DYLIB_COMPATIBILITY_VERSION = 0;
+				DYLIB_CURRENT_VERSION = 3.7.7;
+				ENABLE_TESTABILITY = NO;
+				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.server;
+				PRODUCT_NAME = server;
+				SDKROOT = macosx;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		7B63E7538AE56147A1979AB7 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CONFIGURATION_BUILD_DIR = $SRCROOT/IceStorm/clock/Build;
+				CURRENT_PROJECT_VERSION = 3.7.7;
+				DYLIB_COMPATIBILITY_VERSION = 0;
+				DYLIB_CURRENT_VERSION = 3.7.7;
+				ENABLE_TESTABILITY = NO;
+				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.publisher;
+				PRODUCT_NAME = publisher;
+				SDKROOT = macosx;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		7B74831F0B9F7FF01381ABA8 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CONFIGURATION_BUILD_DIR = $SRCROOT/Manual/printer/Build;
 				CURRENT_PROJECT_VERSION = 3.7.7;
 				DYLIB_COMPATIBILITY_VERSION = 0;
 				DYLIB_CURRENT_VERSION = 3.7.7;
@@ -4950,7 +5732,129 @@
 			};
 			name = Debug;
 		};
-		0DC365C6F13604DB8AC6269D /* Release */ = {
+		7D606C62D052B01E37C1A2B9 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CONFIGURATION_BUILD_DIR = $SRCROOT/Ice/minimal/Build;
+				CURRENT_PROJECT_VERSION = 3.7.7;
+				DYLIB_COMPATIBILITY_VERSION = 0;
+				DYLIB_CURRENT_VERSION = 3.7.7;
+				ENABLE_TESTABILITY = NO;
+				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.server;
+				PRODUCT_NAME = server;
+				SDKROOT = macosx;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		815457A20AE6C6C919FE1612 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CONFIGURATION_BUILD_DIR = $SRCROOT/IceDiscovery/replication/Build;
+				CURRENT_PROJECT_VERSION = 3.7.7;
+				DYLIB_COMPATIBILITY_VERSION = 0;
+				DYLIB_CURRENT_VERSION = 3.7.7;
+				ENABLE_TESTABILITY = NO;
+				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.server;
+				PRODUCT_NAME = server;
+				SDKROOT = macosx;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		8224FAC00B9330CC0BA09163 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+			};
+			name = Debug;
+		};
+		828D7E53635E62D8923EBDD5 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CONFIGURATION_BUILD_DIR = $SRCROOT/Glacier2/callback/Build;
+				CURRENT_PROJECT_VERSION = 3.7.7;
+				DYLIB_COMPATIBILITY_VERSION = 0;
+				DYLIB_CURRENT_VERSION = 3.7.7;
+				ENABLE_TESTABILITY = NO;
+				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.client;
+				PRODUCT_NAME = client;
+				SDKROOT = macosx;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		896E7BC2BB7B78EF89796ACB /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CONFIGURATION_BUILD_DIR = $SRCROOT/Ice/optional/Build;
+				CURRENT_PROJECT_VERSION = 3.7.7;
+				DYLIB_COMPATIBILITY_VERSION = 0;
+				DYLIB_CURRENT_VERSION = 3.7.7;
+				ENABLE_TESTABILITY = NO;
+				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.client;
+				PRODUCT_NAME = client;
+				SDKROOT = macosx;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		8BA771EF72F9A59F1D2F25FF /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CONFIGURATION_BUILD_DIR = $SRCROOT/Ice/invoke/Build;
+				CURRENT_PROJECT_VERSION = 3.7.7;
+				DYLIB_COMPATIBILITY_VERSION = 0;
+				DYLIB_CURRENT_VERSION = 3.7.7;
+				ENABLE_TESTABILITY = NO;
+				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.server;
+				PRODUCT_NAME = server;
+				SDKROOT = macosx;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		8C551B3E30AEA80FE95726EA /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CONFIGURATION_BUILD_DIR = $SRCROOT/Manual/printer/Build;
+				CURRENT_PROJECT_VERSION = 3.7.7;
+				DYLIB_COMPATIBILITY_VERSION = 0;
+				DYLIB_CURRENT_VERSION = 3.7.7;
+				ENABLE_TESTABILITY = NO;
+				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.server;
+				PRODUCT_NAME = server;
+				SDKROOT = macosx;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		991B9BA687032F2A11F97E8F /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
@@ -4969,34 +5873,83 @@
 			};
 			name = Release;
 		};
-		102B35F5A51F49D7F812C021 /* Debug */ = {
+		9A9FDF61F8B8D8FC22373C13 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
-				CONFIGURATION_BUILD_DIR = $SRCROOT/iOS/library/Build;
+				CONFIGURATION_BUILD_DIR = $SRCROOT/Ice/bidir/Build;
 				CURRENT_PROJECT_VERSION = 3.7.7;
 				DYLIB_COMPATIBILITY_VERSION = 0;
 				DYLIB_CURRENT_VERSION = 3.7.7;
 				ENABLE_TESTABILITY = NO;
 				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
-				INFOPLIST_FILE = $SRCROOT/iOS/library/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.library;
-				PRODUCT_NAME = library;
-				SDKROOT = iphoneos;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.server;
+				PRODUCT_NAME = server;
+				SDKROOT = macosx;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		9CB329F96B7018B9E47D193C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CONFIGURATION_BUILD_DIR = $SRCROOT/IceDiscovery/replication/Build;
+				CURRENT_PROJECT_VERSION = 3.7.7;
+				DYLIB_COMPATIBILITY_VERSION = 0;
+				DYLIB_CURRENT_VERSION = 3.7.7;
+				ENABLE_TESTABILITY = NO;
+				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.client;
+				PRODUCT_NAME = client;
+				SDKROOT = macosx;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
-		1213193D803DCB7CAE0BD9D9 /* Release */ = {
+		9DB30F7671B23A5438051D54 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CONFIGURATION_BUILD_DIR = $SRCROOT/Ice/throughput/Build;
+				CURRENT_PROJECT_VERSION = 3.7.7;
+				DYLIB_COMPATIBILITY_VERSION = 0;
+				DYLIB_CURRENT_VERSION = 3.7.7;
+				ENABLE_TESTABILITY = NO;
+				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.client;
+				PRODUCT_NAME = client;
+				SDKROOT = macosx;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		9E925F3AC6A1B05703D3DEC9 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CONFIGURATION_BUILD_DIR = $SRCROOT/Ice/asyncInvocation/Build;
+				CURRENT_PROJECT_VERSION = 3.7.7;
+				DYLIB_COMPATIBILITY_VERSION = 0;
+				DYLIB_CURRENT_VERSION = 3.7.7;
+				ENABLE_TESTABILITY = NO;
+				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.client;
+				PRODUCT_NAME = client;
+				SDKROOT = macosx;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		9F457F5243AD5125A424CBE8 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
@@ -5015,45 +5968,7 @@
 			};
 			name = Release;
 		};
-		12B8816C59658BC7E5F8DAED /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
-				CONFIGURATION_BUILD_DIR = $SRCROOT/Ice/optional/Build;
-				CURRENT_PROJECT_VERSION = 3.7.7;
-				DYLIB_COMPATIBILITY_VERSION = 0;
-				DYLIB_CURRENT_VERSION = 3.7.7;
-				ENABLE_TESTABILITY = NO;
-				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.client;
-				PRODUCT_NAME = client;
-				SDKROOT = macosx;
-				SWIFT_VERSION = 5.0;
-			};
-			name = Debug;
-		};
-		12C0C4CD0CB9858743FBD8A7 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
-				CONFIGURATION_BUILD_DIR = $SRCROOT/Ice/bidir/Build;
-				CURRENT_PROJECT_VERSION = 3.7.7;
-				DYLIB_COMPATIBILITY_VERSION = 0;
-				DYLIB_CURRENT_VERSION = 3.7.7;
-				ENABLE_TESTABILITY = NO;
-				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.client;
-				PRODUCT_NAME = client;
-				SDKROOT = macosx;
-				SWIFT_VERSION = 5.0;
-			};
-			name = Debug;
-		};
-		14105F15DF779392C3FFB54A /* Debug */ = {
+		A6CFC8DDF09D13C6A346BED8 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -5114,49 +6029,11 @@
 			};
 			name = Debug;
 		};
-		1741C491FB8B9B465601394A /* Release */ = {
+		ACC176A228177B656DBCBEEF /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CONFIGURATION_BUILD_DIR = $SRCROOT/IceDiscovery/hello/Build;
-				CURRENT_PROJECT_VERSION = 3.7.7;
-				DYLIB_COMPATIBILITY_VERSION = 0;
-				DYLIB_CURRENT_VERSION = 3.7.7;
-				ENABLE_TESTABILITY = NO;
-				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.server;
-				PRODUCT_NAME = server;
-				SDKROOT = macosx;
-				SWIFT_VERSION = 5.0;
-			};
-			name = Release;
-		};
-		1918FAD67CB6344D00144B8B /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
-				CONFIGURATION_BUILD_DIR = $SRCROOT/Manual/printer/Build;
-				CURRENT_PROJECT_VERSION = 3.7.7;
-				DYLIB_COMPATIBILITY_VERSION = 0;
-				DYLIB_CURRENT_VERSION = 3.7.7;
-				ENABLE_TESTABILITY = NO;
-				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.client;
-				PRODUCT_NAME = client;
-				SDKROOT = macosx;
-				SWIFT_VERSION = 5.0;
-			};
-			name = Debug;
-		};
-		1B80DC959D4731E8A06A2D75 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
-				CONFIGURATION_BUILD_DIR = $SRCROOT/Manual/simpleFilesystem/Build;
+				CONFIGURATION_BUILD_DIR = $SRCROOT/Ice/async/Build;
 				CURRENT_PROJECT_VERSION = 3.7.7;
 				DYLIB_COMPATIBILITY_VERSION = 0;
 				DYLIB_CURRENT_VERSION = 3.7.7;
@@ -5171,344 +6048,7 @@
 			};
 			name = Debug;
 		};
-		1EDB53FF3CFE8704BD41D5B6 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
-				CONFIGURATION_BUILD_DIR = $SRCROOT/IceDiscovery/replication/Build;
-				CURRENT_PROJECT_VERSION = 3.7.7;
-				DYLIB_COMPATIBILITY_VERSION = 0;
-				DYLIB_CURRENT_VERSION = 3.7.7;
-				ENABLE_TESTABILITY = NO;
-				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.client;
-				PRODUCT_NAME = client;
-				SDKROOT = macosx;
-				SWIFT_VERSION = 5.0;
-			};
-			name = Release;
-		};
-		23D2365F8E0CAA5B8EC17ADA /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
-				CONFIGURATION_BUILD_DIR = $SRCROOT/Ice/context/Build;
-				CURRENT_PROJECT_VERSION = 3.7.7;
-				DYLIB_COMPATIBILITY_VERSION = 0;
-				DYLIB_CURRENT_VERSION = 3.7.7;
-				ENABLE_TESTABILITY = NO;
-				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.server;
-				PRODUCT_NAME = server;
-				SDKROOT = macosx;
-				SWIFT_VERSION = 5.0;
-			};
-			name = Release;
-		};
-		36083E176E8AEFFA7DB2E8EB /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
-				CONFIGURATION_BUILD_DIR = $SRCROOT/Manual/simpleFilesystem/Build;
-				CURRENT_PROJECT_VERSION = 3.7.7;
-				DYLIB_COMPATIBILITY_VERSION = 0;
-				DYLIB_CURRENT_VERSION = 3.7.7;
-				ENABLE_TESTABILITY = NO;
-				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.server;
-				PRODUCT_NAME = server;
-				SDKROOT = macosx;
-				SWIFT_VERSION = 5.0;
-			};
-			name = Release;
-		};
-		3789F343831BD43A1A50D909 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
-				CONFIGURATION_BUILD_DIR = $SRCROOT/Ice/minimal/Build;
-				CURRENT_PROJECT_VERSION = 3.7.7;
-				DYLIB_COMPATIBILITY_VERSION = 0;
-				DYLIB_CURRENT_VERSION = 3.7.7;
-				ENABLE_TESTABILITY = NO;
-				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.server;
-				PRODUCT_NAME = server;
-				SDKROOT = macosx;
-				SWIFT_VERSION = 5.0;
-			};
-			name = Release;
-		};
-		37908F8FB5B8D8AD7AAE7B8C /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
-				CONFIGURATION_BUILD_DIR = $SRCROOT/Ice/asyncInvocation/Build;
-				CURRENT_PROJECT_VERSION = 3.7.7;
-				DYLIB_COMPATIBILITY_VERSION = 0;
-				DYLIB_CURRENT_VERSION = 3.7.7;
-				ENABLE_TESTABILITY = NO;
-				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.client;
-				PRODUCT_NAME = client;
-				SDKROOT = macosx;
-				SWIFT_VERSION = 5.0;
-			};
-			name = Debug;
-		};
-		3C25CC6DCF6AB067C0324C7D /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
-				CONFIGURATION_BUILD_DIR = $SRCROOT/Manual/printer/Build;
-				CURRENT_PROJECT_VERSION = 3.7.7;
-				DYLIB_COMPATIBILITY_VERSION = 0;
-				DYLIB_CURRENT_VERSION = 3.7.7;
-				ENABLE_TESTABILITY = NO;
-				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.server;
-				PRODUCT_NAME = server;
-				SDKROOT = macosx;
-				SWIFT_VERSION = 5.0;
-			};
-			name = Release;
-		};
-		40AA439BFC0AD26390F486FD /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-			};
-			name = Release;
-		};
-		494BCF085AFC513E9941DD9D /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_IDENTITY = "-";
-				CODE_SIGN_STYLE = Automatic;
-				CONFIGURATION_BUILD_DIR = $SRCROOT/iOS/hello/Build;
-				CURRENT_PROJECT_VERSION = 3.7.7;
-				DYLIB_COMPATIBILITY_VERSION = 0;
-				DYLIB_CURRENT_VERSION = 3.7.7;
-				ENABLE_TESTABILITY = NO;
-				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
-				INFOPLIST_FILE = $SRCROOT/iOS/hello/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.hello;
-				PRODUCT_NAME = hello;
-				SDKROOT = iphoneos;
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VALIDATE_PRODUCT = YES;
-			};
-			name = Release;
-		};
-		4A5239FED72B70BD9F498DFB /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
-				CONFIGURATION_BUILD_DIR = $SRCROOT/Ice/bidir/Build;
-				CURRENT_PROJECT_VERSION = 3.7.7;
-				DYLIB_COMPATIBILITY_VERSION = 0;
-				DYLIB_CURRENT_VERSION = 3.7.7;
-				ENABLE_TESTABILITY = NO;
-				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.server;
-				PRODUCT_NAME = server;
-				SDKROOT = macosx;
-				SWIFT_VERSION = 5.0;
-			};
-			name = Debug;
-		};
-		4EB0919EF735DF84681BC62A /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
-				CONFIGURATION_BUILD_DIR = $SRCROOT/IceDiscovery/replication/Build;
-				CURRENT_PROJECT_VERSION = 3.7.7;
-				DYLIB_COMPATIBILITY_VERSION = 0;
-				DYLIB_CURRENT_VERSION = 3.7.7;
-				ENABLE_TESTABILITY = NO;
-				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.client;
-				PRODUCT_NAME = client;
-				SDKROOT = macosx;
-				SWIFT_VERSION = 5.0;
-			};
-			name = Debug;
-		};
-		53F5782132F976AFBC9AF1E6 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
-				CONFIGURATION_BUILD_DIR = $SRCROOT/IceGrid/simple/Build;
-				CURRENT_PROJECT_VERSION = 3.7.7;
-				DYLIB_COMPATIBILITY_VERSION = 0;
-				DYLIB_CURRENT_VERSION = 3.7.7;
-				ENABLE_TESTABILITY = NO;
-				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.client;
-				PRODUCT_NAME = client;
-				SDKROOT = macosx;
-				SWIFT_VERSION = 5.0;
-			};
-			name = Release;
-		};
-		5776BBEBD687D5BA0C565C27 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
-				CONFIGURATION_BUILD_DIR = $SRCROOT/Ice/context/Build;
-				CURRENT_PROJECT_VERSION = 3.7.7;
-				DYLIB_COMPATIBILITY_VERSION = 0;
-				DYLIB_CURRENT_VERSION = 3.7.7;
-				ENABLE_TESTABILITY = NO;
-				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.client;
-				PRODUCT_NAME = client;
-				SDKROOT = macosx;
-				SWIFT_VERSION = 5.0;
-			};
-			name = Release;
-		};
-		58F2F9F6B85203078019106C /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
-				CONFIGURATION_BUILD_DIR = $SRCROOT/Ice/interceptor/Build;
-				CURRENT_PROJECT_VERSION = 3.7.7;
-				DYLIB_COMPATIBILITY_VERSION = 0;
-				DYLIB_CURRENT_VERSION = 3.7.7;
-				ENABLE_TESTABILITY = NO;
-				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.server;
-				PRODUCT_NAME = server;
-				SDKROOT = macosx;
-				SWIFT_VERSION = 5.0;
-			};
-			name = Debug;
-		};
-		59CC2B7195F29EEE4256DB6D /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
-				CONFIGURATION_BUILD_DIR = $SRCROOT/Ice/invoke/Build;
-				CURRENT_PROJECT_VERSION = 3.7.7;
-				DYLIB_COMPATIBILITY_VERSION = 0;
-				DYLIB_CURRENT_VERSION = 3.7.7;
-				ENABLE_TESTABILITY = NO;
-				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.client;
-				PRODUCT_NAME = client;
-				SDKROOT = macosx;
-				SWIFT_VERSION = 5.0;
-			};
-			name = Release;
-		};
-		5E7E436E4CF130C2A6C6CCB3 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-			};
-			name = Release;
-		};
-		634F479605E95F55081E27C9 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
-				CONFIGURATION_BUILD_DIR = $SRCROOT/Ice/hello/Build;
-				CURRENT_PROJECT_VERSION = 3.7.7;
-				DYLIB_COMPATIBILITY_VERSION = 0;
-				DYLIB_CURRENT_VERSION = 3.7.7;
-				ENABLE_TESTABILITY = NO;
-				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.server;
-				PRODUCT_NAME = server;
-				SDKROOT = macosx;
-				SWIFT_VERSION = 5.0;
-			};
-			name = Debug;
-		};
-		63D664366B6CAC1B40A1EF02 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
-				CONFIGURATION_BUILD_DIR = $SRCROOT/IceDiscovery/hello/Build;
-				CURRENT_PROJECT_VERSION = 3.7.7;
-				DYLIB_COMPATIBILITY_VERSION = 0;
-				DYLIB_CURRENT_VERSION = 3.7.7;
-				ENABLE_TESTABILITY = NO;
-				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.client;
-				PRODUCT_NAME = client;
-				SDKROOT = macosx;
-				SWIFT_VERSION = 5.0;
-			};
-			name = Debug;
-		};
-		682E4D139F369A688C2D29E5 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
-				CONFIGURATION_BUILD_DIR = $SRCROOT/Ice/optional/Build;
-				CURRENT_PROJECT_VERSION = 3.7.7;
-				DYLIB_COMPATIBILITY_VERSION = 0;
-				DYLIB_CURRENT_VERSION = 3.7.7;
-				ENABLE_TESTABILITY = NO;
-				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.server;
-				PRODUCT_NAME = server;
-				SDKROOT = macosx;
-				SWIFT_VERSION = 5.0;
-			};
-			name = Release;
-		};
-		6C800835E7834989B32C172C /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-			};
-			name = Debug;
-		};
-		6CFA08F03E0B3E9778C4756A /* Release */ = {
+		B53B535F653F4C73D6DDBD00 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
@@ -5527,737 +6067,7 @@
 			};
 			name = Release;
 		};
-		6DC37799209C88562F336769 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
-				CONFIGURATION_BUILD_DIR = $SRCROOT/Ice/async/Build;
-				CURRENT_PROJECT_VERSION = 3.7.7;
-				DYLIB_COMPATIBILITY_VERSION = 0;
-				DYLIB_CURRENT_VERSION = 3.7.7;
-				ENABLE_TESTABILITY = NO;
-				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.client;
-				PRODUCT_NAME = client;
-				SDKROOT = macosx;
-				SWIFT_VERSION = 5.0;
-			};
-			name = Debug;
-		};
-		762FDEFE42EFD0CC20823982 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
-				CONFIGURATION_BUILD_DIR = $SRCROOT/Ice/minimal/Build;
-				CURRENT_PROJECT_VERSION = 3.7.7;
-				DYLIB_COMPATIBILITY_VERSION = 0;
-				DYLIB_CURRENT_VERSION = 3.7.7;
-				ENABLE_TESTABILITY = NO;
-				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.client;
-				PRODUCT_NAME = client;
-				SDKROOT = macosx;
-				SWIFT_VERSION = 5.0;
-			};
-			name = Release;
-		};
-		789D544B21CC97ABC3F07AD3 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
-				CONFIGURATION_BUILD_DIR = $SRCROOT/Ice/minimal/Build;
-				CURRENT_PROJECT_VERSION = 3.7.7;
-				DYLIB_COMPATIBILITY_VERSION = 0;
-				DYLIB_CURRENT_VERSION = 3.7.7;
-				ENABLE_TESTABILITY = NO;
-				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.client;
-				PRODUCT_NAME = client;
-				SDKROOT = macosx;
-				SWIFT_VERSION = 5.0;
-			};
-			name = Debug;
-		};
-		78C83DCEDC220426D770CF62 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
-				CONFIGURATION_BUILD_DIR = $SRCROOT/Ice/throughput/Build;
-				CURRENT_PROJECT_VERSION = 3.7.7;
-				DYLIB_COMPATIBILITY_VERSION = 0;
-				DYLIB_CURRENT_VERSION = 3.7.7;
-				ENABLE_TESTABILITY = NO;
-				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.client;
-				PRODUCT_NAME = client;
-				SDKROOT = macosx;
-				SWIFT_VERSION = 5.0;
-			};
-			name = Debug;
-		};
-		79E6B1C4C88048586569A0AC /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
-				CONFIGURATION_BUILD_DIR = $SRCROOT/IceGrid/simple/Build;
-				CURRENT_PROJECT_VERSION = 3.7.7;
-				DYLIB_COMPATIBILITY_VERSION = 0;
-				DYLIB_CURRENT_VERSION = 3.7.7;
-				ENABLE_TESTABILITY = NO;
-				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.server;
-				PRODUCT_NAME = server;
-				SDKROOT = macosx;
-				SWIFT_VERSION = 5.0;
-			};
-			name = Debug;
-		};
-		7D2B3326C48D8DFFB2B0E239 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
-				CONFIGURATION_BUILD_DIR = $SRCROOT/Ice/asyncInvocation/Build;
-				CURRENT_PROJECT_VERSION = 3.7.7;
-				DYLIB_COMPATIBILITY_VERSION = 0;
-				DYLIB_CURRENT_VERSION = 3.7.7;
-				ENABLE_TESTABILITY = NO;
-				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.server;
-				PRODUCT_NAME = server;
-				SDKROOT = macosx;
-				SWIFT_VERSION = 5.0;
-			};
-			name = Release;
-		};
-		86AC4E509FF91E6EF7C92909 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
-				CONFIGURATION_BUILD_DIR = $SRCROOT/Ice/asyncInvocation/Build;
-				CURRENT_PROJECT_VERSION = 3.7.7;
-				DYLIB_COMPATIBILITY_VERSION = 0;
-				DYLIB_CURRENT_VERSION = 3.7.7;
-				ENABLE_TESTABILITY = NO;
-				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.client;
-				PRODUCT_NAME = client;
-				SDKROOT = macosx;
-				SWIFT_VERSION = 5.0;
-			};
-			name = Release;
-		};
-		87793D4601C002BE84D4F8B2 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
-				CONFIGURATION_BUILD_DIR = $SRCROOT/Ice/interceptor/Build;
-				CURRENT_PROJECT_VERSION = 3.7.7;
-				DYLIB_COMPATIBILITY_VERSION = 0;
-				DYLIB_CURRENT_VERSION = 3.7.7;
-				ENABLE_TESTABILITY = NO;
-				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.server;
-				PRODUCT_NAME = server;
-				SDKROOT = macosx;
-				SWIFT_VERSION = 5.0;
-			};
-			name = Release;
-		};
-		8C21D439F9D70641E36F1171 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
-				CONFIGURATION_BUILD_DIR = $SRCROOT/Glacier2/callback/Build;
-				CURRENT_PROJECT_VERSION = 3.7.7;
-				DYLIB_COMPATIBILITY_VERSION = 0;
-				DYLIB_CURRENT_VERSION = 3.7.7;
-				ENABLE_TESTABILITY = NO;
-				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.server;
-				PRODUCT_NAME = server;
-				SDKROOT = macosx;
-				SWIFT_VERSION = 5.0;
-			};
-			name = Release;
-		};
-		8D02263610FFDD7F7ADFB56C /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_IDENTITY = "-";
-				CODE_SIGN_STYLE = Automatic;
-				CONFIGURATION_BUILD_DIR = $SRCROOT/iOS/library/Build;
-				CURRENT_PROJECT_VERSION = 3.7.7;
-				DYLIB_COMPATIBILITY_VERSION = 0;
-				DYLIB_CURRENT_VERSION = 3.7.7;
-				ENABLE_TESTABILITY = NO;
-				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
-				INFOPLIST_FILE = $SRCROOT/iOS/library/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.library;
-				PRODUCT_NAME = library;
-				SDKROOT = iphoneos;
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VALIDATE_PRODUCT = YES;
-			};
-			name = Release;
-		};
-		8D201BA967715A9CE7742029 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
-				CONFIGURATION_BUILD_DIR = $SRCROOT/IceDiscovery/hello/Build;
-				CURRENT_PROJECT_VERSION = 3.7.7;
-				DYLIB_COMPATIBILITY_VERSION = 0;
-				DYLIB_CURRENT_VERSION = 3.7.7;
-				ENABLE_TESTABILITY = NO;
-				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.server;
-				PRODUCT_NAME = server;
-				SDKROOT = macosx;
-				SWIFT_VERSION = 5.0;
-			};
-			name = Debug;
-		};
-		9107666E46354F8B9E60A2F2 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
-				CONFIGURATION_BUILD_DIR = $SRCROOT/IceGrid/simple/Build;
-				CURRENT_PROJECT_VERSION = 3.7.7;
-				DYLIB_COMPATIBILITY_VERSION = 0;
-				DYLIB_CURRENT_VERSION = 3.7.7;
-				ENABLE_TESTABILITY = NO;
-				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.client;
-				PRODUCT_NAME = client;
-				SDKROOT = macosx;
-				SWIFT_VERSION = 5.0;
-			};
-			name = Debug;
-		};
-		93D48069BD208CC83B9EA772 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
-				CONFIGURATION_BUILD_DIR = $SRCROOT/Ice/invoke/Build;
-				CURRENT_PROJECT_VERSION = 3.7.7;
-				DYLIB_COMPATIBILITY_VERSION = 0;
-				DYLIB_CURRENT_VERSION = 3.7.7;
-				ENABLE_TESTABILITY = NO;
-				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.server;
-				PRODUCT_NAME = server;
-				SDKROOT = macosx;
-				SWIFT_VERSION = 5.0;
-			};
-			name = Release;
-		};
-		95630C54420CBAA9ECECE4B0 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
-				CONFIGURATION_BUILD_DIR = $SRCROOT/Manual/simpleFilesystem/Build;
-				CURRENT_PROJECT_VERSION = 3.7.7;
-				DYLIB_COMPATIBILITY_VERSION = 0;
-				DYLIB_CURRENT_VERSION = 3.7.7;
-				ENABLE_TESTABILITY = NO;
-				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.client;
-				PRODUCT_NAME = client;
-				SDKROOT = macosx;
-				SWIFT_VERSION = 5.0;
-			};
-			name = Release;
-		};
-		98429C901A8EE200ED3311F5 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
-				CONFIGURATION_BUILD_DIR = $SRCROOT/Glacier2/callback/Build;
-				CURRENT_PROJECT_VERSION = 3.7.7;
-				DYLIB_COMPATIBILITY_VERSION = 0;
-				DYLIB_CURRENT_VERSION = 3.7.7;
-				ENABLE_TESTABILITY = NO;
-				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.client;
-				PRODUCT_NAME = client;
-				SDKROOT = macosx;
-				SWIFT_VERSION = 5.0;
-			};
-			name = Debug;
-		};
-		98A645DA3A90EDD264F6017C /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
-				CONFIGURATION_BUILD_DIR = $SRCROOT/Ice/latency/Build;
-				CURRENT_PROJECT_VERSION = 3.7.7;
-				DYLIB_COMPATIBILITY_VERSION = 0;
-				DYLIB_CURRENT_VERSION = 3.7.7;
-				ENABLE_TESTABILITY = NO;
-				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.client;
-				PRODUCT_NAME = client;
-				SDKROOT = macosx;
-				SWIFT_VERSION = 5.0;
-			};
-			name = Debug;
-		};
-		A2E7A53038203F2875231D12 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_IDENTITY = "-";
-				CODE_SIGN_STYLE = Automatic;
-				CONFIGURATION_BUILD_DIR = $SRCROOT/iOS/hello/Build;
-				CURRENT_PROJECT_VERSION = 3.7.7;
-				DYLIB_COMPATIBILITY_VERSION = 0;
-				DYLIB_CURRENT_VERSION = 3.7.7;
-				ENABLE_TESTABILITY = NO;
-				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
-				INFOPLIST_FILE = $SRCROOT/iOS/hello/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.hello;
-				PRODUCT_NAME = hello;
-				SDKROOT = iphoneos;
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = Debug;
-		};
-		A49393FA70C25C789C8BA59C /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
-				CONFIGURATION_BUILD_DIR = $SRCROOT/Ice/optional/Build;
-				CURRENT_PROJECT_VERSION = 3.7.7;
-				DYLIB_COMPATIBILITY_VERSION = 0;
-				DYLIB_CURRENT_VERSION = 3.7.7;
-				ENABLE_TESTABILITY = NO;
-				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.server;
-				PRODUCT_NAME = server;
-				SDKROOT = macosx;
-				SWIFT_VERSION = 5.0;
-			};
-			name = Debug;
-		};
-		A7BBBE7C673CC9FB8F471712 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
-				CONFIGURATION_BUILD_DIR = $SRCROOT/iOS/chat/Build;
-				CURRENT_PROJECT_VERSION = 3.7.7;
-				DEVELOPMENT_TEAM = U4TBVKNQ7F;
-				DYLIB_COMPATIBILITY_VERSION = 0;
-				DYLIB_CURRENT_VERSION = 3.7.7;
-				ENABLE_TESTABILITY = NO;
-				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
-				INFOPLIST_FILE = $SRCROOT/iOS/chat/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.chat;
-				PRODUCT_NAME = chat;
-				SDKROOT = iphoneos;
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VALIDATE_PRODUCT = YES;
-			};
-			name = Release;
-		};
-		A8F353ED0AC92D8151107EB0 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
-				CONFIGURATION_BUILD_DIR = $SRCROOT/Ice/bidir/Build;
-				CURRENT_PROJECT_VERSION = 3.7.7;
-				DYLIB_COMPATIBILITY_VERSION = 0;
-				DYLIB_CURRENT_VERSION = 3.7.7;
-				ENABLE_TESTABILITY = NO;
-				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.server;
-				PRODUCT_NAME = server;
-				SDKROOT = macosx;
-				SWIFT_VERSION = 5.0;
-			};
-			name = Release;
-		};
-		B6C4DAB1CB79297981CAC9A7 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
-				CONFIGURATION_BUILD_DIR = $SRCROOT/Ice/async/Build;
-				CURRENT_PROJECT_VERSION = 3.7.7;
-				DYLIB_COMPATIBILITY_VERSION = 0;
-				DYLIB_CURRENT_VERSION = 3.7.7;
-				ENABLE_TESTABILITY = NO;
-				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.server;
-				PRODUCT_NAME = server;
-				SDKROOT = macosx;
-				SWIFT_VERSION = 5.0;
-			};
-			name = Debug;
-		};
-		BFA96EB548115D7ABCDB5BEC /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
-				CONFIGURATION_BUILD_DIR = $SRCROOT/IceStorm/clock/Build;
-				CURRENT_PROJECT_VERSION = 3.7.7;
-				DYLIB_COMPATIBILITY_VERSION = 0;
-				DYLIB_CURRENT_VERSION = 3.7.7;
-				ENABLE_TESTABILITY = NO;
-				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.subscriber;
-				PRODUCT_NAME = subscriber;
-				SDKROOT = macosx;
-				SWIFT_VERSION = 5.0;
-			};
-			name = Release;
-		};
-		BFB39F79E54319699210BC5C /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
-				CONFIGURATION_BUILD_DIR = $SRCROOT/Manual/printer/Build;
-				CURRENT_PROJECT_VERSION = 3.7.7;
-				DYLIB_COMPATIBILITY_VERSION = 0;
-				DYLIB_CURRENT_VERSION = 3.7.7;
-				ENABLE_TESTABILITY = NO;
-				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.client;
-				PRODUCT_NAME = client;
-				SDKROOT = macosx;
-				SWIFT_VERSION = 5.0;
-			};
-			name = Release;
-		};
-		C040A566A94C0ED3EDBF92BC /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
-				CONFIGURATION_BUILD_DIR = $SRCROOT/IceGrid/simple/Build;
-				CURRENT_PROJECT_VERSION = 3.7.7;
-				DYLIB_COMPATIBILITY_VERSION = 0;
-				DYLIB_CURRENT_VERSION = 3.7.7;
-				ENABLE_TESTABILITY = NO;
-				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.server;
-				PRODUCT_NAME = server;
-				SDKROOT = macosx;
-				SWIFT_VERSION = 5.0;
-			};
-			name = Release;
-		};
-		C0FECBB6076A9B72205643F5 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
-				CONFIGURATION_BUILD_DIR = $SRCROOT/Ice/async/Build;
-				CURRENT_PROJECT_VERSION = 3.7.7;
-				DYLIB_COMPATIBILITY_VERSION = 0;
-				DYLIB_CURRENT_VERSION = 3.7.7;
-				ENABLE_TESTABILITY = NO;
-				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.client;
-				PRODUCT_NAME = client;
-				SDKROOT = macosx;
-				SWIFT_VERSION = 5.0;
-			};
-			name = Release;
-		};
-		C26633E9DA97B80F8B9213B3 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
-				CONFIGURATION_BUILD_DIR = $SRCROOT/Ice/hello/Build;
-				CURRENT_PROJECT_VERSION = 3.7.7;
-				DYLIB_COMPATIBILITY_VERSION = 0;
-				DYLIB_CURRENT_VERSION = 3.7.7;
-				ENABLE_TESTABILITY = NO;
-				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.client;
-				PRODUCT_NAME = client;
-				SDKROOT = macosx;
-				SWIFT_VERSION = 5.0;
-			};
-			name = Debug;
-		};
-		C2772464BCD6BE38E3562DE3 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
-				CONFIGURATION_BUILD_DIR = $SRCROOT/Manual/printer/Build;
-				CURRENT_PROJECT_VERSION = 3.7.7;
-				DYLIB_COMPATIBILITY_VERSION = 0;
-				DYLIB_CURRENT_VERSION = 3.7.7;
-				ENABLE_TESTABILITY = NO;
-				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.server;
-				PRODUCT_NAME = server;
-				SDKROOT = macosx;
-				SWIFT_VERSION = 5.0;
-			};
-			name = Debug;
-		};
-		C30B2CFAB44E5DAD8BFF8321 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
-				CONFIGURATION_BUILD_DIR = $SRCROOT/IceDiscovery/replication/Build;
-				CURRENT_PROJECT_VERSION = 3.7.7;
-				DYLIB_COMPATIBILITY_VERSION = 0;
-				DYLIB_CURRENT_VERSION = 3.7.7;
-				ENABLE_TESTABILITY = NO;
-				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.server;
-				PRODUCT_NAME = server;
-				SDKROOT = macosx;
-				SWIFT_VERSION = 5.0;
-			};
-			name = Release;
-		};
-		CC2A214C357C6725D9BCAECB /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
-				CONFIGURATION_BUILD_DIR = $SRCROOT/Glacier2/callback/Build;
-				CURRENT_PROJECT_VERSION = 3.7.7;
-				DYLIB_COMPATIBILITY_VERSION = 0;
-				DYLIB_CURRENT_VERSION = 3.7.7;
-				ENABLE_TESTABILITY = NO;
-				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.server;
-				PRODUCT_NAME = server;
-				SDKROOT = macosx;
-				SWIFT_VERSION = 5.0;
-			};
-			name = Debug;
-		};
-		CDD45E8D1667FFD80C851B2D /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
-				CONFIGURATION_BUILD_DIR = $SRCROOT/Ice/latency/Build;
-				CURRENT_PROJECT_VERSION = 3.7.7;
-				DYLIB_COMPATIBILITY_VERSION = 0;
-				DYLIB_CURRENT_VERSION = 3.7.7;
-				ENABLE_TESTABILITY = NO;
-				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.server;
-				PRODUCT_NAME = server;
-				SDKROOT = macosx;
-				SWIFT_VERSION = 5.0;
-			};
-			name = Debug;
-		};
-		CE141E384F118579229D9303 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
-				CONFIGURATION_BUILD_DIR = $SRCROOT/Ice/context/Build;
-				CURRENT_PROJECT_VERSION = 3.7.7;
-				DYLIB_COMPATIBILITY_VERSION = 0;
-				DYLIB_CURRENT_VERSION = 3.7.7;
-				ENABLE_TESTABILITY = NO;
-				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.client;
-				PRODUCT_NAME = client;
-				SDKROOT = macosx;
-				SWIFT_VERSION = 5.0;
-			};
-			name = Debug;
-		};
-		CE1F06EF38A8018281025613 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
-				CONFIGURATION_BUILD_DIR = $SRCROOT/Ice/async/Build;
-				CURRENT_PROJECT_VERSION = 3.7.7;
-				DYLIB_COMPATIBILITY_VERSION = 0;
-				DYLIB_CURRENT_VERSION = 3.7.7;
-				ENABLE_TESTABILITY = NO;
-				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.server;
-				PRODUCT_NAME = server;
-				SDKROOT = macosx;
-				SWIFT_VERSION = 5.0;
-			};
-			name = Release;
-		};
-		CF775EF563847866F75B75BA /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
-				CONFIGURATION_BUILD_DIR = $SRCROOT/Ice/latency/Build;
-				CURRENT_PROJECT_VERSION = 3.7.7;
-				DYLIB_COMPATIBILITY_VERSION = 0;
-				DYLIB_CURRENT_VERSION = 3.7.7;
-				ENABLE_TESTABILITY = NO;
-				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.client;
-				PRODUCT_NAME = client;
-				SDKROOT = macosx;
-				SWIFT_VERSION = 5.0;
-			};
-			name = Release;
-		};
-		CFD4CD7313FBC3FCC95CCEEF /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
-				CONFIGURATION_BUILD_DIR = $SRCROOT/Ice/bidir/Build;
-				CURRENT_PROJECT_VERSION = 3.7.7;
-				DYLIB_COMPATIBILITY_VERSION = 0;
-				DYLIB_CURRENT_VERSION = 3.7.7;
-				ENABLE_TESTABILITY = NO;
-				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.client;
-				PRODUCT_NAME = client;
-				SDKROOT = macosx;
-				SWIFT_VERSION = 5.0;
-			};
-			name = Release;
-		};
-		D1BC569F36314044619D3992 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
-				CONFIGURATION_BUILD_DIR = $SRCROOT/Manual/simpleFilesystem/Build;
-				CURRENT_PROJECT_VERSION = 3.7.7;
-				DYLIB_COMPATIBILITY_VERSION = 0;
-				DYLIB_CURRENT_VERSION = 3.7.7;
-				ENABLE_TESTABILITY = NO;
-				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.client;
-				PRODUCT_NAME = client;
-				SDKROOT = macosx;
-				SWIFT_VERSION = 5.0;
-			};
-			name = Debug;
-		};
-		D39B632F2B0E81BA795FE310 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
-				CONFIGURATION_BUILD_DIR = $SRCROOT/IceDiscovery/replication/Build;
-				CURRENT_PROJECT_VERSION = 3.7.7;
-				DYLIB_COMPATIBILITY_VERSION = 0;
-				DYLIB_CURRENT_VERSION = 3.7.7;
-				ENABLE_TESTABILITY = NO;
-				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.server;
-				PRODUCT_NAME = server;
-				SDKROOT = macosx;
-				SWIFT_VERSION = 5.0;
-			};
-			name = Debug;
-		};
-		D78A47CCD3C868E8C360ABE0 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
-				CONFIGURATION_BUILD_DIR = $SRCROOT/Ice/invoke/Build;
-				CURRENT_PROJECT_VERSION = 3.7.7;
-				DYLIB_COMPATIBILITY_VERSION = 0;
-				DYLIB_CURRENT_VERSION = 3.7.7;
-				ENABLE_TESTABILITY = NO;
-				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.client;
-				PRODUCT_NAME = client;
-				SDKROOT = macosx;
-				SWIFT_VERSION = 5.0;
-			};
-			name = Debug;
-		};
-		D80F21F84457CAC2731B5392 /* Release */ = {
+		B8A38A0E41360C31B4C781A3 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -6311,77 +6121,38 @@
 			};
 			name = Release;
 		};
-		DADD8D65159245E074948297 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
-				CONFIGURATION_BUILD_DIR = $SRCROOT/IceDiscovery/hello/Build;
-				CURRENT_PROJECT_VERSION = 3.7.7;
-				DYLIB_COMPATIBILITY_VERSION = 0;
-				DYLIB_CURRENT_VERSION = 3.7.7;
-				ENABLE_TESTABILITY = NO;
-				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.client;
-				PRODUCT_NAME = client;
-				SDKROOT = macosx;
-				SWIFT_VERSION = 5.0;
-			};
-			name = Release;
-		};
-		DEEF93B9B4BA8868F5A13926 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
-				CONFIGURATION_BUILD_DIR = $SRCROOT/IceStorm/clock/Build;
-				CURRENT_PROJECT_VERSION = 3.7.7;
-				DYLIB_COMPATIBILITY_VERSION = 0;
-				DYLIB_CURRENT_VERSION = 3.7.7;
-				ENABLE_TESTABILITY = NO;
-				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.publisher;
-				PRODUCT_NAME = publisher;
-				SDKROOT = macosx;
-				SWIFT_VERSION = 5.0;
-			};
-			name = Debug;
-		};
-		E20398CA6206B6CAA6BCE545 /* Debug */ = {
+		BC4F625CA18E7C53624C620A /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
-				CONFIGURATION_BUILD_DIR = $SRCROOT/iOS/chat/Build;
+				CONFIGURATION_BUILD_DIR = $SRCROOT/IceDiscovery/helloUI/Build;
 				CURRENT_PROJECT_VERSION = 3.7.7;
-				DEVELOPMENT_TEAM = U4TBVKNQ7F;
 				DYLIB_COMPATIBILITY_VERSION = 0;
 				DYLIB_CURRENT_VERSION = 3.7.7;
 				ENABLE_TESTABILITY = NO;
 				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
-				INFOPLIST_FILE = $SRCROOT/iOS/chat/Info.plist;
+				INFOPLIST_FILE = $SRCROOT/IceDiscovery/helloUI/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.chat;
-				PRODUCT_NAME = chat;
+				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.helloui;
+				PRODUCT_NAME = helloui;
 				SDKROOT = iphoneos;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
 		};
-		E388D51C739606B2E51F26BF /* Release */ = {
+		BE83EDF85276013BEE724C43 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CONFIGURATION_BUILD_DIR = $SRCROOT/Ice/throughput/Build;
+				CONFIGURATION_BUILD_DIR = $SRCROOT/Ice/latency/Build;
 				CURRENT_PROJECT_VERSION = 3.7.7;
 				DYLIB_COMPATIBILITY_VERSION = 0;
 				DYLIB_CURRENT_VERSION = 3.7.7;
@@ -6394,9 +6165,28 @@
 				SDKROOT = macosx;
 				SWIFT_VERSION = 5.0;
 			};
-			name = Release;
+			name = Debug;
 		};
-		E90294A051036CEEFA3B7264 /* Release */ = {
+		C072442F77ACF1EB90E8D56B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CONFIGURATION_BUILD_DIR = $SRCROOT/Ice/async/Build;
+				CURRENT_PROJECT_VERSION = 3.7.7;
+				DYLIB_COMPATIBILITY_VERSION = 0;
+				DYLIB_CURRENT_VERSION = 3.7.7;
+				ENABLE_TESTABILITY = NO;
+				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.client;
+				PRODUCT_NAME = client;
+				SDKROOT = macosx;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		C0930440B1E493A30C0044B5 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
@@ -6413,9 +6203,9 @@
 				SDKROOT = macosx;
 				SWIFT_VERSION = 5.0;
 			};
-			name = Release;
+			name = Debug;
 		};
-		E9A92DAD77B6780003E26AA5 /* Release */ = {
+		C128D2906EBCC912A29F6156 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
@@ -6434,30 +6224,11 @@
 			};
 			name = Release;
 		};
-		EA81E1C7B43822C9A925E7C2 /* Debug */ = {
+		C3A6F78FEC4F8DD256F119AF /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CONFIGURATION_BUILD_DIR = $SRCROOT/Ice/throughput/Build;
-				CURRENT_PROJECT_VERSION = 3.7.7;
-				DYLIB_COMPATIBILITY_VERSION = 0;
-				DYLIB_CURRENT_VERSION = 3.7.7;
-				ENABLE_TESTABILITY = NO;
-				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.server;
-				PRODUCT_NAME = server;
-				SDKROOT = macosx;
-				SWIFT_VERSION = 5.0;
-			};
-			name = Debug;
-		};
-		ED68B6C18EF2B64CAC2CE452 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
-				CONFIGURATION_BUILD_DIR = $SRCROOT/Ice/throughput/Build;
+				CONFIGURATION_BUILD_DIR = $SRCROOT/IceGrid/simple/Build;
 				CURRENT_PROJECT_VERSION = 3.7.7;
 				DYLIB_COMPATIBILITY_VERSION = 0;
 				DYLIB_CURRENT_VERSION = 3.7.7;
@@ -6470,9 +6241,28 @@
 				SDKROOT = macosx;
 				SWIFT_VERSION = 5.0;
 			};
+			name = Debug;
+		};
+		CAB2A901CE05ED44862EA279 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CONFIGURATION_BUILD_DIR = $SRCROOT/IceStorm/clock/Build;
+				CURRENT_PROJECT_VERSION = 3.7.7;
+				DYLIB_COMPATIBILITY_VERSION = 0;
+				DYLIB_CURRENT_VERSION = 3.7.7;
+				ENABLE_TESTABILITY = NO;
+				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.subscriber;
+				PRODUCT_NAME = subscriber;
+				SDKROOT = macosx;
+				SWIFT_VERSION = 5.0;
+			};
 			name = Release;
 		};
-		EE31C9367976224AFF5C2F94 /* Debug */ = {
+		CD3BE7EA1AC972AD8A1EE4B4 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
@@ -6491,19 +6281,39 @@
 			};
 			name = Debug;
 		};
-		EEFAEF096D0292F2534C793A /* Debug */ = {
+		CEBA8645C3A8AE59C2C3739B /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_STYLE = Automatic;
+				CONFIGURATION_BUILD_DIR = $SRCROOT/Chat/Build;
+				CURRENT_PROJECT_VERSION = 3.7.7;
+				DYLIB_COMPATIBILITY_VERSION = 0;
+				DYLIB_CURRENT_VERSION = 3.7.7;
+				ENABLE_TESTABILITY = NO;
+				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
+				INFOPLIST_FILE = $SRCROOT/Chat/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.chat;
+				PRODUCT_NAME = chat;
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
 			};
-			name = Debug;
+			name = Release;
 		};
-		F0A203CAE3FE27256A28A743 /* Release */ = {
+		D10B33FC84DAD0CA0AB11EB9 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CONFIGURATION_BUILD_DIR = $SRCROOT/IceStorm/clock/Build;
+				CONFIGURATION_BUILD_DIR = $SRCROOT/Manual/simpleFilesystem/Build;
 				CURRENT_PROJECT_VERSION = 3.7.7;
 				DYLIB_COMPATIBILITY_VERSION = 0;
 				DYLIB_CURRENT_VERSION = 3.7.7;
@@ -6511,18 +6321,26 @@
 				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.publisher;
-				PRODUCT_NAME = publisher;
+				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.client;
+				PRODUCT_NAME = client;
 				SDKROOT = macosx;
 				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
-		F512BC99F80858709E981E5D /* Debug */ = {
+		D2E9B0D502B860AA0FC6E522 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+			};
+			name = Release;
+		};
+		DD6AB89F94DCC2058B8E678D /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CONFIGURATION_BUILD_DIR = $SRCROOT/Ice/interceptor/Build;
+				CONFIGURATION_BUILD_DIR = $SRCROOT/Manual/printer/Build;
 				CURRENT_PROJECT_VERSION = 3.7.7;
 				DYLIB_COMPATIBILITY_VERSION = 0;
 				DYLIB_CURRENT_VERSION = 3.7.7;
@@ -6537,11 +6355,30 @@
 			};
 			name = Debug;
 		};
-		FABF170E7AD43D3D6EB8EC18 /* Debug */ = {
+		E39C1E4DD0CAF46C37BA7D3B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				CONFIGURATION_BUILD_DIR = $SRCROOT/Ice/invoke/Build;
+				CURRENT_PROJECT_VERSION = 3.7.7;
+				DYLIB_COMPATIBILITY_VERSION = 0;
+				DYLIB_CURRENT_VERSION = 3.7.7;
+				ENABLE_TESTABILITY = NO;
+				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.client;
+				PRODUCT_NAME = client;
+				SDKROOT = macosx;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		E6CC57DD369D51A6E05117C1 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CONFIGURATION_BUILD_DIR = $SRCROOT/Ice/interceptor/Build;
 				CURRENT_PROJECT_VERSION = 3.7.7;
 				DYLIB_COMPATIBILITY_VERSION = 0;
 				DYLIB_CURRENT_VERSION = 3.7.7;
@@ -6556,388 +6393,521 @@
 			};
 			name = Debug;
 		};
+		E735A7494B5D2BF0D66613F2 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CONFIGURATION_BUILD_DIR = $SRCROOT/IceStorm/clock/Build;
+				CURRENT_PROJECT_VERSION = 3.7.7;
+				DYLIB_COMPATIBILITY_VERSION = 0;
+				DYLIB_CURRENT_VERSION = 3.7.7;
+				ENABLE_TESTABILITY = NO;
+				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.subscriber;
+				PRODUCT_NAME = subscriber;
+				SDKROOT = macosx;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		EA2A24CF326B029B4AD30674 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CONFIGURATION_BUILD_DIR = $SRCROOT/Ice/bidir/Build;
+				CURRENT_PROJECT_VERSION = 3.7.7;
+				DYLIB_COMPATIBILITY_VERSION = 0;
+				DYLIB_CURRENT_VERSION = 3.7.7;
+				ENABLE_TESTABILITY = NO;
+				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.client;
+				PRODUCT_NAME = client;
+				SDKROOT = macosx;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		F438239C5AF3C45C61201D90 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CONFIGURATION_BUILD_DIR = $SRCROOT/Ice/hello/Build;
+				CURRENT_PROJECT_VERSION = 3.7.7;
+				DYLIB_COMPATIBILITY_VERSION = 0;
+				DYLIB_CURRENT_VERSION = 3.7.7;
+				ENABLE_TESTABILITY = NO;
+				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.client;
+				PRODUCT_NAME = client;
+				SDKROOT = macosx;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		F5B981470D5F63A4E2644708 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CONFIGURATION_BUILD_DIR = $SRCROOT/Ice/context/Build;
+				CURRENT_PROJECT_VERSION = 3.7.7;
+				DYLIB_COMPATIBILITY_VERSION = 0;
+				DYLIB_CURRENT_VERSION = 3.7.7;
+				ENABLE_TESTABILITY = NO;
+				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.server;
+				PRODUCT_NAME = server;
+				SDKROOT = macosx;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		F82A03D97DF9F8749A6E0F6D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CONFIGURATION_BUILD_DIR = $SRCROOT/Ice/context/Build;
+				CURRENT_PROJECT_VERSION = 3.7.7;
+				DYLIB_COMPATIBILITY_VERSION = 0;
+				DYLIB_CURRENT_VERSION = 3.7.7;
+				ENABLE_TESTABILITY = NO;
+				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.server;
+				PRODUCT_NAME = server;
+				SDKROOT = macosx;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		FE3F865CBBCCC8DFD4453B6C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CONFIGURATION_BUILD_DIR = $SRCROOT/IceGrid/simple/Build;
+				CURRENT_PROJECT_VERSION = 3.7.7;
+				DYLIB_COMPATIBILITY_VERSION = 0;
+				DYLIB_CURRENT_VERSION = 3.7.7;
+				ENABLE_TESTABILITY = NO;
+				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.server;
+				PRODUCT_NAME = server;
+				SDKROOT = macosx;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		FE7F6CD1BFF03279A8698903 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CONFIGURATION_BUILD_DIR = $SRCROOT/Ice/async/Build;
+				CURRENT_PROJECT_VERSION = 3.7.7;
+				DYLIB_COMPATIBILITY_VERSION = 0;
+				DYLIB_CURRENT_VERSION = 3.7.7;
+				ENABLE_TESTABILITY = NO;
+				FRAMEWORK_SEARCH_PATHS = $SRCROOT/Carthage/Build/;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path";
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				PRODUCT_BUNDLE_IDENTIFIER = com.zeroc.demo.server;
+				PRODUCT_NAME = server;
+				SDKROOT = macosx;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		00EA2003459891C598218C90 /* Build configuration list for PBXNativeTarget "IceInvokeServer" */ = {
+		027C68065DE24751572B7E37 /* Build configuration list for PBXNativeTarget "ManualSimpleFilesystemServer" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				FABF170E7AD43D3D6EB8EC18 /* Debug */,
-				93D48069BD208CC83B9EA772 /* Release */,
+				4149BBCC742FD233D827A63D /* Debug */,
+				500CFED525CB329756D98F91 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		1477EF932D609567F15FD17D /* Build configuration list for PBXNativeTarget "IceLatencyClient" */ = {
+		0C9A64174C9644B5ED2C41F4 /* Build configuration list for PBXNativeTarget "IceDiscoveryReplicationClient" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				98A645DA3A90EDD264F6017C /* Debug */,
-				CF775EF563847866F75B75BA /* Release */,
+				9CB329F96B7018B9E47D193C /* Debug */,
+				78199483C24CF9D3992966DD /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		1662F20592C3CA8BB8F3C72C /* Build configuration list for PBXNativeTarget "IceStormClockPublisher" */ = {
+		169F1F3007DC0FA109F32D73 /* Build configuration list for PBXNativeTarget "IceDiscoveryHelloServer" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				DEEF93B9B4BA8868F5A13926 /* Debug */,
-				F0A203CAE3FE27256A28A743 /* Release */,
+				2A2C869CBE59D8A68D68718F /* Debug */,
+				1DA209434B4975DBB048EE42 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		255A8B3231CC13B6A7B034EE /* Build configuration list for PBXNativeTarget "IOSLibrary" */ = {
+		17EED16FD192835E37C08F02 /* Build configuration list for PBXNativeTarget "IceGridSimpleServer" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				102B35F5A51F49D7F812C021 /* Debug */,
-				8D02263610FFDD7F7ADFB56C /* Release */,
+				FE3F865CBBCCC8DFD4453B6C /* Debug */,
+				15AB6A3DE2D1AD2371134914 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		2B1D739A5ABDFE7403B6979A /* Build configuration list for PBXAggregateTarget "allDemos iOS" */ = {
+		18FC462EB7FAF94D59CBFA66 /* Build configuration list for PBXNativeTarget "IceInvokeClient" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				EEFAEF096D0292F2534C793A /* Debug */,
-				40AA439BFC0AD26390F486FD /* Release */,
+				E39C1E4DD0CAF46C37BA7D3B /* Debug */,
+				2A86F4E8459969ADA861B4A2 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		2C979B40A9B83E8D3D20C5B8 /* Build configuration list for PBXNativeTarget "IceAsyncInvocationClient" */ = {
+		1A1F296C9C2DFAFC8E9EE849 /* Build configuration list for PBXNativeTarget "IceHelloServer" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				37908F8FB5B8D8AD7AAE7B8C /* Debug */,
-				86AC4E509FF91E6EF7C92909 /* Release */,
+				71A138B08578C7965D40AAF1 /* Debug */,
+				C128D2906EBCC912A29F6156 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		4C23DA67FE2344D08FCF1354 /* Build configuration list for PBXNativeTarget "IceDiscoveryHelloClient" */ = {
+		1E5B2E9429A78A1F2F7FE1C4 /* Build configuration list for PBXNativeTarget "IceDiscoveryHelloUI" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				63D664366B6CAC1B40A1EF02 /* Debug */,
-				DADD8D65159245E074948297 /* Release */,
+				BC4F625CA18E7C53624C620A /* Debug */,
+				6D3C40E199710152DF80288D /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		4D28FADA985218DEBED6EDB4 /* Build configuration list for PBXNativeTarget "IceLatencyServer" */ = {
+		2019457B7736436BDD6908FF /* Build configuration list for PBXNativeTarget "IceContextServer" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				CDD45E8D1667FFD80C851B2D /* Debug */,
-				0DC365C6F13604DB8AC6269D /* Release */,
+				F82A03D97DF9F8749A6E0F6D /* Debug */,
+				F5B981470D5F63A4E2644708 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		4D65493F20B4E0CDDA5F32DB /* Build configuration list for PBXNativeTarget "IOSHello" */ = {
+		276B44590FB6644D55603174 /* Build configuration list for PBXNativeTarget "IceDiscoveryReplicationServer" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				A2E7A53038203F2875231D12 /* Debug */,
-				494BCF085AFC513E9941DD9D /* Release */,
+				5B9E7A3B7A9F948935D22DA5 /* Debug */,
+				815457A20AE6C6C919FE1612 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		540AA1CE227A94705A039762 /* Build configuration list for PBXNativeTarget "IceAsyncClient" */ = {
+		320E9D3263C4EF994BF0ACB0 /* Build configuration list for PBXNativeTarget "Chat" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				6DC37799209C88562F336769 /* Debug */,
-				C0FECBB6076A9B72205643F5 /* Release */,
+				6C722A44FDA78ECCB27A591B /* Debug */,
+				CEBA8645C3A8AE59C2C3739B /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		590E6C63A4E703ED5C37C10A /* Build configuration list for PBXNativeTarget "Glacier2CallbackClient" */ = {
+		33D371A007F066CDA00D507F /* Build configuration list for PBXNativeTarget "IceMinimalServer" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				98429C901A8EE200ED3311F5 /* Debug */,
-				1213193D803DCB7CAE0BD9D9 /* Release */,
+				CD3BE7EA1AC972AD8A1EE4B4 /* Debug */,
+				7D606C62D052B01E37C1A2B9 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		6273F343B340BC2B3077B30B /* Build configuration list for PBXNativeTarget "IceThroughputServer" */ = {
+		398FA99AF60CC10017DF6DD8 /* Build configuration list for PBXNativeTarget "Glacier2CallbackClient" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				EA81E1C7B43822C9A925E7C2 /* Debug */,
-				E388D51C739606B2E51F26BF /* Release */,
+				828D7E53635E62D8923EBDD5 /* Debug */,
+				9F457F5243AD5125A424CBE8 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		65E607EB4C0068D271C83421 /* Build configuration list for PBXNativeTarget "IceInterceptorServer" */ = {
+		3DD9F5EEAE7F71DFC0B81DCE /* Build configuration list for PBXNativeTarget "ManualSimpleFilesystemClient" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				58F2F9F6B85203078019106C /* Debug */,
-				87793D4601C002BE84D4F8B2 /* Release */,
+				5038A500F9673E81A2484ADF /* Debug */,
+				D10B33FC84DAD0CA0AB11EB9 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		74AB20302D0B6A8E7301684A /* Build configuration list for PBXNativeTarget "IceDiscoveryReplicationServer" */ = {
+		47F871B84A7762A6EA86CC51 /* Build configuration list for PBXNativeTarget "IceThroughputServer" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				D39B632F2B0E81BA795FE310 /* Debug */,
-				C30B2CFAB44E5DAD8BFF8321 /* Release */,
+				622B5FE7145597B27D7A80A2 /* Debug */,
+				2605856688B8FA5051969784 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		7CA397F4251ECCE98C893188 /* Build configuration list for PBXNativeTarget "IceContextServer" */ = {
+		4B4171E8C36C8C7DE57E5CE4 /* Build configuration list for PBXNativeTarget "IceContextClient" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				0B0C24EB35FEBE60DD7E8569 /* Debug */,
-				23D2365F8E0CAA5B8EC17ADA /* Release */,
+				337FAE90BEBF00DA3A226BF3 /* Debug */,
+				49BFE8B6B3A09BD86E113E07 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		801B535E78133B1A9EDE9CB6 /* Build configuration list for PBXProject "demos" */ = {
+		4C756B9FDEB5F9DDFEE191A2 /* Build configuration list for PBXNativeTarget "IceAsyncServer" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				14105F15DF779392C3FFB54A /* Debug */,
-				D80F21F84457CAC2731B5392 /* Release */,
+				ACC176A228177B656DBCBEEF /* Debug */,
+				FE7F6CD1BFF03279A8698903 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		80CCF7745F9FAA4E18C1C935 /* Build configuration list for PBXNativeTarget "IceAsyncInvocationServer" */ = {
+		542F5EFE654DD57E0C11307D /* Build configuration list for PBXNativeTarget "IceMinimalClient" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				053C3B2A38A55047B9D10578 /* Debug */,
-				7D2B3326C48D8DFFB2B0E239 /* Release */,
+				0EC620666B04344A291AB009 /* Debug */,
+				5F8BA6FA36DC4C102F431EE9 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		827FC53EE32182A7861FA861 /* Build configuration list for PBXNativeTarget "IceGridSimpleServer" */ = {
+		5DAA1FD741044347B763D93F /* Build configuration list for PBXNativeTarget "Glacier2CallbackServer" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				79E6B1C4C88048586569A0AC /* Debug */,
-				C040A566A94C0ED3EDBF92BC /* Release */,
+				3A232A25B936A7AF4B0CBE42 /* Debug */,
+				39E2B1F43D6AF024EA415FBB /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		89453109B4357FEAED6111F0 /* Build configuration list for PBXNativeTarget "IceStormClockSubscriber" */ = {
+		6AD851E6F69695DE19EA2C94 /* Build configuration list for PBXAggregateTarget "allDemos iOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				00B671CBA60F60B187379F7A /* Debug */,
-				BFA96EB548115D7ABCDB5BEC /* Release */,
+				8224FAC00B9330CC0BA09163 /* Debug */,
+				D2E9B0D502B860AA0FC6E522 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		8B706BEF1426196ACF12C1D3 /* Build configuration list for PBXNativeTarget "ManualSimpleFilesystemClient" */ = {
+		6DE6ECA62A425FC1AF752B7D /* Build configuration list for PBXNativeTarget "IceInterceptorServer" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				D1BC569F36314044619D3992 /* Debug */,
-				95630C54420CBAA9ECECE4B0 /* Release */,
+				E6CC57DD369D51A6E05117C1 /* Debug */,
+				3113627ED588E986D3E126B3 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		90913A7AF8AD359EDA1E26F9 /* Build configuration list for PBXNativeTarget "IceDiscoveryHelloServer" */ = {
+		72FFAD0DAD9BBB1BC3BDDBE7 /* Build configuration list for PBXNativeTarget "IceAsyncInvocationClient" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				8D201BA967715A9CE7742029 /* Debug */,
-				1741C491FB8B9B465601394A /* Release */,
+				33D54B152C19AEC682C2A44B /* Debug */,
+				9E925F3AC6A1B05703D3DEC9 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		91CFEFF5E725F23A39F19AD3 /* Build configuration list for PBXAggregateTarget "allDemos macOS" */ = {
+		7E3D80CE3E75EED82FCFE10B /* Build configuration list for PBXNativeTarget "IceGridSimpleClient" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				6C800835E7834989B32C172C /* Debug */,
-				5E7E436E4CF130C2A6C6CCB3 /* Release */,
+				C3A6F78FEC4F8DD256F119AF /* Debug */,
+				6AF8E346CC87BF8648CBFB5D /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		A897D1D102B49B3A778BFBB0 /* Build configuration list for PBXNativeTarget "Glacier2CallbackServer" */ = {
+		807A02B429BE2DDF4D2C1D8B /* Build configuration list for PBXNativeTarget "ManualPrinterClient" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				CC2A214C357C6725D9BCAECB /* Debug */,
-				8C21D439F9D70641E36F1171 /* Release */,
+				DD6AB89F94DCC2058B8E678D /* Debug */,
+				156C01803FA828D820217C1E /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		AB712B67CDEF04D274EC6D69 /* Build configuration list for PBXNativeTarget "IceDiscoveryReplicationClient" */ = {
+		8150E043A0B68EAFEFE3E267 /* Build configuration list for PBXNativeTarget "IceLatencyClient" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				4EB0919EF735DF84681BC62A /* Debug */,
-				1EDB53FF3CFE8704BD41D5B6 /* Release */,
+				769445F5EFC5894D6E707E10 /* Debug */,
+				05ED89259B19CEC493DE14A9 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		B0F9CF3EF9219C6642864998 /* Build configuration list for PBXNativeTarget "IceBidirClient" */ = {
+		84128DFC5D92D6DBF5430595 /* Build configuration list for PBXNativeTarget "IceHelloUI" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				12C0C4CD0CB9858743FBD8A7 /* Debug */,
-				CFD4CD7313FBC3FCC95CCEEF /* Release */,
+				028D86C9D76AB40A61813D18 /* Debug */,
+				6E268A2A349787FA0408C7A1 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		B1F51375608717E2A57E1DCC /* Build configuration list for PBXNativeTarget "ManualPrinterServer" */ = {
+		9804B75F73A52AB858FD5236 /* Build configuration list for PBXNativeTarget "IceAsyncClient" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				C2772464BCD6BE38E3562DE3 /* Debug */,
-				3C25CC6DCF6AB067C0324C7D /* Release */,
+				C072442F77ACF1EB90E8D56B /* Debug */,
+				316485E8AE37725665C8BBD0 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		B3AA58A85C88E200FEFF4969 /* Build configuration list for PBXNativeTarget "IceInterceptorClient" */ = {
+		98069F0465634A2B7DF722C2 /* Build configuration list for PBXNativeTarget "ManualPrinterServer" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				F512BC99F80858709E981E5D /* Debug */,
-				034D67E8ADE2B4D70BA3AB38 /* Release */,
+				7B74831F0B9F7FF01381ABA8 /* Debug */,
+				8C551B3E30AEA80FE95726EA /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		BA49156F45F7453B13FEF8B2 /* Build configuration list for PBXNativeTarget "IceOptionalServer" */ = {
+		9A272BA413D4B1A341628D43 /* Build configuration list for PBXNativeTarget "IceBidirClient" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				A49393FA70C25C789C8BA59C /* Debug */,
-				682E4D139F369A688C2D29E5 /* Release */,
+				EA2A24CF326B029B4AD30674 /* Debug */,
+				3F8CCA34BA576329381B4D10 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		BCAFBBAD835A85E28CC4D76F /* Build configuration list for PBXNativeTarget "IceAsyncServer" */ = {
+		AC0916E07C12D8419E3DF06A /* Build configuration list for PBXNativeTarget "IceLatencyServer" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				B6C4DAB1CB79297981CAC9A7 /* Debug */,
-				CE1F06EF38A8018281025613 /* Release */,
+				BE83EDF85276013BEE724C43 /* Debug */,
+				991B9BA687032F2A11F97E8F /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		BDA4474131B634CCA8361736 /* Build configuration list for PBXNativeTarget "IceMinimalClient" */ = {
+		B59022905C78425FE7C63286 /* Build configuration list for PBXAggregateTarget "allDemos macOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				789D544B21CC97ABC3F07AD3 /* Debug */,
-				762FDEFE42EFD0CC20823982 /* Release */,
+				6D9B5C5F68E7F1E843B51C0B /* Debug */,
+				55A6EF20796E6059A3C3C070 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		C2179CA3066C87E3F3A33C7C /* Build configuration list for PBXNativeTarget "ManualPrinterClient" */ = {
+		B9753D2999179047C0F843D6 /* Build configuration list for PBXNativeTarget "IceStormClockPublisher" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				1918FAD67CB6344D00144B8B /* Debug */,
-				BFB39F79E54319699210BC5C /* Release */,
+				7B63E7538AE56147A1979AB7 /* Debug */,
+				091F709A456B00D7A231A51D /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		C21C29AEAAFF06961BADDE24 /* Build configuration list for PBXNativeTarget "IceInvokeClient" */ = {
+		BE551E77DF2CF4D43219C651 /* Build configuration list for PBXNativeTarget "IceDiscoveryHelloClient" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				D78A47CCD3C868E8C360ABE0 /* Debug */,
-				59CC2B7195F29EEE4256DB6D /* Release */,
+				4FAA844BCC74DFD0FC944587 /* Debug */,
+				2A26B38787D72B11A8B39A88 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		C8567BB5E0ED1B46910BBCBB /* Build configuration list for PBXNativeTarget "IceContextClient" */ = {
+		C03E065DF91CAC20DF8C5BC2 /* Build configuration list for PBXProject "demos" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				CE141E384F118579229D9303 /* Debug */,
-				5776BBEBD687D5BA0C565C27 /* Release */,
+				A6CFC8DDF09D13C6A346BED8 /* Debug */,
+				B8A38A0E41360C31B4C781A3 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		C8C00A4981A8A430185FB865 /* Build configuration list for PBXNativeTarget "IceHelloServer" */ = {
+		C1A2DEDB7D0701CA1A7808C8 /* Build configuration list for PBXNativeTarget "IceThroughputClient" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				634F479605E95F55081E27C9 /* Debug */,
-				E9A92DAD77B6780003E26AA5 /* Release */,
+				9DB30F7671B23A5438051D54 /* Debug */,
+				41BBCEE2FC76DBDA507A5F02 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		CE9B58718C321CE74DEE8C13 /* Build configuration list for PBXNativeTarget "IceThroughputClient" */ = {
+		C59D28140D012AE46D0F7987 /* Build configuration list for PBXNativeTarget "IceAsyncInvocationServer" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				78C83DCEDC220426D770CF62 /* Debug */,
-				ED68B6C18EF2B64CAC2CE452 /* Release */,
+				7711B1AB30D9554481C861D0 /* Debug */,
+				79EA14AABEF3A708D9C669BB /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		D4562A2DDDA2791556A09F92 /* Build configuration list for PBXNativeTarget "IceGridSimpleClient" */ = {
+		CA434A8635C37FC1ED823AFA /* Build configuration list for PBXNativeTarget "IceInterceptorClient" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				9107666E46354F8B9E60A2F2 /* Debug */,
-				53F5782132F976AFBC9AF1E6 /* Release */,
+				3F055D80CD85A102965BB95D /* Debug */,
+				2FEB317A27B7CD52E6E89A6D /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		D4ABA528D89F3F2B4AC8A13E /* Build configuration list for PBXNativeTarget "IOSChat" */ = {
+		CF4BAF9DF89BFAF3E97C9BE5 /* Build configuration list for PBXNativeTarget "IceInvokeServer" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				E20398CA6206B6CAA6BCE545 /* Debug */,
-				A7BBBE7C673CC9FB8F471712 /* Release */,
+				8BA771EF72F9A59F1D2F25FF /* Debug */,
+				390516ADE1A0416301049B1E /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		DF912EF23FD5DB0EC4914DA9 /* Build configuration list for PBXNativeTarget "ManualSimpleFilesystemServer" */ = {
+		D420CCF7CC1428A9FAF8E23B /* Build configuration list for PBXNativeTarget "IceOptionalClient" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				1B80DC959D4731E8A06A2D75 /* Debug */,
-				36083E176E8AEFFA7DB2E8EB /* Release */,
+				C0930440B1E493A30C0044B5 /* Debug */,
+				896E7BC2BB7B78EF89796ACB /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		DFC770DA6333AD2B412DA911 /* Build configuration list for PBXNativeTarget "IceBidirServer" */ = {
+		D8A689E605A9CF40A85A02D8 /* Build configuration list for PBXNativeTarget "IceStormClockSubscriber" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				4A5239FED72B70BD9F498DFB /* Debug */,
-				A8F353ED0AC92D8151107EB0 /* Release */,
+				E735A7494B5D2BF0D66613F2 /* Debug */,
+				CAB2A901CE05ED44862EA279 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		DFDCFA4F1609E1A9A7FD5907 /* Build configuration list for PBXNativeTarget "IceHelloClient" */ = {
+		E009F87BD497BEFD31C4B710 /* Build configuration list for PBXNativeTarget "IceHelloClient" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				C26633E9DA97B80F8B9213B3 /* Debug */,
-				6CFA08F03E0B3E9778C4756A /* Release */,
+				F438239C5AF3C45C61201D90 /* Debug */,
+				B53B535F653F4C73D6DDBD00 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		F2B5D81BEA80B456322045A6 /* Build configuration list for PBXNativeTarget "IceMinimalServer" */ = {
+		E5BE94CC7E12A4C7636881CC /* Build configuration list for PBXNativeTarget "IceBidirServer" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				EE31C9367976224AFF5C2F94 /* Debug */,
-				3789F343831BD43A1A50D909 /* Release */,
+				58B073BF736BC6EF24EE4B24 /* Debug */,
+				9A9FDF61F8B8D8FC22373C13 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		FE60CFBC42EDE94D5CD1436E /* Build configuration list for PBXNativeTarget "IceOptionalClient" */ = {
+		F5C893FF9A5E99B51E0AC52B /* Build configuration list for PBXNativeTarget "IceOptionalServer" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				12B8816C59658BC7E5F8DAED /* Debug */,
-				E90294A051036CEEFA3B7264 /* Release */,
+				5A909F7A0BD4EA2BB1DAE7D2 /* Debug */,
+				76778A79C1B8B51402ED4F62 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};
-	rootObject = EB97194894496C5DB10325DC /* Project object */;
+	rootObject = ED7A4595F994579960C2BA8E /* Project object */;
 }


### PR DESCRIPTION
When trying to install the dependencies for the Swift iOS demos the following error appears:

*** Skipped building MessageKit due to the error:
Dependency "MessageKit" has no shared framework schemes

If you believe this to be an error, please file an issue with the maintainers at https://github.com/MessageKit/MessageKit/issues/new

Setting the MessageKit version to "3.4.2" fixes this.

Fixes #150 
