### PR TITLE
Fix issues reported by clang-tidy

### DIFF
--- a/cpp11/Chat/client/ChatUtils.cpp
+++ b/cpp11/Chat/client/ChatUtils.cpp
@@ -20,13 +20,13 @@ string
 ChatUtils::unstripHtml(const string& s)
 {
     string out = s;
-    for(unsigned int count = 0; count < sizeof(htmlEntities) / sizeof(htmlEntities[0]); ++count)
+    for(const HtmlEntity& entity : htmlEntities)
     {
-        for(string::size_type pos = out.find(htmlEntities[count].first);
+        for(string::size_type pos = out.find(entity.first);
             pos != string::npos;
-            pos = out.find(htmlEntities[count].first, pos))
+            pos = out.find(entity.first, pos))
         {
-            out.replace(pos, htmlEntities[count].first.size(), htmlEntities[count].second);
+            out.replace(pos, entity.first.size(), entity.second);
         }
     }
     return out;
@@ -36,7 +36,7 @@ string
 ChatUtils::trim(const string& s)
 {
     static const string delims = "\t\r\n ";
-    string::size_type last = s.find_last_not_of(delims);
+    const string::size_type last = s.find_last_not_of(delims);
     if(last != string::npos)
     {
         return s.substr(s.find_first_not_of(delims), last+1);

--- a/cpp11/Chat/client/Client.cpp
+++ b/cpp11/Chat/client/Client.cpp
@@ -27,7 +27,7 @@ public:
     virtual void
     init(Ice::StringSeq names, const Ice::Current&) override
     {
-        lock_guard<mutex> lock(coutMutex);
+        const lock_guard<mutex> lock(coutMutex);
         cout << "Users: ";
         for(auto it = names.begin(); it != names.end();)
         {
@@ -44,21 +44,21 @@ public:
     virtual void
     join(long long, string name, const Ice::Current&) override
     {
-        lock_guard<mutex> lock(coutMutex);
+        const lock_guard<mutex> lock(coutMutex);
         cout << ">>>> " << name << " joined." << endl;
     }
 
     virtual void
     leave(long long, string name, const Ice::Current&) override
     {
-        lock_guard<mutex> lock(coutMutex);
+        const lock_guard<mutex> lock(coutMutex);
         cout << "<<<< " << name << " left." << endl;
     }
 
     virtual void
     send(long long, string name, string message, const Ice::Current&) override
     {
-        lock_guard<mutex> lock(coutMutex);
+        const lock_guard<mutex> lock(coutMutex);
         cout << name << " > " << ChatUtils::unstripHtml(message) << endl;
     }
 };
@@ -156,7 +156,7 @@ public:
                 {
                     if(s.size() > maxMessageSize)
                     {
-                        lock_guard<mutex> lock(coutMutex);
+                        const lock_guard<mutex> lock(coutMutex);
                         cout << "Message length exceeded, maximum length is " << maxMessageSize << " characters.";
                     }
                     else
@@ -175,7 +175,7 @@ private:
     void
     menu()
     {
-        lock_guard<mutex> lock(coutMutex);
+        const lock_guard<mutex> lock(coutMutex);
         cout << "enter /quit to exit." << endl;
     }
 };

--- a/cpp11/Chat/client/PollingClient.cpp
+++ b/cpp11/Chat/client/PollingClient.cpp
@@ -23,7 +23,7 @@ class GetUpdatesTask
 {
 public:
 
-    GetUpdatesTask(const shared_ptr<PollingChat::PollingChatSessionPrx>& session) :
+    explicit GetUpdatesTask(const shared_ptr<PollingChat::PollingChatSessionPrx>& session) :
         _session(session)
     {
     }
@@ -31,7 +31,7 @@ public:
     ~GetUpdatesTask()
     {
         {
-            lock_guard<mutex> lock(_mutex);
+            const lock_guard<mutex> lock(_mutex);
             _done = true;
         }
         _cond.notify_all();
@@ -67,7 +67,7 @@ public:
                     auto joinedEvt = dynamic_pointer_cast<PollingChat::UserJoinedEvent>(u);
                     if(joinedEvt)
                     {
-                        lock_guard<mutex> lkg(coutMutex);
+                        const lock_guard<mutex> lkg(coutMutex);
                         cout << ">>>> " << joinedEvt->name << " joined." << endl;
                     }
                     else
@@ -75,7 +75,7 @@ public:
                         auto leftEvt = dynamic_pointer_cast<PollingChat::UserLeftEvent>(u);
                         if(leftEvt)
                         {
-                            lock_guard<mutex> lkg(coutMutex);
+                            const lock_guard<mutex> lkg(coutMutex);
                             cout << ">>>> " << leftEvt->name << " left." << endl;
                         }
                         else
@@ -83,7 +83,7 @@ public:
                             auto messageEvt = dynamic_pointer_cast<PollingChat::MessageEvent>(u);
                             if(messageEvt)
                             {
-                                lock_guard<mutex> lkg(coutMutex);
+                                const lock_guard<mutex> lkg(coutMutex);
                                 cout << messageEvt->name << " > " << ChatUtils::unstripHtml(messageEvt->message) << endl;
                             }
                         }
@@ -93,7 +93,7 @@ public:
             catch(const Ice::LocalException& ex)
             {
                 {
-                    lock_guard<mutex> lkg(_mutex);
+                    const lock_guard<mutex> lkg(_mutex);
                     _done = true;
                 }
                 if(!dynamic_cast<const Ice::ObjectNotExistException*>(&ex))
@@ -112,7 +112,7 @@ public:
 
     bool isDone() const
     {
-        lock_guard<mutex> lock(const_cast<mutex&>(_mutex));
+        const lock_guard<mutex> lock(const_cast<mutex&>(_mutex));
         return _done;
     }
 
@@ -157,7 +157,7 @@ main(int argc, char* argv[])
             initData.properties->setProperty("OverrideSessionEndpoints", "1");
          }
 
-        Ice::CommunicatorHolder ich(argc, argv, initData);
+        const Ice::CommunicatorHolder ich(argc, argv, initData);
 
         if(argc > 1)
         {
@@ -242,7 +242,7 @@ run(const shared_ptr<Ice::Communicator>& communicator)
 
     auto users = session->getInitialUsers();
     {
-        lock_guard<mutex> lock(coutMutex);
+        const lock_guard<mutex> lock(coutMutex);
         cout << "Users: ";
         for(auto it = users.begin(); it != users.end();)
         {
@@ -278,7 +278,7 @@ run(const shared_ptr<Ice::Communicator>& communicator)
                 {
                     if(s.size() > maxMessageSize)
                     {
-                        lock_guard<mutex> lock(coutMutex);
+                        const lock_guard<mutex> lock(coutMutex);
                         cout << "Message length exceeded, maximum length is " << maxMessageSize << " characters.";
                     }
                     else
@@ -316,6 +316,6 @@ run(const shared_ptr<Ice::Communicator>& communicator)
 void
 menu()
 {
-    lock_guard<mutex> lock(coutMutex);
+    const lock_guard<mutex> lock(coutMutex);
     cout << "enter /quit to exit." << endl;
 }

--- a/cpp11/Chat/server/ChatRoom.cpp
+++ b/cpp11/Chat/server/ChatRoom.cpp
@@ -15,7 +15,7 @@ ChatRoom::ChatRoom(bool trace, const shared_ptr<Ice::Logger>& logger) :
 void
 ChatRoom::reserve(const string& name)
 {
-    lock_guard<mutex> sync(_mutex);
+    const lock_guard<mutex> sync(_mutex);
     if(_reserved.find(name) != _reserved.end() || _members.find(name) != _members.end())
     {
         throw runtime_error("The name " + name + " is already in use.");
@@ -26,15 +26,16 @@ ChatRoom::reserve(const string& name)
 void
 ChatRoom::unreserve(const string& name)
 {
-    lock_guard<mutex> sync(_mutex);
+    const lock_guard<mutex> sync(_mutex);
     _reserved.erase(name);
 }
 
 void
 ChatRoom::join(const string& name, const shared_ptr<ChatRoomCallbackAdapter>& callback)
 {
-    lock_guard<mutex> sync(_mutex);
-    long long timestamp = chrono::duration_cast<chrono::milliseconds>(chrono::system_clock::now().time_since_epoch()).count();
+    const lock_guard<mutex> sync(_mutex);
+    const long long timestamp =
+        chrono::duration_cast<chrono::milliseconds>(chrono::system_clock::now().time_since_epoch()).count();
 
     _reserved.erase(name);
 
@@ -44,7 +45,7 @@ ChatRoom::join(const string& name, const shared_ptr<ChatRoomCallbackAdapter>& ca
         names.push_back(q.first);
     }
 
-    callback->init(move(names));
+    callback->init(std::move(names));
 
     _members[name] = callback;
 
@@ -64,8 +65,9 @@ ChatRoom::join(const string& name, const shared_ptr<ChatRoomCallbackAdapter>& ca
 void
 ChatRoom::leave(const string& name)
 {
-    lock_guard<mutex> sync(_mutex);
-    long long timestamp = chrono::duration_cast<chrono::milliseconds>(chrono::system_clock::now().time_since_epoch()).count();
+    const lock_guard<mutex> sync(_mutex);
+    const long long timestamp =
+        chrono::duration_cast<chrono::milliseconds>(chrono::system_clock::now().time_since_epoch()).count();
 
     _members.erase(name);
 
@@ -83,12 +85,13 @@ ChatRoom::leave(const string& name)
 }
 
 Ice::Long
-ChatRoom::send(const string& name, string message)
+ChatRoom::send(const string& name, const string& message)
 {
-    lock_guard<mutex> sync(_mutex);
-    long long timestamp = chrono::duration_cast<chrono::milliseconds>(chrono::system_clock::now().time_since_epoch()).count();
+    const lock_guard<mutex> sync(_mutex);
+    const long long timestamp =
+        chrono::duration_cast<chrono::milliseconds>(chrono::system_clock::now().time_since_epoch()).count();
 
-    auto e = make_shared<PollingChat::MessageEvent>(timestamp, name, message);
+    auto e = make_shared<PollingChat::MessageEvent>(timestamp, name, std::move(message));
     for(const auto& q: _members)
     {
         q.second->send(e);

--- a/cpp11/Chat/server/ChatRoom.cpp
+++ b/cpp11/Chat/server/ChatRoom.cpp
@@ -91,7 +91,7 @@ ChatRoom::send(const string& name, const string& message)
     const long long timestamp =
         chrono::duration_cast<chrono::milliseconds>(chrono::system_clock::now().time_since_epoch()).count();
 
-    auto e = make_shared<PollingChat::MessageEvent>(timestamp, name, std::move(message));
+    auto e = make_shared<PollingChat::MessageEvent>(timestamp, name, message);
     for(const auto& q: _members)
     {
         q.second->send(e);

--- a/cpp11/Chat/server/ChatRoom.h
+++ b/cpp11/Chat/server/ChatRoom.h
@@ -30,7 +30,7 @@ public:
     void unreserve(const std::string&);
     void join(const std::string&, const std::shared_ptr<ChatRoomCallbackAdapter>&);
     void leave(const std::string&);
-    long long send(const std::string&, std::string);
+    long long send(const std::string&, const std::string&);
 
 private:
 

--- a/cpp11/Chat/server/ChatServer.cpp
+++ b/cpp11/Chat/server/ChatServer.cpp
@@ -23,8 +23,8 @@ private:
 bool
 ChatServer::start(int, char*[], int& status)
 {
-    int timeout = communicator()->getProperties()->getPropertyAsIntWithDefault("PollingChatSessionTimeout", 10);
-    bool traceEnabled = communicator()->getProperties()->getPropertyAsIntWithDefault("Server.Trace", 0) != 0;
+    const int timeout = communicator()->getProperties()->getPropertyAsIntWithDefault("PollingChatSessionTimeout", 10);
+    const bool traceEnabled = communicator()->getProperties()->getPropertyAsIntWithDefault("Server.Trace", 0) != 0;
     auto logger = communicator()->getLogger();
 
     try

--- a/cpp11/Chat/server/ChatSessionI.h
+++ b/cpp11/Chat/server/ChatSessionI.h
@@ -12,7 +12,7 @@ class ChatSessionI : public Chat::ChatSession
 {
 public:
 
-    ChatSessionI(const std::shared_ptr<ChatRoom>&, const std::string&, bool trace, const std::shared_ptr<Ice::Logger>& logger);
+    ChatSessionI(const std::shared_ptr<ChatRoom>&, const std::string, bool trace, const std::shared_ptr<Ice::Logger>& logger);
 
     virtual void setCallback(std::shared_ptr<Chat::ChatRoomCallbackPrx>, const Ice::Current&) override;
     virtual long long send(std::string, const Ice::Current&) override;

--- a/cpp11/Chat/server/ChatSessionI.h
+++ b/cpp11/Chat/server/ChatSessionI.h
@@ -12,7 +12,7 @@ class ChatSessionI : public Chat::ChatSession
 {
 public:
 
-    ChatSessionI(const std::shared_ptr<ChatRoom>&, const std::string, bool trace, const std::shared_ptr<Ice::Logger>& logger);
+    ChatSessionI(const std::shared_ptr<ChatRoom>&, std::string, bool trace, const std::shared_ptr<Ice::Logger>& logger);
 
     virtual void setCallback(std::shared_ptr<Chat::ChatRoomCallbackPrx>, const Ice::Current&) override;
     virtual long long send(std::string, const Ice::Current&) override;

--- a/cpp11/Chat/server/ChatUtils.cpp
+++ b/cpp11/Chat/server/ChatUtils.cpp
@@ -54,7 +54,7 @@ validateMessage(const string& in)
     }
     // Strip html codes in the message
     string out;
-    for(char c : in)
+    for(const char c : in)
     {
         switch(c)
         {

--- a/cpp11/Chat/server/PollingChatSessionI.cpp
+++ b/cpp11/Chat/server/PollingChatSessionI.cpp
@@ -14,35 +14,35 @@ public:
     virtual void
     init(Ice::StringSeq users) override
     {
-        lock_guard<mutex> sync(_mutex);
-        _users = move(users);
+        const lock_guard<mutex> sync(_mutex);
+        _users = std::move(users);
     }
 
     virtual void
     send(const shared_ptr<PollingChat::MessageEvent>& e) override
     {
-        lock_guard<mutex> sync(_mutex);
+        const lock_guard<mutex> sync(_mutex);
         _updates.push_back(e);
     }
 
     virtual void
     join(const shared_ptr<PollingChat::UserJoinedEvent>& e) override
     {
-        lock_guard<mutex> sync(_mutex);
+        const lock_guard<mutex> sync(_mutex);
         _updates.push_back(e);
     }
 
     virtual void
     leave(const shared_ptr<PollingChat::UserLeftEvent>& e) override
     {
-        lock_guard<mutex> sync(_mutex);
+        const lock_guard<mutex> sync(_mutex);
         _updates.push_back(e);
     }
 
     Ice::StringSeq
     getInitialUsers()
     {
-        lock_guard<mutex> sync(_mutex);
+        const lock_guard<mutex> sync(_mutex);
         Ice::StringSeq users;
         users.swap(_users);
         return users;
@@ -51,7 +51,7 @@ public:
     PollingChat::ChatRoomEventSeq
     getUpdates()
     {
-        lock_guard<mutex> sync(_mutex);
+        const lock_guard<mutex> sync(_mutex);
         PollingChat::ChatRoomEventSeq updates;
         updates.swap(_updates);
         return updates;
@@ -78,7 +78,7 @@ PollingChatSessionI::PollingChatSessionI(const shared_ptr<ChatRoom>& chatRoom, c
 Ice::StringSeq
 PollingChatSessionI::getInitialUsers(const Ice::Current&)
 {
-    lock_guard<mutex> sync(_mutex);
+    const lock_guard<mutex> sync(_mutex);
     if(_destroy)
     {
         if(_trace)
@@ -94,7 +94,7 @@ PollingChatSessionI::getInitialUsers(const Ice::Current&)
 PollingChat::ChatRoomEventSeq
 PollingChatSessionI::getUpdates(const Ice::Current&)
 {
-    lock_guard<mutex> sync(_mutex);
+    const lock_guard<mutex> sync(_mutex);
     if(_destroy)
     {
         if(_trace)
@@ -110,7 +110,7 @@ PollingChatSessionI::getUpdates(const Ice::Current&)
 Ice::Long
 PollingChatSessionI::send(string message, const Ice::Current&)
 {
-    lock_guard<mutex> sync(_mutex);
+    const lock_guard<mutex> sync(_mutex);
     if(_destroy)
     {
         if(_trace)
@@ -134,13 +134,13 @@ PollingChatSessionI::send(string message, const Ice::Current&)
         }
         throw Chat::InvalidMessageException(ex.what());
     }
-    return _chatRoom->send(_name, move(msg));
+    return _chatRoom->send(_name, std::move(msg));
 }
 
 void
 PollingChatSessionI::destroy(const Ice::Current& current)
 {
-    lock_guard<mutex> sync(_mutex);
+    const lock_guard<mutex> sync(_mutex);
     if(_destroy)
     {
         if(_trace)

--- a/cpp11/Glacier2/callback/Client.cpp
+++ b/cpp11/Glacier2/callback/Client.cpp
@@ -36,7 +36,7 @@ main(int argc, char* argv[])
         // CommunicatorHolder's ctor initializes an Ice communicator,
         // and its dtor destroys this communicator.
         //
-        Ice::CommunicatorHolder ich(argc, argv, "config.client");
+        const Ice::CommunicatorHolder ich(argc, argv, "config.client");
 
         //
         // The communicator initialization removes all Ice-related arguments from argc/argv
@@ -64,7 +64,8 @@ void menu();
 void
 run(const shared_ptr<Ice::Communicator>& communicator)
 {
-    shared_ptr<Glacier2::RouterPrx> router = Ice::checkedCast<Glacier2::RouterPrx>(communicator->getDefaultRouter());
+    const shared_ptr<Glacier2::RouterPrx> router =
+        Ice::checkedCast<Glacier2::RouterPrx>(communicator->getDefaultRouter());
     shared_ptr<Glacier2::SessionPrx> session;
     //
     // Loop until we have successfully create a session.
@@ -103,8 +104,8 @@ run(const shared_ptr<Ice::Communicator>& communicator)
         }
     }
 
-    Ice::Int acmTimeout = router->getACMTimeout();
-    Ice::ConnectionPtr connection = router->ice_getCachedConnection();
+    const Ice::Int acmTimeout = router->getACMTimeout();
+    const Ice::ConnectionPtr connection = router->ice_getCachedConnection();
     assert(connection);
     connection->setACM(acmTimeout, IceUtil::None, Ice::ACMHeartbeat::HeartbeatAlways);
     connection->setCloseCallback([](Ice::ConnectionPtr)

--- a/cpp11/Glacier2/callback/Server.cpp
+++ b/cpp11/Glacier2/callback/Server.cpp
@@ -27,8 +27,8 @@ int main(int argc, char* argv[])
         // CommunicatorHolder's ctor initializes an Ice communicator,
         // and its dtor destroys this communicator.
         //
-        Ice::CommunicatorHolder ich(argc, argv, "config.server");
-        auto communicator = ich.communicator();
+        const Ice::CommunicatorHolder ich(argc, argv, "config.server");
+        const auto& communicator = ich.communicator();
 
         ctrlCHandler.setCallback(
             [communicator](int)

--- a/cpp11/Glacier2/simpleChat/ChatSessionI.h
+++ b/cpp11/Glacier2/simpleChat/ChatSessionI.h
@@ -13,7 +13,7 @@ class ChatSessionI : public Demo::ChatSession
 {
 public:
 
-    ChatSessionI(const std::string&);
+    ChatSessionI(std::string);
 
     virtual void setCallback(std::shared_ptr<Demo::ChatCallbackPrx>, const Ice::Current&) override;
     virtual void say(std::string, const Ice::Current&) override;

--- a/cpp11/Glacier2/simpleChat/Client.cpp
+++ b/cpp11/Glacier2/simpleChat/Client.cpp
@@ -19,7 +19,7 @@ public:
     virtual void
     message(string data, const Ice::Current&) override
     {
-        lock_guard<mutex> lock(coutMutex);
+        const lock_guard<mutex> lock(coutMutex);
         cout << data << endl;
     }
 };
@@ -41,7 +41,7 @@ main(int argc, char* argv[])
         // CommunicatorHolder's ctor initializes an Ice communicator,
         // and its dtor destroys this communicator.
         //
-        Ice::CommunicatorHolder ich(argc, argv, "config.client");
+        const Ice::CommunicatorHolder ich(argc, argv, "config.client");
 
         //
         // The communicator initialization removes all Ice-related arguments from argc/argv
@@ -70,7 +70,8 @@ string trim(const string&);
 void
 run(const shared_ptr<Ice::Communicator>& communicator)
 {
-    shared_ptr<Glacier2::RouterPrx> router = Ice::checkedCast<Glacier2::RouterPrx>(communicator->getDefaultRouter());
+    const shared_ptr<Glacier2::RouterPrx> router =
+        Ice::checkedCast<Glacier2::RouterPrx>(communicator->getDefaultRouter());
     shared_ptr<ChatSessionPrx> session;
     while(!session)
     {
@@ -99,13 +100,13 @@ run(const shared_ptr<Ice::Communicator>& communicator)
         }
     }
 
-    Ice::Int acmTimeout = router->getACMTimeout();
-    Ice::ConnectionPtr connection = router->ice_getCachedConnection();
+    const Ice::Int acmTimeout = router->getACMTimeout();
+    const Ice::ConnectionPtr connection = router->ice_getCachedConnection();
     assert(connection);
     connection->setACM(acmTimeout, IceUtil::None, Ice::ACMHeartbeat::HeartbeatAlways);
     connection->setCloseCallback([](Ice::ConnectionPtr)
                                  {
-                                     lock_guard<mutex> lock(coutMutex);
+                                     const lock_guard<mutex> lock(coutMutex);
                                      cout << "The Glacier2 session has been destroyed." << endl;
                                  });
 
@@ -126,7 +127,7 @@ run(const shared_ptr<Ice::Communicator>& communicator)
     {
         string s;
         {
-            lock_guard<mutex> lock(coutMutex);
+            const lock_guard<mutex> lock(coutMutex);
             cout << "==> ";
         }
         getline(cin, s);
@@ -153,7 +154,7 @@ run(const shared_ptr<Ice::Communicator>& communicator)
 void
 menu()
 {
-    lock_guard<mutex> lock(coutMutex);
+    const lock_guard<mutex> lock(coutMutex);
     cout << "enter /quit to exit." << endl;
 }
 

--- a/cpp11/Glacier2/simpleChat/Server.cpp
+++ b/cpp11/Glacier2/simpleChat/Server.cpp
@@ -40,8 +40,8 @@ int main(int argc, char* argv[])
         // CommunicatorHolder's ctor initializes an Ice communicator,
         // and its dtor destroys this communicator.
         //
-        Ice::CommunicatorHolder ich(argc, argv, "config.server");
-        auto communicator = ich.communicator();
+        const Ice::CommunicatorHolder ich(argc, argv, "config.server");
+        const auto& communicator = ich.communicator();
 
         ctrlCHandler.setCallback(
             [communicator](int)

--- a/cpp11/Ice/async/Client.cpp
+++ b/cpp11/Ice/async/Client.cpp
@@ -21,7 +21,7 @@ main(int argc, char* argv[])
         // CommunicatorHolder's ctor initializes an Ice communicator,
         // and its dtor destroys this communicator.
         //
-        Ice::CommunicatorHolder ich(argc, argv, "config.client");
+        const Ice::CommunicatorHolder ich(argc, argv, "config.client");
 
         //
         // The communicator initialization removes all Ice-related arguments from argc/argv

--- a/cpp11/Ice/async/HelloI.cpp
+++ b/cpp11/Ice/async/HelloI.cpp
@@ -25,7 +25,7 @@ HelloI::sayHelloAsync(int delay,
     }
     else
     {
-        _workQueue->add(delay, move(response), move(error));
+        _workQueue->add(delay, std::move(response), std::move(error));
     }
 }
 

--- a/cpp11/Ice/async/Server.cpp
+++ b/cpp11/Ice/async/Server.cpp
@@ -23,8 +23,8 @@ int main(int argc, char* argv[])
         // CommunicatorHolder's ctor initializes an Ice communicator,
         // and its dtor destroys this communicator.
         //
-        Ice::CommunicatorHolder ich(argc, argv, "config.server");
-        auto communicator = ich.communicator();
+        const Ice::CommunicatorHolder ich(argc, argv, "config.server");
+        const auto& communicator = ich.communicator();
 
         shared_ptr<WorkQueue> _workQueue;
 

--- a/cpp11/Ice/async/WorkQueue.cpp
+++ b/cpp11/Ice/async/WorkQueue.cpp
@@ -18,7 +18,7 @@ WorkQueue::start()
         {
             this->run();
         });
-    _thread = move(t);
+    _thread = std::move(t);
 }
 
 void
@@ -81,7 +81,7 @@ WorkQueue::run()
 void
 WorkQueue::add(int delay, function<void ()> response, function<void (exception_ptr)> error)
 {
-    unique_lock<mutex> lock(_mutex);
+    const unique_lock<mutex> lock(_mutex);
 
     if(!_done)
     {
@@ -92,7 +92,7 @@ WorkQueue::add(int delay, function<void ()> response, function<void (exception_p
         {
             _condition.notify_one();
         }
-        _callbacks.push_back(make_tuple(delay, move(response), move(error)));
+        _callbacks.emplace_back(delay, std::move(response), std::move(error));
     }
     else
     {
@@ -106,7 +106,7 @@ WorkQueue::add(int delay, function<void ()> response, function<void (exception_p
 void
 WorkQueue::destroy()
 {
-    unique_lock<mutex> lock(_mutex);
+    const unique_lock<mutex> lock(_mutex);
 
     //
     // Set done flag and notify.

--- a/cpp11/Ice/asyncInvocation/CalculatorI.cpp
+++ b/cpp11/Ice/asyncInvocation/CalculatorI.cpp
@@ -4,7 +4,7 @@
 
 #include <Ice/Ice.h>
 #include <CalculatorI.h>
-#include <math.h>
+#include <cmath>
 
 using namespace std;
 

--- a/cpp11/Ice/asyncInvocation/Client.cpp
+++ b/cpp11/Ice/asyncInvocation/Client.cpp
@@ -28,8 +28,8 @@ main(int argc, char* argv[])
         // CommunicatorHolder's ctor initializes an Ice communicator,
         // and its dtor destroys this communicator.
         //
-        Ice::CommunicatorHolder ich(argc, argv, "config.client");
-        auto communicator = ich.communicator();
+        const Ice::CommunicatorHolder ich(argc, argv, "config.client");
+        const auto& communicator = ich.communicator();
 
         ctrlCHandler.setCallback(
             [communicator](int)
@@ -62,7 +62,7 @@ main(int argc, char* argv[])
 int
 run(const shared_ptr<Ice::Communicator>& communicator, const string& appName)
 {
-    auto calculator = Ice::checkedCast<Demo::CalculatorPrx>(communicator->propertyToProxy("Calculator.Proxy"));
+    const auto calculator = Ice::checkedCast<Demo::CalculatorPrx>(communicator->propertyToProxy("Calculator.Proxy"));
     if(!calculator)
     {
         cerr << appName << ": invalid proxy" << endl;

--- a/cpp11/Ice/asyncInvocation/Server.cpp
+++ b/cpp11/Ice/asyncInvocation/Server.cpp
@@ -23,8 +23,8 @@ int main(int argc, char* argv[])
         // CommunicatorHolder's ctor initializes an Ice communicator,
         // and its dtor destroys this communicator.
         //
-        Ice::CommunicatorHolder ich(argc, argv, "config.server");
-        auto communicator = ich.communicator();
+        const Ice::CommunicatorHolder ich(argc, argv, "config.server");
+        const auto& communicator = ich.communicator();
 
         ctrlCHandler.setCallback(
             [communicator](int)

--- a/cpp11/Ice/bidir/CallbackI.cpp
+++ b/cpp11/Ice/bidir/CallbackI.cpp
@@ -11,7 +11,7 @@ using namespace Demo;
 void
 CallbackSenderI::addClient(std::shared_ptr<CallbackReceiverPrx> client, const Ice::Current& current)
 {
-    lock_guard<mutex> lock(_mutex);
+    const lock_guard<mutex> lock(_mutex);
     cout << "adding client `" << Ice::identityToString(client->ice_getIdentity()) << "'" << endl;
     _clients.push_back(client->ice_fixed(current.con));
 }
@@ -20,7 +20,7 @@ void
 CallbackSenderI::destroy()
 {
     {
-        lock_guard<mutex> lock(_mutex);
+        const lock_guard<mutex> lock(_mutex);
         cout << "destroying callback sender" << endl;
         _destroy = true;
     }
@@ -83,7 +83,7 @@ CallbackSenderI::invokeCallback()
 void
 CallbackSenderI::removeClient(const shared_ptr<CallbackReceiverPrx>& client, exception_ptr eptr)
 {
-    lock_guard<mutex> lock(_mutex);
+    const lock_guard<mutex> lock(_mutex);
     auto p = find(_clients.begin(), _clients.end(), client);
     if(p != _clients.end())
     {

--- a/cpp11/Ice/bidir/Client.cpp
+++ b/cpp11/Ice/bidir/Client.cpp
@@ -41,8 +41,8 @@ main(int argc, char* argv[])
         // CommunicatorHolder's ctor initializes an Ice communicator,
         // and its dtor destroys this communicator.
         //
-        Ice::CommunicatorHolder ich(argc, argv, "config.client");
-        auto communicator = ich.communicator();
+        const Ice::CommunicatorHolder ich(argc, argv, "config.client");
+        const auto& communicator = ich.communicator();
 
         ctrlCHandler.setCallback(
             [communicator](int)

--- a/cpp11/Ice/bidir/Server.cpp
+++ b/cpp11/Ice/bidir/Server.cpp
@@ -27,8 +27,8 @@ int main(int argc, char* argv[])
         // CommunicatorHolder's ctor initializes an Ice communicator,
         // and its dtor destroys this communicator.
         //
-        Ice::CommunicatorHolder ich(argc, argv, "config.server");
-        auto communicator = ich.communicator();
+        const Ice::CommunicatorHolder ich(argc, argv, "config.server");
+        const auto& communicator = ich.communicator();
 
         ctrlCHandler.setCallback(
             [communicator](int)

--- a/cpp11/Ice/callback/Client.cpp
+++ b/cpp11/Ice/callback/Client.cpp
@@ -35,7 +35,7 @@ main(int argc, char* argv[])
         // CommunicatorHolder's ctor initializes an Ice communicator,
         // and its dtor destroys this communicator.
         //
-        Ice::CommunicatorHolder ich(argc, argv, "config.client");
+        const Ice::CommunicatorHolder ich(argc, argv, "config.client");
 
         //
         // The communicator initialization removes all Ice-related arguments from argc/argv

--- a/cpp11/Ice/callback/Server.cpp
+++ b/cpp11/Ice/callback/Server.cpp
@@ -27,8 +27,8 @@ int main(int argc, char* argv[])
         // CommunicatorHolder's ctor initializes an Ice communicator,
         // and its dtor destroys this communicator.
         //
-        Ice::CommunicatorHolder ich(argc, argv, "config.server");
-        auto communicator = ich.communicator();
+        const Ice::CommunicatorHolder ich(argc, argv, "config.server");
+        const auto& communicator = ich.communicator();
 
         ctrlCHandler.setCallback(
             [communicator](int)

--- a/cpp11/Ice/context/Client.cpp
+++ b/cpp11/Ice/context/Client.cpp
@@ -25,7 +25,7 @@ main(int argc, char* argv[])
         // CommunicatorHolder's ctor initializes an Ice communicator,
         // and its dtor destroys this communicator.
         //
-        Ice::CommunicatorHolder ich(argc, argv, "config.client");
+        const Ice::CommunicatorHolder ich(argc, argv, "config.client");
 
         //
         // The communicator initialization removes all Ice-related arguments from argc/argv

--- a/cpp11/Ice/context/Server.cpp
+++ b/cpp11/Ice/context/Server.cpp
@@ -26,8 +26,8 @@ int main(int argc, char* argv[])
         // CommunicatorHolder's ctor initializes an Ice communicator,
         // and its dtor destroys this communicator.
         //
-        Ice::CommunicatorHolder ich(argc, argv, "config.server");
-        auto communicator = ich.communicator();
+        const Ice::CommunicatorHolder ich(argc, argv, "config.server");
+        const auto& communicator = ich.communicator();
 
         ctrlCHandler.setCallback(
             [communicator](int)

--- a/cpp11/Ice/hello/Client.cpp
+++ b/cpp11/Ice/hello/Client.cpp
@@ -27,7 +27,7 @@ main(int argc, char* argv[])
         // CommunicatorHolder's ctor initializes an Ice communicator,
         // and its dtor destroys this communicator.
         //
-        Ice::CommunicatorHolder ich(argc, argv, "config.client");
+        const Ice::CommunicatorHolder ich(argc, argv, "config.client");
 
         //
         // The communicator initialization removes all Ice-related arguments from argc/argv

--- a/cpp11/Ice/hello/Server.cpp
+++ b/cpp11/Ice/hello/Server.cpp
@@ -28,8 +28,8 @@ int main(int argc, char* argv[])
         // CommunicatorHolder's ctor initializes an Ice communicator,
         // and its dtor destroys this communicator.
         //
-        Ice::CommunicatorHolder ich(argc, argv, "config.server");
-        auto communicator = ich.communicator();
+        const Ice::CommunicatorHolder ich(argc, argv, "config.server");
+        const auto& communicator = ich.communicator();
 
         ctrlCHandler.setCallback(
             [communicator](int)

--- a/cpp11/Ice/interceptor/AuthenticatorI.cpp
+++ b/cpp11/Ice/interceptor/AuthenticatorI.cpp
@@ -19,7 +19,7 @@ AuthenticatorI::AuthenticatorI() :
 string
 AuthenticatorI::getToken(const Ice::Current&)
 {
-    lock_guard<mutex> lock(_tokenLock);
+    const lock_guard<mutex> lock(_tokenLock);
     //
     // Generate a random 32 character long token.
     //
@@ -43,7 +43,7 @@ AuthenticatorI::getToken(const Ice::Current&)
 void
 AuthenticatorI::validateToken(const string& tokenValue)
 {
-    lock_guard<mutex> lock(_tokenLock);
+    const lock_guard<mutex> lock(_tokenLock);
 
     //
     // Remove any expired tokens.

--- a/cpp11/Ice/interceptor/Client.cpp
+++ b/cpp11/Ice/interceptor/Client.cpp
@@ -20,7 +20,7 @@ main(int argc, char* argv[])
         // CommunicatorHolder's ctor initializes an Ice communicator,
         // and its dtor destroys this communicator.
         //
-        Ice::CommunicatorHolder ich(argc, argv, "config.client");
+        const Ice::CommunicatorHolder ich(argc, argv, "config.client");
 
         //
         // The communicator intialization removes all Ice-related arguments from argc/argv.
@@ -106,7 +106,7 @@ run(const shared_ptr<Ice::Communicator>& communicator)
                 //
                 // Request an access token from the server's authentication object.
                 //
-                string token = authenticator->getToken();
+                const string token = authenticator->getToken();
                 cout << "Successfully retrieved access token: \"" << token << "\"" << endl;
                 //
                 // Add the access token to the communicator's context, so it will be

--- a/cpp11/Ice/interceptor/InterceptorI.cpp
+++ b/cpp11/Ice/interceptor/InterceptorI.cpp
@@ -8,7 +8,9 @@ using namespace std;
 
 InterceptorI::InterceptorI(shared_ptr<Ice::Object> servant, shared_ptr<AuthenticatorI> authenticator,
                            unordered_set<string> securedOperations) :
-    _servant(move(servant)), _authenticator(move(authenticator)), _securedOperations(move(securedOperations))
+    _servant(std::move(servant)),
+    _authenticator(std::move(authenticator)),
+    _securedOperations(std::move(securedOperations))
 {
 }
 

--- a/cpp11/Ice/interceptor/Server.cpp
+++ b/cpp11/Ice/interceptor/Server.cpp
@@ -26,8 +26,8 @@ int main(int argc, char* argv[])
         // CommunicatorHolder's ctor initializes an Ice communicator,
         // and its dtor destroys this communicator.
         //
-        Ice::CommunicatorHolder ich(argc, argv, "config.server");
-        auto communicator = ich.communicator();
+        const Ice::CommunicatorHolder ich(argc, argv, "config.server");
+        const auto& communicator = ich.communicator();
 
         ctrlCHandler.setCallback(
             [communicator](int)
@@ -68,7 +68,10 @@ int main(int argc, char* argv[])
             //
             auto thermostatAdapter = communicator->createObjectAdapter("Thermostat");
             auto thermostat = make_shared<ThermostatI>();
-            auto interceptor = make_shared<InterceptorI>(move(thermostat), authenticator, move(securedOperations));
+            auto interceptor = make_shared<InterceptorI>(
+                std::move(thermostat),
+                authenticator,
+                std::move(securedOperations));
             thermostatAdapter->add(interceptor, Ice::stringToIdentity("thermostat"));
             thermostatAdapter->activate();
 

--- a/cpp11/Ice/interceptor/ThermostatI.cpp
+++ b/cpp11/Ice/interceptor/ThermostatI.cpp
@@ -10,14 +10,14 @@ using namespace std;
 float
 ThermostatI::getTemp(const Ice::Current&)
 {
-    lock_guard<mutex> lock(_thermostatLock);
+    const lock_guard<mutex> lock(_thermostatLock);
     return _temperature;
 }
 
 void
 ThermostatI::setTemp(float temp, const Ice::Current&)
 {
-    lock_guard<mutex> lock(_thermostatLock);
+    const lock_guard<mutex> lock(_thermostatLock);
     _temperature = temp;
 }
 

--- a/cpp11/Ice/interleaved/Client.cpp
+++ b/cpp11/Ice/interleaved/Client.cpp
@@ -34,8 +34,8 @@ main(int argc, char* argv[])
         // CommunicatorHolder's ctor initializes an Ice communicator,
         // and its dtor destroys this communicator.
         //
-        Ice::CommunicatorHolder ich(argc, argv, "config.client");
-        auto communicator = ich.communicator();
+        const Ice::CommunicatorHolder ich(argc, argv, "config.client");
+        const auto& communicator = ich.communicator();
 
         ctrlCHandler.setCallback(
             [communicator](int)
@@ -133,7 +133,7 @@ auto throughput = Ice::checkedCast<ThroughputPrx>(communicator->propertyToProxy(
     cout << "time for " << repetitions << " sequences: " << duration.count() << "ms" << endl;
     cout << "time per sequence: " << duration.count() / repetitions << "ms" << endl;
 
-    double mbit = 2 * repetitions * ByteSeqSize * 1 * 8.0 / duration.count() / 1000;
+    const double mbit = 2 * repetitions * ByteSeqSize * 1 * 8.0 / duration.count() / 1000;
 
     cout << "throughput: " << setprecision(5) << mbit << "Mbps" << endl;
 

--- a/cpp11/Ice/interleaved/Server.cpp
+++ b/cpp11/Ice/interleaved/Server.cpp
@@ -26,8 +26,8 @@ int main(int argc, char* argv[])
         // CommunicatorHolder's ctor initializes an Ice communicator,
         // and its dtor destroys this communicator.
         //
-        Ice::CommunicatorHolder ich(argc, argv, "config.server");
-        auto communicator = ich.communicator();
+        const Ice::CommunicatorHolder ich(argc, argv, "config.server");
+        const auto& communicator = ich.communicator();
 
         ctrlCHandler.setCallback(
             [communicator](int)

--- a/cpp11/Ice/invoke/Client.cpp
+++ b/cpp11/Ice/invoke/Client.cpp
@@ -43,7 +43,7 @@ main(int argc, char* argv[])
         // CommunicatorHolder's ctor initializes an Ice communicator,
         // and its dtor destroys this communicator.
         //
-        Ice::CommunicatorHolder ich(argc, argv, "config.client");
+        const Ice::CommunicatorHolder ich(argc, argv, "config.client");
 
         //
         // The communicator initialization removes all Ice-related arguments from argc/argv
@@ -111,7 +111,7 @@ run(const shared_ptr<Ice::Communicator>& communicator)
                 Ice::ByteSeq inParams, outParams;
                 Ice::OutputStream out(communicator);
                 out.startEncapsulation();
-                Demo::StringSeq arr({"The", "streaming", "API", "works!"});
+                const Demo::StringSeq arr({"The", "streaming", "API", "works!"});
                 out.write(arr);
                 out.endEncapsulation();
                 out.finished(inParams);
@@ -132,7 +132,7 @@ run(const shared_ptr<Ice::Communicator>& communicator)
                 Ice::ByteSeq inParams, outParams;
                 Ice::OutputStream out(communicator);
                 out.startEncapsulation();
-                Demo::StringDict dict
+                const Demo::StringDict dict
                     {
                         {"The", "streaming"},
                         {"API", "works!"}
@@ -251,7 +251,8 @@ run(const shared_ptr<Ice::Communicator>& communicator)
                 //
                 // Invoke operation.
                 //
-                Ice::ByteSeq inParams, outParams;
+                const Ice::ByteSeq inParams;
+                Ice::ByteSeq outParams;
                 if(!obj->ice_invoke("getValues", Ice::OperationMode::Normal, inParams, outParams))
                 {
                     cout << "Unknown user exception" << endl;
@@ -277,7 +278,8 @@ run(const shared_ptr<Ice::Communicator>& communicator)
                 //
                 // Invoke operation.
                 //
-                Ice::ByteSeq inParams, outParams;
+                const Ice::ByteSeq inParams;
+                Ice::ByteSeq outParams;
                 if(obj->ice_invoke("throwPrintFailure", Ice::OperationMode::Normal, inParams, outParams))
                 {
                     cout << "Expected exception" << endl;
@@ -302,7 +304,8 @@ run(const shared_ptr<Ice::Communicator>& communicator)
             }
             else if(ch == 's')
             {
-                Ice::ByteSeq inParams, outParams;
+                const Ice::ByteSeq inParams;
+                Ice::ByteSeq outParams;
                 obj->ice_invoke("shutdown", Ice::OperationMode::Normal, inParams, outParams);
             }
             else if(ch == 'x')

--- a/cpp11/Ice/invoke/PrinterI.cpp
+++ b/cpp11/Ice/invoke/PrinterI.cpp
@@ -47,7 +47,7 @@ PrinterI::ice_invoke(vector<Ice::Byte> inParams, vector<Ice::Byte>& outParams, c
         Demo::StringSeq seq;
         in.read(seq);
         cout << "Printing string sequence {";
-        for(Demo::StringSeq::iterator p = seq.begin(); p != seq.end(); ++p)
+        for(auto p = seq.begin(); p != seq.end(); ++p)
         {
             if(p != seq.begin())
             {
@@ -62,7 +62,7 @@ PrinterI::ice_invoke(vector<Ice::Byte> inParams, vector<Ice::Byte>& outParams, c
         Demo::StringDict dict;
         in.read(dict);
         cout << "Printing dictionary {";
-        for(Demo::StringDict::iterator p = dict.begin(); p != dict.end(); ++p)
+        for(auto p = dict.begin(); p != dict.end(); ++p)
         {
             if(p != dict.begin())
             {
@@ -89,7 +89,7 @@ PrinterI::ice_invoke(vector<Ice::Byte> inParams, vector<Ice::Byte>& outParams, c
         Demo::StructureSeq seq;
         in.read(seq);
         cout << "Printing struct sequence: {";
-        for(Demo::StructureSeq::iterator p = seq.begin(); p != seq.end(); ++p)
+        for(auto p = seq.begin(); p != seq.end(); ++p)
         {
             if(p != seq.begin())
             {
@@ -135,11 +135,7 @@ PrinterI::ice_invoke(vector<Ice::Byte> inParams, vector<Ice::Byte>& outParams, c
     }
     else
     {
-        Ice::OperationNotExistException ex(__FILE__, __LINE__);
-        ex.id = current.id;
-        ex.facet = current.facet;
-        ex.operation = current.operation;
-        throw ex;
+        throw Ice::OperationNotExistException(__FILE__, __LINE__, current.id, current.facet, current.operation);
     }
 
     //

--- a/cpp11/Ice/invoke/Server.cpp
+++ b/cpp11/Ice/invoke/Server.cpp
@@ -26,8 +26,8 @@ int main(int argc, char* argv[])
         // CommunicatorHolder's ctor initializes an Ice communicator,
         // and its dtor destroys this communicator.
         //
-        Ice::CommunicatorHolder ich(argc, argv, "config.server");
-        auto communicator = ich.communicator();
+        const Ice::CommunicatorHolder ich(argc, argv, "config.server");
+        const auto& communicator = ich.communicator();
 
         ctrlCHandler.setCallback(
             [communicator](int)

--- a/cpp11/Ice/latency/Client.cpp
+++ b/cpp11/Ice/latency/Client.cpp
@@ -31,8 +31,8 @@ main(int argc, char* argv[])
         // CommunicatorHolder's ctor initializes an Ice communicator,
         // and its dtor destroys this communicator.
         //
-        Ice::CommunicatorHolder ich(argc, argv, "config.client");
-        auto communicator = ich.communicator();
+        const Ice::CommunicatorHolder ich(argc, argv, "config.client");
+        const auto& communicator = ich.communicator();
 
         ctrlCHandler.setCallback(
             [communicator](int)

--- a/cpp11/Ice/latency/Server.cpp
+++ b/cpp11/Ice/latency/Server.cpp
@@ -28,8 +28,8 @@ int main(int argc, char* argv[])
         // CommunicatorHolder's ctor initializes an Ice communicator,
         // and its dtor destroys this communicator.
         //
-        Ice::CommunicatorHolder ich(argc, argv, "config.server");
-        auto communicator = ich.communicator();
+        const Ice::CommunicatorHolder ich(argc, argv, "config.server");
+        const auto& communicator = ich.communicator();
 
         ctrlCHandler.setCallback(
             [communicator](int)

--- a/cpp11/Ice/locator/Client.cpp
+++ b/cpp11/Ice/locator/Client.cpp
@@ -21,7 +21,7 @@ main(int argc, char* argv[])
         // CommunicatorHolder's ctor initializes an Ice communicator,
         // and its dtor destroys this communicator.
         //
-        Ice::CommunicatorHolder ich(argc, argv, "config.client");
+        const Ice::CommunicatorHolder ich(argc, argv, "config.client");
 
         //
         // The communicator initialization removes all Ice-related arguments from argc/argv

--- a/cpp11/Ice/locator/Locator.cpp
+++ b/cpp11/Ice/locator/Locator.cpp
@@ -68,8 +68,8 @@ public:
 
     LocatorI(shared_ptr<LocatorRegistryI> registry,
              shared_ptr<Ice::LocatorRegistryPrx> registryPrx) :
-        _registry(move(registry)),
-        _registryPrx(move(registryPrx))
+        _registry(std::move(registry)),
+        _registryPrx(std::move(registryPrx))
     {
     }
 
@@ -120,8 +120,8 @@ int main(int argc, char* argv[])
         // CommunicatorHolder's ctor initializes an Ice communicator,
         // and its dtor destroys this communicator.
         //
-        Ice::CommunicatorHolder ich(argc, argv, "config.locator");
-        auto communicator = ich.communicator();
+        const Ice::CommunicatorHolder ich(argc, argv, "config.locator");
+        const auto& communicator = ich.communicator();
 
         ctrlCHandler.setCallback(
             [communicator](int)
@@ -145,7 +145,7 @@ int main(int argc, char* argv[])
             auto registryPrx = Ice::uncheckedCast<Ice::LocatorRegistryPrx>(
                 adapter->add(registry, Ice::stringToIdentity("registry")));
 
-            adapter->add(make_shared<LocatorI>(move(registry), move(registryPrx)),
+            adapter->add(make_shared<LocatorI>(std::move(registry), std::move(registryPrx)),
                          Ice::stringToIdentity("locator"));
             adapter->activate();
 

--- a/cpp11/Ice/locator/Server.cpp
+++ b/cpp11/Ice/locator/Server.cpp
@@ -22,8 +22,8 @@ int main(int argc, char* argv[])
         // CommunicatorHolder's ctor initializes an Ice communicator,
         // and its dtor destroys this communicator.
         //
-        Ice::CommunicatorHolder ich(argc, argv, "config.server");
-        auto communicator = ich.communicator();
+        const Ice::CommunicatorHolder ich(argc, argv, "config.server");
+        const auto& communicator = ich.communicator();
 
         ctrlCHandler.setCallback(
             [communicator](int)

--- a/cpp11/Ice/minimal/Client.cpp
+++ b/cpp11/Ice/minimal/Client.cpp
@@ -13,7 +13,7 @@ main(int argc, char* argv[])
 {
     try
     {
-        Ice::CommunicatorHolder ich(argc, argv);
+        const Ice::CommunicatorHolder ich(argc, argv);
         auto hello = Ice::checkedCast<HelloPrx>(ich->stringToProxy("hello:default -h localhost -p 10000"));
         hello->sayHello();
     }

--- a/cpp11/Ice/minimal/Server.cpp
+++ b/cpp11/Ice/minimal/Server.cpp
@@ -17,8 +17,8 @@ main(int argc, char* argv[])
         //
         Ice::CtrlCHandler ctrlCHandler;
 
-        Ice::CommunicatorHolder ich(argc, argv);
-        auto communicator = ich.communicator();
+        const Ice::CommunicatorHolder ich(argc, argv);
+        const auto& communicator = ich.communicator();
 
         ctrlCHandler.setCallback(
             [communicator](int)

--- a/cpp11/Ice/mtalk/Client.cpp
+++ b/cpp11/Ice/mtalk/Client.cpp
@@ -142,7 +142,7 @@ public:
     ~DiscoverTask()
     {
         {
-            lock_guard<mutex> lock(_mutex);
+            const lock_guard<mutex> lock(_mutex);
             _destroyed = true;
         }
         _condition.notify_one();
@@ -332,7 +332,7 @@ ChatApp::run(const shared_ptr<Ice::Communicator>& communicator)
 void
 ChatApp::discoveredPeer(const string& name, const shared_ptr<MTalk::PeerPrx>& peer)
 {
-    lock_guard<mutex> lock(_mutex);
+    const lock_guard<mutex> lock(_mutex);
 
     //
     // We also receive multicast messages that we send, so ignore requests from ourself.
@@ -361,7 +361,7 @@ ChatApp::connect(const string& name, const shared_ptr<MTalk::PeerPrx>& peer)
     // Called for a new incoming connection request.
     //
 
-    lock_guard<mutex> lock(_mutex);
+    const lock_guard<mutex> lock(_mutex);
 
     if(_remote)
     {
@@ -394,7 +394,7 @@ ChatApp::connect(const string& name, const shared_ptr<MTalk::PeerPrx>& peer)
 void
 ChatApp::message(const string& text)
 {
-    lock_guard<mutex> lock(_mutex);
+    const lock_guard<mutex> lock(_mutex);
 
     if(_remote)
     {
@@ -405,7 +405,7 @@ ChatApp::message(const string& text)
 void
 ChatApp::disconnect(const Ice::Identity& id, const shared_ptr<Ice::Connection>& con, bool incoming)
 {
-    lock_guard<mutex> lock(_mutex);
+    const lock_guard<mutex> lock(_mutex);
 
     if(_remote)
     {
@@ -424,7 +424,7 @@ ChatApp::disconnect(const Ice::Identity& id, const shared_ptr<Ice::Connection>& 
 void
 ChatApp::closed()
 {
-    lock_guard<mutex> lock(_mutex);
+    const lock_guard<mutex> lock(_mutex);
 
     _remote = nullptr;
 
@@ -450,7 +450,7 @@ ChatApp::doConnect(const string& cmd)
 
     shared_ptr<MTalk::PeerPrx> remote;
     {
-        lock_guard<mutex> lock(_mutex);
+        const lock_guard<mutex> lock(_mutex);
 
         if(_remote)
         {
@@ -529,7 +529,7 @@ ChatApp::doConnect(const string& cmd)
 void
 ChatApp::doList()
 {
-    lock_guard<mutex> lock(_mutex);
+    const lock_guard<mutex> lock(_mutex);
 
     if(_peers.empty())
     {
@@ -550,7 +550,7 @@ ChatApp::doDisconnect()
     shared_ptr<MTalk::PeerPrx> peer;
 
     {
-        lock_guard<mutex> lock(_mutex);
+        const lock_guard<mutex> lock(_mutex);
 
         if(!_remote)
         {
@@ -577,7 +577,7 @@ ChatApp::doMessage(const string& text)
     shared_ptr<MTalk::PeerPrx> peer;
 
     {
-        lock_guard<mutex> lock(_mutex);
+        const lock_guard<mutex> lock(_mutex);
 
         if(!_remote)
         {
@@ -604,7 +604,7 @@ ChatApp::failed(const Ice::LocalException& ex)
     shared_ptr<MTalk::PeerPrx> peer;
 
     {
-        lock_guard<mutex> lock(_mutex);
+        const lock_guard<mutex> lock(_mutex);
         peer = _remote;
         _remote = nullptr;
     }

--- a/cpp11/Ice/multicast/Client.cpp
+++ b/cpp11/Ice/multicast/Client.cpp
@@ -22,7 +22,7 @@ public:
     reply(shared_ptr<Ice::ObjectPrx> obj, const Ice::Current&) override
     {
         {
-            lock_guard<mutex> lk(_mutex);
+            const lock_guard<mutex> lock(_mutex);
             if(!_obj)
             {
                 _obj = obj;
@@ -35,11 +35,11 @@ public:
     waitReply(int seconds)
     {
         auto until = chrono::system_clock::now() + chrono::seconds(seconds);
-        unique_lock<mutex> lk(_mutex);
+        unique_lock<mutex> lock(_mutex);
         bool timedOut = false;
         do
         {
-            timedOut = _cond.wait_until(lk, until) == cv_status::timeout;
+            timedOut = _cond.wait_until(lock, until) == cv_status::timeout;
         } while(!_obj && !timedOut);
 
         return _obj;
@@ -74,8 +74,8 @@ main(int argc, char* argv[])
         // CommunicatorHolder's ctor initializes an Ice communicator,
         // and its dtor destroys this communicator.
         //
-        Ice::CommunicatorHolder ich(argc, argv, "config.client");
-        auto communicator = ich.communicator();
+        const Ice::CommunicatorHolder ich(argc, argv, "config.client");
+        const auto& communicator = ich.communicator();
 
         ctrlCHandler.setCallback(
             [communicator](int)

--- a/cpp11/Ice/multicast/Server.cpp
+++ b/cpp11/Ice/multicast/Server.cpp
@@ -67,8 +67,8 @@ int main(int argc, char* argv[])
         // CommunicatorHolder's ctor initializes an Ice communicator,
         // and its dtor destroys this communicator.
         //
-        Ice::CommunicatorHolder ich(argc, argv, "config.server");
-        auto communicator = ich.communicator();
+        const Ice::CommunicatorHolder ich(argc, argv, "config.server");
+        const auto& communicator = ich.communicator();
 
         ctrlCHandler.setCallback(
             [communicator](int)

--- a/cpp11/Ice/nested/Client.cpp
+++ b/cpp11/Ice/nested/Client.cpp
@@ -25,7 +25,7 @@ main(int argc, char* argv[])
         // CommunicatorHolder's ctor initializes an Ice communicator,
         // and its dtor destroys this communicator.
         //
-        Ice::CommunicatorHolder ich(argc, argv, "config.client");
+        const Ice::CommunicatorHolder ich(argc, argv, "config.client");
 
         //
         // The communicator initialization removes all Ice-related arguments from argc/argv

--- a/cpp11/Ice/nested/NestedI.cpp
+++ b/cpp11/Ice/nested/NestedI.cpp
@@ -9,7 +9,7 @@ using namespace std;
 using namespace Demo;
 
 NestedI::NestedI(shared_ptr<NestedPrx> self) :
-    _self(move(self))
+    _self(std::move(self))
 {
 }
 

--- a/cpp11/Ice/nested/Server.cpp
+++ b/cpp11/Ice/nested/Server.cpp
@@ -27,8 +27,8 @@ int main(int argc, char* argv[])
         // CommunicatorHolder's ctor initializes an Ice communicator,
         // and its dtor destroys this communicator.
         //
-        Ice::CommunicatorHolder ich(argc, argv, "config.server");
-        auto communicator = ich.communicator();
+        const Ice::CommunicatorHolder ich(argc, argv, "config.server");
+        const auto& communicator = ich.communicator();
 
         ctrlCHandler.setCallback(
             [communicator](int)

--- a/cpp11/Ice/optional/Client.cpp
+++ b/cpp11/Ice/optional/Client.cpp
@@ -35,8 +35,8 @@ main(int argc, char* argv[])
         // CommunicatorHolder's ctor initializes an Ice communicator,
         // and its dtor destroys this communicator.
         //
-        Ice::CommunicatorHolder ich(argc, argv, "config.client");
-        auto communicator = ich.communicator();
+        const Ice::CommunicatorHolder ich(argc, argv, "config.client");
+        const auto& communicator = ich.communicator();
 
         ctrlCHandler.setCallback(
             [communicator](int)

--- a/cpp11/Ice/optional/ContactDBI.cpp
+++ b/cpp11/Ice/optional/ContactDBI.cpp
@@ -16,15 +16,15 @@ ContactDBI::addContact(string name, Ice::optional<NumberType> type, Ice::optiona
     contact->name = name;
     if(type)
     {
-        contact->type = move(type);
+        contact->type = std::move(type);
     }
     if(number)
     {
-        contact->number = move(number);
+        contact->number = std::move(number);
     }
     if(dialGroup)
     {
-        contact->dialGroup = move(dialGroup);
+        contact->dialGroup = std::move(dialGroup);
     }
     auto p = _contacts.insert(make_pair(name, contact));
     if(!p.second)
@@ -42,15 +42,15 @@ ContactDBI::updateContact(string name, Ice::optional<NumberType> type, Ice::opti
     {
         if(type)
         {
-            p->second->type = move(type);
+            p->second->type = std::move(type);
         }
         if(number)
         {
-            p->second->number = move(number);
+            p->second->number = std::move(number);
         }
         if(dialGroup)
         {
-            p->second->dialGroup = move(dialGroup);
+            p->second->dialGroup = std::move(dialGroup);
         }
     }
 }

--- a/cpp11/Ice/optional/Server.cpp
+++ b/cpp11/Ice/optional/Server.cpp
@@ -26,8 +26,8 @@ int main(int argc, char* argv[])
         // CommunicatorHolder's ctor initializes an Ice communicator,
         // and its dtor destroys this communicator.
         //
-        Ice::CommunicatorHolder ich(argc, argv, "config.server");
-        auto communicator = ich.communicator();
+        const Ice::CommunicatorHolder ich(argc, argv, "config.server");
+        const auto& communicator = ich.communicator();
 
         ctrlCHandler.setCallback(
             [communicator](int)

--- a/cpp11/Ice/plugin/Client.cpp
+++ b/cpp11/Ice/plugin/Client.cpp
@@ -21,7 +21,7 @@ main(int argc, char* argv[])
         // CommunicatorHolder's ctor initializes an Ice communicator,
         // and its dtor destroys this communicator.
         //
-        Ice::CommunicatorHolder ich(argc, argv, "config.client");
+        const Ice::CommunicatorHolder ich(argc, argv, "config.client");
 
         //
         // The communicator initialization removes all Ice-related arguments from argc/argv

--- a/cpp11/Ice/plugin/Server.cpp
+++ b/cpp11/Ice/plugin/Server.cpp
@@ -21,8 +21,8 @@ int main(int argc, char* argv[])
         // CommunicatorHolder's ctor initializes an Ice communicator,
         // and its dtor destroys this communicator.
         //
-        Ice::CommunicatorHolder ich(argc, argv, "config.server");
-        auto communicator = ich.communicator();
+        const Ice::CommunicatorHolder ich(argc, argv, "config.server");
+        const auto& communicator = ich.communicator();
 
         ctrlCHandler.setCallback(
             [communicator](int)

--- a/cpp11/Ice/properties/Client.cpp
+++ b/cpp11/Ice/properties/Client.cpp
@@ -25,7 +25,7 @@ main(int argc, char* argv[])
         // CommunicatorHolder's ctor initializes an Ice communicator,
         // and its dtor destroys this communicator.
         //
-        Ice::CommunicatorHolder ich(argc, argv, "config.client");
+        const Ice::CommunicatorHolder ich(argc, argv, "config.client");
 
         //
         // The communicator initialization removes all Ice-related arguments from argc/argv
@@ -100,7 +100,7 @@ run(const shared_ptr<Ice::Communicator>& communicator)
                 admin->setProperties(dict);
 
                 cout << "Changes:" << endl;
-                Ice::PropertyDict changes = props->getChanges();
+                const Ice::PropertyDict changes = props->getChanges();
                 if(changes.empty())
                 {
                     cout << "  None." << endl;

--- a/cpp11/Ice/properties/Server.cpp
+++ b/cpp11/Ice/properties/Server.cpp
@@ -14,11 +14,6 @@ class PropsI : public Demo::Props
 {
 public:
 
-    PropsI() :
-        _called(false)
-    {
-    }
-
     virtual Ice::PropertyDict getChanges(const Ice::Current&) override
     {
         unique_lock<mutex> lock(_mutex);
@@ -43,7 +38,7 @@ public:
 
     void updated(const Ice::PropertyDict& changes)
     {
-        lock_guard<mutex> lock(_mutex);
+        const lock_guard<mutex> lock(_mutex);
 
         _changes = changes;
         _called = true;
@@ -53,7 +48,7 @@ public:
 private:
 
     Ice::PropertyDict _changes;
-    bool _called;
+    bool _called = false;
     mutex _mutex;
     condition_variable _cv;
 };
@@ -77,8 +72,8 @@ int main(int argc, char* argv[])
         // CommunicatorHolder's ctor initializes an Ice communicator,
         // and its dtor destroys this communicator.
         //
-        Ice::CommunicatorHolder ich(argc, argv, "config.server");
-        auto communicator = ich.communicator();
+        const Ice::CommunicatorHolder ich(argc, argv, "config.server");
+        const auto& communicator = ich.communicator();
 
         ctrlCHandler.setCallback(
             [communicator](int)

--- a/cpp11/Ice/session/Client.cpp
+++ b/cpp11/Ice/session/Client.cpp
@@ -25,7 +25,7 @@ main(int argc, char* argv[])
         // CommunicatorHolder's ctor initializes an Ice communicator,
         // and its dtor destroys this communicator.
         //
-        Ice::CommunicatorHolder ich(argc, argv, "config.client");
+        const Ice::CommunicatorHolder ich(argc, argv, "config.client");
 
         //
         // The communicator initialization removes all Ice-related arguments from argc/argv
@@ -89,7 +89,7 @@ run(const shared_ptr<Ice::Communicator>& communicator)
             {
                 string s;
                 s += c;
-                size_t index = static_cast<size_t>(atoi(s.c_str()));
+                const auto index = static_cast<size_t>(stoi(s));
                 if(index < hellos.size())
                 {
                     hellos[index]->sayHello();

--- a/cpp11/Ice/session/Server.cpp
+++ b/cpp11/Ice/session/Server.cpp
@@ -26,8 +26,8 @@ int main(int argc, char* argv[])
         // CommunicatorHolder's ctor initializes an Ice communicator,
         // and its dtor destroys this communicator.
         //
-        Ice::CommunicatorHolder ich(argc, argv, "config.server");
-        auto communicator = ich.communicator();
+        const Ice::CommunicatorHolder ich(argc, argv, "config.server");
+        const auto& communicator = ich.communicator();
 
         ctrlCHandler.setCallback(
             [communicator](int)

--- a/cpp11/Ice/session/SessionI.cpp
+++ b/cpp11/Ice/session/SessionI.cpp
@@ -11,8 +11,8 @@ class HelloI : public Hello
 {
 public:
 
-    HelloI(const string& name, int id) :
-        _name(name),
+    HelloI(string name, int id) :
+        _name(std::move(name)),
         _id(id)
     {
     }
@@ -35,8 +35,8 @@ private:
     const int _id;
 };
 
-SessionI::SessionI(const string& name) :
-    _name(name),
+SessionI::SessionI(string name) :
+    _name(std::move(name)),
     _nextId(0),
     _destroy(false)
 {
@@ -46,7 +46,7 @@ SessionI::SessionI(const string& name) :
 shared_ptr<HelloPrx>
 SessionI::createHello(const Ice::Current& current)
 {
-    lock_guard<mutex> sync(_mutex);
+    const lock_guard<mutex> sync(_mutex);
     if(_destroy)
     {
         throw Ice::ObjectNotExistException(__FILE__, __LINE__);
@@ -61,7 +61,7 @@ SessionI::createHello(const Ice::Current& current)
 string
 SessionI::getName(const Ice::Current&)
 {
-    lock_guard<mutex> sync(_mutex);
+    const lock_guard<mutex> sync(_mutex);
     if(_destroy)
     {
         throw Ice::ObjectNotExistException(__FILE__, __LINE__);
@@ -73,7 +73,7 @@ SessionI::getName(const Ice::Current&)
 void
 SessionI::destroy(const Ice::Current& current)
 {
-    lock_guard<mutex> sync(_mutex);
+    const lock_guard<mutex> sync(_mutex);
     if(_destroy)
     {
         throw Ice::ObjectNotExistException(__FILE__, __LINE__);

--- a/cpp11/Ice/session/SessionI.h
+++ b/cpp11/Ice/session/SessionI.h
@@ -14,7 +14,7 @@ class SessionI : public Demo::Session
 {
 public:
 
-    SessionI(const std::string&);
+    SessionI(std::string);
 
     virtual std::shared_ptr<Demo::HelloPrx> createHello(const Ice::Current&) override;
     virtual std::string getName(const Ice::Current&) override;

--- a/cpp11/Ice/throughput/Client.cpp
+++ b/cpp11/Ice/throughput/Client.cpp
@@ -27,7 +27,7 @@ main(int argc, char* argv[])
         // CommunicatorHolder's ctor initializes an Ice communicator,
         // and its dtor destroys this communicator.
         //
-        Ice::CommunicatorHolder ich(argc, argv, "config.client");
+        const Ice::CommunicatorHolder ich(argc, argv, "config.client");
 
         //
         // The communicator initialization removes all Ice-related arguments from argc/argv
@@ -69,10 +69,10 @@ run(const shared_ptr<Ice::Communicator>& communicator)
     auto byteArr = make_pair(byteSeq.data(), byteSeq.data() + byteSeq.size());
 
     StringSeq stringSeq(StringSeqSize, "hello");
-    vector<Util::string_view> stringViewSeq(StringSeqSize, "hello");
+    const vector<Util::string_view> stringViewSeq(StringSeqSize, "hello");
 
     StringDoubleSeq structSeq(StringDoubleSeqSize, { "hello", 3.14 });
-    FixedSeq fixedSeq(FixedSeqSize, { 0, 0, 0.0 });
+    const FixedSeq fixedSeq(FixedSeqSize, { 0, 0, 0.0 });
 
     //
     // To allow cross-language tests we may need to "warm up" the
@@ -87,9 +87,9 @@ run(const shared_ptr<Ice::Communicator>& communicator)
         ByteSeq warmupBytesBuf(1);
         auto warmupBytes = make_pair(warmupBytesBuf.data(), warmupBytesBuf.data() + warmupBytesBuf.size());
 
-        vector<Util::string_view> warmupStringViews(1);
-        StringDoubleSeq warmupStructs(1);
-        FixedSeq warmupFixed(1);
+        const vector<Util::string_view> warmupStringViews(1);
+        const StringDoubleSeq warmupStructs(1);
+        const FixedSeq warmupFixed(1);
 
         cout << "warming up the server... " << flush;
         for(int i = 0; i < 10000; i++)
@@ -369,7 +369,7 @@ run(const shared_ptr<Ice::Communicator>& communicator)
 
                 auto duration = chrono::duration<float, chrono::milliseconds::period>(chrono::high_resolution_clock::now() - start);
                 cout << "time for " << repetitions << " sequences: " << duration.count() << "ms" << endl;
-                cout << "time per sequence: " << duration.count() / repetitions << "ms" << endl;
+                cout << "time per sequence: " << duration.count() / static_cast<float>(repetitions) << "ms" << endl;
                 int wireSize = 0;
                 switch(currentType)
                 {

--- a/cpp11/Ice/throughput/Server.cpp
+++ b/cpp11/Ice/throughput/Server.cpp
@@ -27,8 +27,8 @@ int main(int argc, char* argv[])
         // CommunicatorHolder's ctor initializes an Ice communicator,
         // and its dtor destroys this communicator.
         //
-        Ice::CommunicatorHolder ich(argc, argv, "config.server");
-        auto communicator = ich.communicator();
+        const Ice::CommunicatorHolder ich(argc, argv, "config.server");
+        const auto& communicator = ich.communicator();
 
         ctrlCHandler.setCallback(
             [communicator](int)

--- a/cpp11/Ice/throughput/ThroughputI.cpp
+++ b/cpp11/Ice/throughput/ThroughputI.cpp
@@ -45,13 +45,13 @@ ThroughputI::recvByteSeq(const Ice::Current& current)
     if(_warmup)
     {
         Demo::ByteSeq warmupBytesBuf(1);
-        std::pair<const Ice::Byte*, const Ice::Byte*> ret =
+        const std::pair<const Ice::Byte*, const Ice::Byte*> ret =
             std::make_pair(warmupBytesBuf.data(), warmupBytesBuf.data() + warmupBytesBuf.size());
         return RecvByteSeqMarshaledResult(ret, current);
     }
     else
     {
-        std::pair<const Ice::Byte*, const Ice::Byte*> ret =
+        const std::pair<const Ice::Byte*, const Ice::Byte*> ret =
             std::make_pair(_byteSeq.data(), _byteSeq.data() + _byteSeq.size());
         return RecvByteSeqMarshaledResult(ret, current);
     }

--- a/cpp11/IceBT/talk/App.cpp
+++ b/cpp11/IceBT/talk/App.cpp
@@ -119,8 +119,8 @@ main(int argc, char* argv[])
         // CommunicatorHolder's ctor initializes an Ice communicator,
         // and its dtor destroys this communicator.
         //
-        Ice::CommunicatorHolder ich(argc, argv, "config");
-        auto communicator = ich.communicator();
+        const Ice::CommunicatorHolder ich(argc, argv, "config");
+        const auto& communicator = ich.communicator();
 
         //
         // The communicator initialization removes all Ice-related arguments from argc/argv

--- a/cpp11/IceBox/hello/Client.cpp
+++ b/cpp11/IceBox/hello/Client.cpp
@@ -26,7 +26,7 @@ main(int argc, char* argv[])
         // CommunicatorHolder's ctor initializes an Ice communicator,
         // and its dtor destroys this communicator.
         //
-        Ice::CommunicatorHolder ich(argc, argv, "config.client");
+        const Ice::CommunicatorHolder ich(argc, argv, "config.client");
 
         //
         // The communicator initialization removes all Ice-related arguments from argc/argv

--- a/cpp11/IceDiscovery/hello/Client.cpp
+++ b/cpp11/IceDiscovery/hello/Client.cpp
@@ -26,7 +26,7 @@ main(int argc, char* argv[])
         // CommunicatorHolder's ctor initializes an Ice communicator,
         // and its dtor destroys this communicator.
         //
-        Ice::CommunicatorHolder ich(argc, argv, "config.client");
+        const Ice::CommunicatorHolder ich(argc, argv, "config.client");
 
         //
         // The communicator initialization removes all Ice-related arguments from argc/argv

--- a/cpp11/IceDiscovery/hello/Server.cpp
+++ b/cpp11/IceDiscovery/hello/Server.cpp
@@ -27,8 +27,8 @@ int main(int argc, char* argv[])
         // CommunicatorHolder's ctor initializes an Ice communicator,
         // and its dtor destroys this communicator.
         //
-        Ice::CommunicatorHolder ich(argc, argv, "config.server");
-        auto communicator = ich.communicator();
+        const Ice::CommunicatorHolder ich(argc, argv, "config.server");
+        const auto& communicator = ich.communicator();
 
         ctrlCHandler.setCallback(
             [communicator](int)

--- a/cpp11/IceDiscovery/replication/Client.cpp
+++ b/cpp11/IceDiscovery/replication/Client.cpp
@@ -27,7 +27,7 @@ main(int argc, char* argv[])
         // CommunicatorHolder's ctor initializes an Ice communicator,
         // and its dtor destroys this communicator.
         //
-        Ice::CommunicatorHolder ich(argc, argv, "config.client");
+        const Ice::CommunicatorHolder ich(argc, argv, "config.client");
 
         //
         // The communicator initialization removes all Ice-related arguments from argc/argv
@@ -76,10 +76,10 @@ run(const shared_ptr<Ice::Communicator>& communicator)
     {
         cout << "enter the number of iterations: ";
         cin >> s;
-        int count = atoi(s.c_str());
+        const int count = stoi(s);
         cout << "enter the delay between each greetings (in ms): ";
         cin >> s;
-        int delay = atoi(s.c_str());
+        int delay = stoi(s);
         if(delay < 0)
         {
             delay = 500; // 500 milli-seconds

--- a/cpp11/IceDiscovery/replication/HelloI.cpp
+++ b/cpp11/IceDiscovery/replication/HelloI.cpp
@@ -7,8 +7,8 @@
 
 using namespace std;
 
-HelloI::HelloI(const string& name) :
-    _name(name)
+HelloI::HelloI(string name) :
+    _name(std::move(name))
 {
 }
 

--- a/cpp11/IceDiscovery/replication/HelloI.h
+++ b/cpp11/IceDiscovery/replication/HelloI.h
@@ -11,7 +11,7 @@ class HelloI : public Demo::Hello
 {
 public:
 
-    HelloI(const std::string&);
+    HelloI(std::string);
 
     virtual std::string getGreeting(const Ice::Current&) override;
     virtual void shutdown(const Ice::Current&) override;

--- a/cpp11/IceDiscovery/replication/Server.cpp
+++ b/cpp11/IceDiscovery/replication/Server.cpp
@@ -27,8 +27,8 @@ int main(int argc, char* argv[])
         // CommunicatorHolder's ctor initializes an Ice communicator,
         // and its dtor destroys this communicator.
         //
-        Ice::CommunicatorHolder ich(argc, argv);
-        auto communicator = ich.communicator();
+        const Ice::CommunicatorHolder ich(argc, argv);
+        const auto& communicator = ich.communicator();
 
         ctrlCHandler.setCallback(
             [communicator](int)

--- a/cpp11/IceGrid/allocate/Client.cpp
+++ b/cpp11/IceGrid/allocate/Client.cpp
@@ -26,7 +26,7 @@ main(int argc, char* argv[])
         // CommunicatorHolder's ctor initializes an Ice communicator,
         // and its dtor destroys this communicator.
         //
-        Ice::CommunicatorHolder ich(argc, argv, "config.client");
+        const Ice::CommunicatorHolder ich(argc, argv, "config.client");
 
         //
         // The communicator initialization removes all Ice-related arguments from argc/argv
@@ -186,7 +186,7 @@ string
 trim(const string& s)
 {
     static const string delims = "\t\r\n ";
-    string::size_type last = s.find_last_not_of(delims);
+    const string::size_type last = s.find_last_not_of(delims);
     if(last != string::npos)
     {
         return s.substr(s.find_first_not_of(delims), last+1);

--- a/cpp11/IceGrid/allocate/HelloI.cpp
+++ b/cpp11/IceGrid/allocate/HelloI.cpp
@@ -7,8 +7,8 @@
 
 using namespace std;
 
-HelloI::HelloI(const string& name) :
-    _name(name)
+HelloI::HelloI(string name) :
+    _name(std::move(name))
 {
 }
 

--- a/cpp11/IceGrid/allocate/HelloI.h
+++ b/cpp11/IceGrid/allocate/HelloI.h
@@ -11,7 +11,7 @@ class HelloI : public Demo::Hello
 {
 public:
 
-    HelloI(const std::string&);
+    HelloI(std::string);
 
     virtual void sayHello(const Ice::Current&) override;
     virtual void shutdown(const Ice::Current&) override;

--- a/cpp11/IceGrid/allocate/Server.cpp
+++ b/cpp11/IceGrid/allocate/Server.cpp
@@ -22,8 +22,8 @@ int main(int argc, char* argv[])
         // CommunicatorHolder's ctor initializes an Ice communicator,
         // and its dtor destroys this communicator.
         //
-        Ice::CommunicatorHolder ich(argc, argv);
-        auto communicator = ich.communicator();
+        const Ice::CommunicatorHolder ich(argc, argv);
+        const auto& communicator = ich.communicator();
 
         ctrlCHandler.setCallback(
             [communicator](int)

--- a/cpp11/IceGrid/customLocator/Client.cpp
+++ b/cpp11/IceGrid/customLocator/Client.cpp
@@ -22,7 +22,7 @@ main(int argc, char* argv[])
         // CommunicatorHolder's ctor initializes an Ice communicator,
         // and its dtor destroys this communicator.
         //
-        Ice::CommunicatorHolder ich(argc, argv, "config.client");
+        const Ice::CommunicatorHolder ich(argc, argv, "config.client");
 
         //
         // The communicator initialization removes all Ice-related arguments from argc/argv
@@ -97,10 +97,6 @@ run(const shared_ptr<Ice::Communicator>& communicator, bool addContext)
             cout << "==> ";
             cin >> c;
             if(c == 't')
-            {
-                hello->sayHello();
-            }
-            else if(c == 't')
             {
                 hello->sayHello();
             }

--- a/cpp11/IceGrid/customLocator/HelloI.cpp
+++ b/cpp11/IceGrid/customLocator/HelloI.cpp
@@ -7,8 +7,8 @@
 
 using namespace std;
 
-HelloI::HelloI(const string& name) :
-    _name(name)
+HelloI::HelloI(string name) :
+    _name(std::move(name))
 {
 }
 

--- a/cpp11/IceGrid/customLocator/HelloI.h
+++ b/cpp11/IceGrid/customLocator/HelloI.h
@@ -11,7 +11,7 @@ class HelloI : public Demo::Hello
 {
 public:
 
-    HelloI(const std::string&);
+    HelloI(std::string);
 
     virtual void sayHello(const Ice::Current&) override;
     virtual void shutdown(const Ice::Current&) override;

--- a/cpp11/IceGrid/customLocator/Locator.cpp
+++ b/cpp11/IceGrid/customLocator/Locator.cpp
@@ -17,7 +17,7 @@ class LocatorRegistryI : public Ice::LocatorRegistry
 {
 public:
 
-    LocatorRegistryI(const shared_ptr<Ice::LocatorRegistryPrx>& registry) :
+    explicit LocatorRegistryI(const shared_ptr<Ice::LocatorRegistryPrx>& registry) :
         _registry(registry)
     {
     }
@@ -137,8 +137,8 @@ int main(int argc, char* argv[])
         // CommunicatorHolder's ctor initializes an Ice communicator,
         // and its dtor destroys this communicator.
         //
-        Ice::CommunicatorHolder ich(argc, argv, "config.locator");
-        auto communicator = ich.communicator();
+        const Ice::CommunicatorHolder ich(argc, argv, "config.locator");
+        const auto& communicator = ich.communicator();
 
         ctrlCHandler.setCallback(
             [communicator](int)

--- a/cpp11/IceGrid/customLocator/Server.cpp
+++ b/cpp11/IceGrid/customLocator/Server.cpp
@@ -29,8 +29,8 @@ int main(int argc, char* argv[])
         // CommunicatorHolder's ctor initializes an Ice communicator,
         // and its dtor destroys this communicator.
         //
-        Ice::CommunicatorHolder ich(argc, argv, initData);
-        auto communicator = ich.communicator();
+        const Ice::CommunicatorHolder ich(argc, argv, initData);
+        const auto& communicator = ich.communicator();
 
         ctrlCHandler.setCallback(
             [communicator](int)

--- a/cpp11/IceGrid/icebox/Client.cpp
+++ b/cpp11/IceGrid/icebox/Client.cpp
@@ -30,8 +30,8 @@ main(int argc, char* argv[])
         // CommunicatorHolder's ctor initializes an Ice communicator,
         // and its dtor destroys this communicator.
         //
-        Ice::CommunicatorHolder ich(argc, argv, "config.client");
-        auto communicator = ich.communicator();
+        const Ice::CommunicatorHolder ich(argc, argv, "config.client");
+        const auto& communicator = ich.communicator();
 
         ctrlCHandler.setCallback(
             [communicator](int)

--- a/cpp11/IceGrid/icebox/HelloI.cpp
+++ b/cpp11/IceGrid/icebox/HelloI.cpp
@@ -12,8 +12,8 @@
 
 using namespace std;
 
-HelloI::HelloI(const string& serviceName) :
-    _serviceName(serviceName)
+HelloI::HelloI(string serviceName) :
+    _serviceName(std::move(serviceName))
 {
 }
 
@@ -21,7 +21,7 @@ void
 HelloI::sayHello(const Ice::Current&)
 {
     char* val = getenv("LANG");
-    string lang = val ? string(val) : "en";
+    const string lang = val ? string(val) : "en";
 
     string greeting = "Hello, ";
     if(lang == "fr")

--- a/cpp11/IceGrid/icebox/HelloI.h
+++ b/cpp11/IceGrid/icebox/HelloI.h
@@ -11,7 +11,7 @@ class HelloI : public Demo::Hello
 {
 public:
 
-    HelloI(const std::string&);
+    HelloI(std::string);
 
     virtual void sayHello(const Ice::Current&) override;
 

--- a/cpp11/IceGrid/icebox/HelloServiceI.cpp
+++ b/cpp11/IceGrid/icebox/HelloServiceI.cpp
@@ -27,7 +27,7 @@ HelloServiceI::start(const string& name, const shared_ptr<Ice::Communicator>& co
 {
     _adapter = communicator->createObjectAdapter("Hello-" + name);
 
-    string helloIdentity = communicator->getProperties()->getProperty("Hello.Identity");
+    const string helloIdentity = communicator->getProperties()->getProperty("Hello.Identity");
 
     auto hello = make_shared<HelloI>(name);
     _adapter->add(hello, Ice::stringToIdentity(helloIdentity));

--- a/cpp11/IceGrid/replication/Client.cpp
+++ b/cpp11/IceGrid/replication/Client.cpp
@@ -28,7 +28,7 @@ main(int argc, char* argv[])
         // CommunicatorHolder's ctor initializes an Ice communicator,
         // and its dtor destroys this communicator.
         //
-        Ice::CommunicatorHolder ich(argc, argv, "config.client");
+        const Ice::CommunicatorHolder ich(argc, argv, "config.client");
 
         //
         // The communicator initialization removes all Ice-related arguments from argc/argv
@@ -79,10 +79,10 @@ run(const shared_ptr<Ice::Communicator>& communicator)
     {
         cout << "enter the number of iterations: ";
         cin >> s;
-        int count = atoi(s.c_str());
+        const int count = stoi(s);
         cout << "enter the delay between each greetings (in ms): ";
         cin >> s;
-        int delay = atoi(s.c_str());
+        int delay = stoi(s);
         if(delay < 0)
         {
             delay = 500; // 500 milliseconds

--- a/cpp11/IceGrid/replication/Server.cpp
+++ b/cpp11/IceGrid/replication/Server.cpp
@@ -26,8 +26,8 @@ int main(int argc, char* argv[])
         // CommunicatorHolder's ctor initializes an Ice communicator,
         // and its dtor destroys this communicator.
         //
-        Ice::CommunicatorHolder ich(argc, argv);
-        auto communicator = ich.communicator();
+        const Ice::CommunicatorHolder ich(argc, argv);
+        const auto& communicator = ich.communicator();
 
         ctrlCHandler.setCallback(
             [communicator](int)

--- a/cpp11/IceGrid/secure/Client.cpp
+++ b/cpp11/IceGrid/secure/Client.cpp
@@ -26,7 +26,7 @@ main(int argc, char* argv[])
         // CommunicatorHolder's ctor initializes an Ice communicator,
         // and its dtor destroys this communicator.
         //
-        Ice::CommunicatorHolder ich(argc, argv, "config.client");
+        const Ice::CommunicatorHolder ich(argc, argv, "config.client");
 
         //
         // The communicator initialization removes all Ice-related arguments from argc/argv

--- a/cpp11/IceGrid/secure/HelloI.cpp
+++ b/cpp11/IceGrid/secure/HelloI.cpp
@@ -7,8 +7,8 @@
 
 using namespace std;
 
-HelloI::HelloI(const string& name) :
-    _name(name)
+HelloI::HelloI(string name) :
+    _name(std::move(name))
 {
 }
 

--- a/cpp11/IceGrid/secure/HelloI.h
+++ b/cpp11/IceGrid/secure/HelloI.h
@@ -11,7 +11,7 @@ class HelloI : public Demo::Hello
 {
 public:
 
-    HelloI(const std::string&);
+    HelloI(std::string);
 
     virtual void sayHello(const Ice::Current&) override;
     virtual void shutdown(const Ice::Current&) override;

--- a/cpp11/IceGrid/secure/Server.cpp
+++ b/cpp11/IceGrid/secure/Server.cpp
@@ -33,8 +33,8 @@ int main(int argc, char* argv[])
         // CommunicatorHolder's ctor initializes an Ice communicator,
         // and its dtor destroys this communicator.
         //
-        Ice::CommunicatorHolder ich(argc, argv, initData);
-        auto communicator = ich.communicator();
+        const Ice::CommunicatorHolder ich(argc, argv, initData);
+        const auto& communicator = ich.communicator();
 
         ctrlCHandler.setCallback(
             [communicator](int)

--- a/cpp11/IceGrid/sessionActivation/Client.cpp
+++ b/cpp11/IceGrid/sessionActivation/Client.cpp
@@ -26,7 +26,7 @@ main(int argc, char* argv[])
         // CommunicatorHolder's ctor initializes an Ice communicator,
         // and its dtor destroys this communicator.
         //
-        Ice::CommunicatorHolder ich(argc, argv, "config.client");
+        const Ice::CommunicatorHolder ich(argc, argv, "config.client");
 
         //
         // The communicator initialization removes all Ice-related arguments from argc/argv
@@ -171,7 +171,7 @@ string
 trim(const string& s)
 {
     static const string delims = "\t\r\n ";
-    string::size_type last = s.find_last_not_of(delims);
+    const string::size_type last = s.find_last_not_of(delims);
     if(last != string::npos)
     {
         return s.substr(s.find_first_not_of(delims), last+1);

--- a/cpp11/IceGrid/sessionActivation/Server.cpp
+++ b/cpp11/IceGrid/sessionActivation/Server.cpp
@@ -22,8 +22,8 @@ int main(int argc, char* argv[])
         // CommunicatorHolder's ctor initializes an Ice communicator,
         // and its dtor destroys this communicator.
         //
-        Ice::CommunicatorHolder ich(argc, argv);
-        auto communicator = ich.communicator();
+        const Ice::CommunicatorHolder ich(argc, argv);
+        const auto& communicator = ich.communicator();
 
         ctrlCHandler.setCallback(
             [communicator](int)

--- a/cpp11/IceGrid/simple/Client.cpp
+++ b/cpp11/IceGrid/simple/Client.cpp
@@ -26,7 +26,7 @@ main(int argc, char* argv[])
         // CommunicatorHolder's ctor initializes an Ice communicator,
         // and its dtor destroys this communicator.
         //
-        Ice::CommunicatorHolder ich(argc, argv, "config.client");
+        const Ice::CommunicatorHolder ich(argc, argv, "config.client");
 
         //
         // The communicator initialization removes all Ice-related arguments from argc/argv

--- a/cpp11/IceGrid/simple/Server.cpp
+++ b/cpp11/IceGrid/simple/Server.cpp
@@ -29,8 +29,8 @@ int main(int argc, char* argv[])
         // CommunicatorHolder's ctor initializes an Ice communicator,
         // and its dtor destroys this communicator.
         //
-        Ice::CommunicatorHolder ich(argc, argv, initData);
-        auto communicator = ich.communicator();
+        const Ice::CommunicatorHolder ich(argc, argv, initData);
+        const auto& communicator = ich.communicator();
 
         ctrlCHandler.setCallback(
             [communicator](int)

--- a/cpp11/IceStorm/clock/Publisher.cpp
+++ b/cpp11/IceStorm/clock/Publisher.cpp
@@ -39,8 +39,8 @@ main(int argc, char* argv[])
         // CommunicatorHolder's ctor initializes an Ice communicator,
         // and its dtor destroys this communicator.
         //
-        Ice::CommunicatorHolder ich(argc, argv, "config.pub");
-        auto communicator = ich.communicator();
+        const Ice::CommunicatorHolder ich(argc, argv, "config.pub");
+        const auto& communicator = ich.communicator();
 
         ctrlCHandler.setCallback(
             [communicator](int)
@@ -75,8 +75,8 @@ run(const shared_ptr<Ice::Communicator>& communicator, int argc, char* argv[])
 
     for(i = 1; i < argc; ++i)
     {
-        string optionString = argv[i];
-        Option oldoption = option;
+        const string optionString = argv[i];
+        const Option oldoption = option;
         if(optionString == "--datagram")
         {
             option = Option::Datagram;
@@ -163,10 +163,9 @@ run(const shared_ptr<Ice::Communicator>& communicator, int argc, char* argv[])
     auto clock = Ice::uncheckedCast<ClockPrx>(publisher);
 
     cout << "publishing tick events. Press ^C to terminate the application." << endl;
-    try
+    while(true)
     {
-        bool stop = false;
-        while(!stop)
+        try
         {
             auto now = chrono::system_clock::to_time_t(chrono::system_clock::now());
             char timeString[100];
@@ -177,10 +176,10 @@ run(const shared_ptr<Ice::Communicator>& communicator, int argc, char* argv[])
             clock->tick(timeString);
             this_thread::sleep_for(chrono::seconds(1));
         }
-    }
-    catch(const Ice::CommunicatorDestroyedException&)
-    {
-        // Ignore
+        catch(const Ice::CommunicatorDestroyedException&)
+        {
+            break;
+        }
     }
 
     return 0;

--- a/cpp11/IceStorm/clock/Subscriber.cpp
+++ b/cpp11/IceStorm/clock/Subscriber.cpp
@@ -42,8 +42,8 @@ int main(int argc, char* argv[])
         // CommunicatorHolder's ctor initializes an Ice communicator,
         // and its dtor destroys this communicator.
         //
-        Ice::CommunicatorHolder ich(argc, argv, "config.sub");
-        auto communicator = ich.communicator();
+        const Ice::CommunicatorHolder ich(argc, argv, "config.sub");
+        const auto& communicator = ich.communicator();
 
         ctrlCHandler.setCallback(
             [communicator](int)
@@ -86,8 +86,8 @@ run(const shared_ptr<Ice::Communicator>& communicator, int argc, char* argv[])
 
     for(i = 1; i < argc; ++i)
     {
-        string optionString = argv[i];
-        Option oldoption = option;
+        const string optionString = argv[i];
+        const Option oldoption = option;
         if(optionString == "--datagram")
         {
             option = Option::Datagram;

--- a/cpp11/IceStorm/counter/Client.cpp
+++ b/cpp11/IceStorm/counter/Client.cpp
@@ -21,7 +21,7 @@ main(int argc, char* argv[])
         // CommunicatorHolder's ctor initializes an Ice communicator,
         // and its dtor destroys this communicator.
         //
-        Ice::CommunicatorHolder ich(argc, argv, "config.client");
+        const Ice::CommunicatorHolder ich(argc, argv, "config.client");
 
         //
         // The communicator initialization removes all Ice-related arguments from argc/argv

--- a/cpp11/IceStorm/counter/CounterI.cpp
+++ b/cpp11/IceStorm/counter/CounterI.cpp
@@ -18,7 +18,7 @@ CounterI::CounterI(const shared_ptr<IceStorm::TopicPrx>& topic) :
 void
 CounterI::subscribe(shared_ptr<CounterObserverPrx> observer, const Ice::Current&)
 {
-    lock_guard<mutex> sync(_mutex);
+    const lock_guard<mutex> sync(_mutex);
 
     //
     // Subscribe to the IceStorm topic. This returns a per-subscriber
@@ -38,7 +38,7 @@ CounterI::unsubscribe(shared_ptr<CounterObserverPrx> observer, const Ice::Curren
 void
 CounterI::inc(int value, const Ice::Current&)
 {
-    lock_guard<mutex> sync(_mutex);
+    const lock_guard<mutex> sync(_mutex);
 
     _value += value;
     _publisher->inc(value);

--- a/cpp11/IceStorm/counter/CounterObserverI.cpp
+++ b/cpp11/IceStorm/counter/CounterObserverI.cpp
@@ -11,14 +11,14 @@ using namespace std;
 void print(const string& str)
 {
     static mutex _coutMutex;
-    lock_guard<mutex> sync(_coutMutex);
+    const lock_guard<mutex> sync(_coutMutex);
     cout << str << flush;
 }
 
 void
 CounterObserverI::init(int value, const Ice::Current&)
 {
-    lock_guard<mutex> sync(_mutex);
+    const lock_guard<mutex> sync(_mutex);
     _value = value;
     ostringstream ostr;
     ostr << "init: " << value << endl;
@@ -28,7 +28,7 @@ CounterObserverI::init(int value, const Ice::Current&)
 void
 CounterObserverI::inc(int value, const Ice::Current&)
 {
-    lock_guard<mutex> sync(_mutex);
+    const lock_guard<mutex> sync(_mutex);
     _value += value;
     ostringstream ostr;
     ostr << "int: " << value << " total: " << _value << endl;

--- a/cpp11/IceStorm/counter/Server.cpp
+++ b/cpp11/IceStorm/counter/Server.cpp
@@ -27,8 +27,8 @@ int main(int argc, char* argv[])
         // CommunicatorHolder's ctor initializes an Ice communicator,
         // and its dtor destroys this communicator.
         //
-        Ice::CommunicatorHolder ich(argc, argv, "config.server");
-        auto communicator = ich.communicator();
+        const Ice::CommunicatorHolder ich(argc, argv, "config.server");
+        const auto& communicator = ich.communicator();
 
         ctrlCHandler.setCallback(
             [communicator](int)

--- a/cpp11/IceStorm/replicated/Publisher.cpp
+++ b/cpp11/IceStorm/replicated/Publisher.cpp
@@ -39,8 +39,8 @@ main(int argc, char* argv[])
         // CommunicatorHolder's ctor initializes an Ice communicator,
         // and its dtor destroys this communicator.
         //
-        Ice::CommunicatorHolder ich(argc, argv, "config.pub");
-        auto communicator = ich.communicator();
+        const Ice::CommunicatorHolder ich(argc, argv, "config.pub");
+        const auto& communicator = ich.communicator();
 
         ctrlCHandler.setCallback(
             [communicator](int)
@@ -75,8 +75,8 @@ run(const shared_ptr<Ice::Communicator>& communicator, int argc, char* argv[])
 
     for(i = 1; i < argc; ++i)
     {
-        string optionString = argv[i];
-        Option oldoption = option;
+        const string optionString = argv[i];
+        const Option oldoption = option;
         if(optionString == "--datagram")
         {
             option = Option::Datagram;
@@ -163,10 +163,9 @@ run(const shared_ptr<Ice::Communicator>& communicator, int argc, char* argv[])
     auto clock = Ice::uncheckedCast<ClockPrx>(publisher);
 
     cout << "publishing tick events. Press ^C to terminate the application." << endl;
-    try
+    while(true)
     {
-        bool stop = false;
-        while(!stop)
+        try
         {
             auto now = chrono::system_clock::to_time_t(chrono::system_clock::now());
             char timeString[100];
@@ -177,10 +176,10 @@ run(const shared_ptr<Ice::Communicator>& communicator, int argc, char* argv[])
             clock->tick(timeString);
             this_thread::sleep_for(chrono::seconds(1));
         }
-    }
-    catch(const Ice::CommunicatorDestroyedException&)
-    {
-        // Ignore
+        catch(const Ice::CommunicatorDestroyedException&)
+        {
+            break;
+        }
     }
 
     return 0;

--- a/cpp11/IceStorm/replicated/Subscriber.cpp
+++ b/cpp11/IceStorm/replicated/Subscriber.cpp
@@ -42,8 +42,8 @@ int main(int argc, char* argv[])
         // CommunicatorHolder's ctor initializes an Ice communicator,
         // and its dtor destroys this communicator.
         //
-        Ice::CommunicatorHolder ich(argc, argv, "config.sub");
-        auto communicator = ich.communicator();
+        const Ice::CommunicatorHolder ich(argc, argv, "config.sub");
+        const auto& communicator = ich.communicator();
 
         ctrlCHandler.setCallback(
             [communicator](int)
@@ -86,8 +86,8 @@ run(const shared_ptr<Ice::Communicator>& communicator, int argc, char* argv[])
 
     for(i = 1; i < argc; ++i)
     {
-        string optionString = argv[i];
-        Option oldoption = option;
+        const string optionString = argv[i];
+        const Option oldoption = option;
         if(optionString == "--datagram")
         {
             option = Option::Datagram;

--- a/cpp11/IceStorm/replicated2/Publisher.cpp
+++ b/cpp11/IceStorm/replicated2/Publisher.cpp
@@ -39,8 +39,8 @@ main(int argc, char* argv[])
         // CommunicatorHolder's ctor initializes an Ice communicator,
         // and its dtor destroys this communicator.
         //
-        Ice::CommunicatorHolder ich(argc, argv, "config.pub");
-        auto communicator = ich.communicator();
+        const Ice::CommunicatorHolder ich(argc, argv, "config.pub");
+        const auto& communicator = ich.communicator();
 
         ctrlCHandler.setCallback(
             [communicator](int)
@@ -75,8 +75,8 @@ run(const shared_ptr<Ice::Communicator>& communicator, int argc, char* argv[])
 
     for(i = 1; i < argc; ++i)
     {
-        string optionString = argv[i];
-        Option oldoption = option;
+        const string optionString = argv[i];
+        const Option oldoption = option;
         if(optionString == "--datagram")
         {
             option = Option::Datagram;
@@ -163,10 +163,9 @@ run(const shared_ptr<Ice::Communicator>& communicator, int argc, char* argv[])
     auto clock = Ice::uncheckedCast<ClockPrx>(publisher);
 
     cout << "publishing tick events. Press ^C to terminate the application." << endl;
-    try
+    while(true)
     {
-        bool stop = false;
-        while(!stop)
+        try
         {
             auto now = chrono::system_clock::to_time_t(chrono::system_clock::now());
             char timeString[100];
@@ -177,10 +176,10 @@ run(const shared_ptr<Ice::Communicator>& communicator, int argc, char* argv[])
             clock->tick(timeString);
             this_thread::sleep_for(chrono::seconds(1));
         }
-    }
-    catch(const Ice::CommunicatorDestroyedException&)
-    {
-        // Ignore
+        catch(const Ice::CommunicatorDestroyedException&)
+        {
+            break;
+        }
     }
 
     return 0;

--- a/cpp11/IceStorm/replicated2/Subscriber.cpp
+++ b/cpp11/IceStorm/replicated2/Subscriber.cpp
@@ -42,8 +42,8 @@ int main(int argc, char* argv[])
         // CommunicatorHolder's ctor initializes an Ice communicator,
         // and its dtor destroys this communicator.
         //
-        Ice::CommunicatorHolder ich(argc, argv, "config.sub");
-        auto communicator = ich.communicator();
+        const Ice::CommunicatorHolder ich(argc, argv, "config.sub");
+        const auto& communicator = ich.communicator();
 
         ctrlCHandler.setCallback(
             [communicator](int)
@@ -86,8 +86,8 @@ run(const shared_ptr<Ice::Communicator>& communicator, int argc, char* argv[])
 
     for(i = 1; i < argc; ++i)
     {
-        string optionString = argv[i];
-        Option oldoption = option;
+        const string optionString = argv[i];
+        const Option oldoption = option;
         if(optionString == "--datagram")
         {
             option = Option::Datagram;

--- a/cpp11/Manual/lifecycle/Client.cpp
+++ b/cpp11/Manual/lifecycle/Client.cpp
@@ -20,7 +20,7 @@ main(int argc, char* argv[])
         // CommunicatorHolder's ctor initializes an Ice communicator,
         // and its dtor destroys this communicator.
         //
-        Ice::CommunicatorHolder ich(argc, argv);
+        const Ice::CommunicatorHolder ich(argc, argv);
 
         //
         // Create a proxy for the root directory

--- a/cpp11/Manual/lifecycle/FilesystemI.cpp
+++ b/cpp11/Manual/lifecycle/FilesystemI.cpp
@@ -76,7 +76,7 @@ FilesystemI::FileI::write(Lines text, const Ice::Current& c)
         throw Ice::ObjectNotExistException(__FILE__, __LINE__, c.id, c.facet, c.operation);
     }
 
-    _lines = move(text);
+    _lines = std::move(text);
 }
 
 // Slice File::destroy() operation.

--- a/cpp11/Manual/lifecycle/FilesystemI.cpp
+++ b/cpp11/Manual/lifecycle/FilesystemI.cpp
@@ -13,7 +13,7 @@ using namespace FilesystemI;
 std::string
 FilesystemI::NodeI::name(const Ice::Current& c)
 {
-    lock_guard<mutex> lock(_mutex);
+    const lock_guard<mutex> lock(_mutex);
 
     if(_destroyed)
     {
@@ -54,7 +54,7 @@ FilesystemI::NodeI::NodeI(const string& nm, const shared_ptr<DirectoryI>& parent
 Lines
 FilesystemI::FileI::read(const Ice::Current& c)
 {
-    lock_guard<mutex> lock(_mutex);
+    const lock_guard<mutex> lock(_mutex);
 
     if(_destroyed)
     {
@@ -69,7 +69,7 @@ FilesystemI::FileI::read(const Ice::Current& c)
 void
 FilesystemI::FileI::write(Lines text, const Ice::Current& c)
 {
-    lock_guard<mutex> lock(_mutex);
+    const lock_guard<mutex> lock(_mutex);
 
     if(_destroyed)
     {
@@ -85,7 +85,7 @@ void
 FilesystemI::FileI::destroy(const Ice::Current& c)
 {
     {
-        lock_guard<mutex> lock(_mutex);
+        const lock_guard<mutex> lock(_mutex);
 
         if(_destroyed)
         {
@@ -111,7 +111,7 @@ FilesystemI::FileI::FileI(const string& nm, const shared_ptr<DirectoryI>& parent
 NodeDescSeq
 FilesystemI::DirectoryI::list(const Ice::Current& c)
 {
-    lock_guard<mutex> lock(_mutex);
+    const lock_guard<mutex> lock(_mutex);
 
     if(_destroyed)
     {
@@ -135,7 +135,7 @@ FilesystemI::DirectoryI::list(const Ice::Current& c)
 NodeDesc
 FilesystemI::DirectoryI::find(string nm, const Ice::Current& c)
 {
-    lock_guard<mutex> lock(_mutex);
+    const lock_guard<mutex> lock(_mutex);
 
     if(_destroyed)
     {
@@ -161,7 +161,7 @@ FilesystemI::DirectoryI::find(string nm, const Ice::Current& c)
 shared_ptr<FilePrx>
 FilesystemI::DirectoryI::createFile(string nm, const Ice::Current& c)
 {
-    lock_guard<mutex> lock(_mutex);
+    const lock_guard<mutex> lock(_mutex);
 
     if(_destroyed)
     {
@@ -184,7 +184,7 @@ FilesystemI::DirectoryI::createFile(string nm, const Ice::Current& c)
 shared_ptr<DirectoryPrx>
 FilesystemI::DirectoryI::createDirectory(string nm, const Ice::Current& c)
 {
-    lock_guard<mutex> lock(_mutex);
+    const lock_guard<mutex> lock(_mutex);
 
     if(_destroyed)
     {
@@ -213,7 +213,7 @@ FilesystemI::DirectoryI::destroy(const Ice::Current& c)
     }
 
     {
-        lock_guard<mutex> lock(_mutex);
+        const lock_guard<mutex> lock(_mutex);
 
         if(_destroyed)
         {
@@ -244,7 +244,7 @@ FilesystemI::DirectoryI::DirectoryI(const string& nm, const shared_ptr<Directory
 void
 FilesystemI::DirectoryI::removeEntry(const string& nm)
 {
-    lock_guard<mutex> lock(_mutex);
+    const lock_guard<mutex> lock(_mutex);
     auto i = _contents.find(nm);
     if(i != _contents.end())
     {

--- a/cpp11/Manual/lifecycle/Grammar.cpp
+++ b/cpp11/Manual/lifecycle/Grammar.cpp
@@ -87,6 +87,10 @@
 #   pragma warning( disable : 4702 )
 #endif
 
+#if defined(__clang__)
+#   pragma clang diagnostic ignored "-Wunused-but-set-variable"
+#endif
+
 using namespace std;
 
 void

--- a/cpp11/Manual/lifecycle/Grammar.y
+++ b/cpp11/Manual/lifecycle/Grammar.y
@@ -21,6 +21,10 @@
 #   pragma warning( disable : 4702 )
 #endif
 
+#if defined(__clang__)
+#   pragma clang diagnostic ignored "-Wunused-but-set-variable"
+#endif
+
 using namespace std;
 
 void

--- a/cpp11/Manual/lifecycle/Parser.cpp
+++ b/cpp11/Manual/lifecycle/Parser.cpp
@@ -52,7 +52,7 @@ Parser::list(bool recursive)
 void
 Parser::list(const shared_ptr<DirectoryPrx>& dir, bool recursive, size_t depth)
 {
-    string indent(depth++, '\t');
+    const string indent(depth++, '\t');
 
     auto contents = dir->list();
 

--- a/cpp11/Manual/lifecycle/Scanner.cpp
+++ b/cpp11/Manual/lifecycle/Scanner.cpp
@@ -525,6 +525,10 @@ char *yytext;
 #   pragma GCC diagnostic ignored "-Wsign-compare"
 #endif
 
+#if defined(__clang__)
+#   pragma clang diagnostic ignored "-Wregister"
+#endif
+
 using namespace std;
 
 #ifdef _MSC_VER

--- a/cpp11/Manual/lifecycle/Scanner.l
+++ b/cpp11/Manual/lifecycle/Scanner.l
@@ -35,6 +35,10 @@
 #   pragma GCC diagnostic ignored "-Wsign-compare"
 #endif
 
+#if defined(__clang__)
+#   pragma clang diagnostic ignored "-Wconversion"
+#endif
+
 using namespace std;
 
 #ifdef _MSC_VER

--- a/cpp11/Manual/lifecycle/Server.cpp
+++ b/cpp11/Manual/lifecycle/Server.cpp
@@ -24,8 +24,8 @@ int main(int argc, char* argv[])
         // CommunicatorHolder's ctor initializes an Ice communicator,
         // and its dtor destroys this communicator.
         //
-        Ice::CommunicatorHolder ich(argc, argv);
-        auto communicator = ich.communicator();
+        const Ice::CommunicatorHolder ich(argc, argv);
+        const auto& communicator = ich.communicator();
 
         auto appName = argv[0];
         ctrlCHandler.setCallback(

--- a/cpp11/Manual/printer/Client.cpp
+++ b/cpp11/Manual/printer/Client.cpp
@@ -14,7 +14,7 @@ main(int argc, char* argv[])
 {
     try
     {
-        Ice::CommunicatorHolder ich(argc, argv);
+        const Ice::CommunicatorHolder ich(argc, argv);
         auto base = ich->stringToProxy("SimplePrinter:default -p 10000");
         auto printer = Ice::checkedCast<PrinterPrx>(base);
         if(!printer)

--- a/cpp11/Manual/printer/Server.cpp
+++ b/cpp11/Manual/printer/Server.cpp
@@ -26,7 +26,7 @@ main(int argc, char* argv[])
 {
     try
     {
-        Ice::CommunicatorHolder ich(argc, argv);
+        const Ice::CommunicatorHolder ich(argc, argv);
         auto adapter = ich->createObjectAdapterWithEndpoints("SimplePrinterAdapter", "default -p 10000");
         auto servant = make_shared<PrinterI>();
         adapter->add(servant, Ice::stringToIdentity("SimplePrinter"));

--- a/cpp11/Manual/simpleFilesystem/Client.cpp
+++ b/cpp11/Manual/simpleFilesystem/Client.cpp
@@ -18,7 +18,7 @@ using namespace Filesystem;
 static void
 listRecursive(const shared_ptr<DirectoryPrx>& dir, size_t depth = 0)
 {
-    string indent(++depth, '\t');
+    const string indent(++depth, '\t');
 
     auto contents = dir->list();
 
@@ -49,7 +49,7 @@ main(int argc, char* argv[])
     {
         // Create Ice communicator
         //
-        Ice::CommunicatorHolder ich(argc, argv);
+        const Ice::CommunicatorHolder ich(argc, argv);
 
         // Create a proxy for the root directory
         //

--- a/cpp11/Manual/simpleFilesystem/FilesystemI.cpp
+++ b/cpp11/Manual/simpleFilesystem/FilesystemI.cpp
@@ -15,8 +15,8 @@ Filesystem::NodeI::name(const Ice::Current&)
 }
 
 // NodeI constructor
-Filesystem::NodeI::NodeI(const string& nm, const shared_ptr<DirectoryI>& parent) :
-    _name(nm),
+Filesystem::NodeI::NodeI(string name, const shared_ptr<DirectoryI>& parent) :
+    _name(std::move(name)),
     _parent(parent)
 {
     // Create an identity. The root directory has the fixed identity "RootDir"
@@ -49,8 +49,8 @@ Filesystem::FileI::write(Filesystem::Lines text, const Ice::Current&)
 }
 
 // FileI constructor
-Filesystem::FileI::FileI(const string& nm, const shared_ptr<DirectoryI>& parent) :
-    NodeI(nm, parent)
+Filesystem::FileI::FileI(string name, const shared_ptr<DirectoryI>& parent) :
+    NodeI(std::move(name), parent)
 {
 }
 
@@ -62,8 +62,8 @@ Filesystem::DirectoryI::list(const Ice::Current&)
 }
 
 // DirectoryI constructor
-Filesystem::DirectoryI::DirectoryI(const string& nm, const shared_ptr<DirectoryI>& parent) :
-    NodeI(nm, parent)
+Filesystem::DirectoryI::DirectoryI(string name, const shared_ptr<DirectoryI>& parent) :
+    NodeI(std::move(name), parent)
 {
 }
 

--- a/cpp11/Manual/simpleFilesystem/FilesystemI.h
+++ b/cpp11/Manual/simpleFilesystem/FilesystemI.h
@@ -23,7 +23,7 @@ class NodeI : public virtual Node, public std::enable_shared_from_this<NodeI>
 public:
 
     virtual std::string name(const Ice::Current&) override;
-    NodeI(const std::string&, const std::shared_ptr<DirectoryI>&);
+    NodeI(std::string, const std::shared_ptr<DirectoryI>&);
     void activate(const std::shared_ptr<Ice::ObjectAdapter>&);
 
 private:
@@ -40,7 +40,7 @@ public:
     virtual Lines read(const Ice::Current&) override;
     virtual void write(Lines, const Ice::Current&) override;
 
-    FileI(const std::string&, const std::shared_ptr<DirectoryI>&);
+    FileI(std::string, const std::shared_ptr<DirectoryI>&);
 
 private:
 
@@ -52,7 +52,7 @@ class DirectoryI : public Directory, public NodeI
 public:
 
     virtual NodeSeq list(const Ice::Current&) override;
-    DirectoryI(const std::string&, const std::shared_ptr<DirectoryI>&);
+    DirectoryI(std::string, const std::shared_ptr<DirectoryI>&);
     void addChild(const std::shared_ptr<NodePrx>&);
 
 private:

--- a/cpp11/Manual/simpleFilesystem/Server.cpp
+++ b/cpp11/Manual/simpleFilesystem/Server.cpp
@@ -25,8 +25,8 @@ int main(int argc, char* argv[])
         // CommunicatorHolder's ctor initializes an Ice communicator,
         // and its dtor destroys this communicator.
         //
-        Ice::CommunicatorHolder ich(argc, argv);
-        auto communicator = ich.communicator();
+        const Ice::CommunicatorHolder ich(argc, argv);
+        const auto& communicator = ich.communicator();
 
         auto appName = argv[0];
         ctrlCHandler.setCallback(

--- a/cpp11/make/Make.rules
+++ b/cpp11/make/Make.rules
@@ -52,6 +52,14 @@ $(foreach v,$(supported-platforms) platform config,$(eval $v_targetdir := ) $(ev
 slice2cpp_targetext             = cpp
 slice2cpp_path                  = $(or $(ice_bindir[$(build-platform)]),$(ice_bindir))/slice2cpp
 
+# With Xcode 14.3 C++17 deprecations apply when building with -std=c++11, we pass -std=c++17
+# to enable C++17 mode conditional code.
+ifeq ($(os),Darwin)
+ice_cpp_mode                    = c++17
+else
+ice_cpp_mode                    = c++11
+endif
+
 ifeq ($(wildcard $(slice2cpp_path)),)
 $(error Can't find Ice distribution, please set ICE_HOME to the Ice installation directory)
 endif
@@ -65,7 +73,7 @@ $1_srcext               := cpp
 $1_dependencies         := $$(or $$($1_dependencies),Ice)
 $1_slicecompiler        := slice2cpp
 $1_sliceflags           := -I$(ice_slicedir) -I$1 $$($1_sliceflags)
-$1_cppflags             := -DICE_CPP11_MAPPING -std=c++11 -I$1 -I$1/generated $(ice_cppflags) $$($1_cppflags)
+$1_cppflags             := -DICE_CPP11_MAPPING -std=$(ice_cpp_mode) -I$1 -I$1/generated $(ice_cppflags) $$($1_cppflags)
 $1_caninstall           := no
 
 # Also link with IceSSL, IceDiscovery and IceLocatorDiscovery when compiling the project with the static configuration

--- a/cpp98/IceGrid/customLocator/Client.cpp
+++ b/cpp98/IceGrid/customLocator/Client.cpp
@@ -109,10 +109,6 @@ run(const Ice::CommunicatorPtr& communicator, bool addContext)
             {
                 hello->sayHello();
             }
-            else if(c == 't')
-            {
-                hello->sayHello();
-            }
             else if(c == 's')
             {
                 hello->shutdown();


### PR DESCRIPTION
This PR updates C++11 demos, to fix warnings reported by clang-tidy, the majority are about const correctness, for places where we forget to declare a variable const. There are a few other things like `std::move` usage and some other minor issues.

see also #146