### PR TITLE
Handle exceptions from stoi calls

### DIFF
--- a/cpp11/IceDiscovery/replication/Client.cpp
+++ b/cpp11/IceDiscovery/replication/Client.cpp
@@ -74,16 +74,56 @@ run(const shared_ptr<Ice::Communicator>& communicator)
     string s;
     do
     {
-        cout << "enter the number of iterations: ";
-        cin >> s;
-        const int count = stoi(s);
-        cout << "enter the delay between each greetings (in ms): ";
-        cin >> s;
-        int delay = stoi(s);
-        if(delay < 0)
+        int count;
+        int delay = 500;
+
+        // Read the iterations parameter from stdin.
+        do
         {
-            delay = 500; // 500 milli-seconds
+            cout << "enter the number of iterations or 'x' to exit: ";
+            cin >> s;
+            if(s == "x")
+            {
+                return 0;
+            }
+
+            try
+            {
+                count = stoi(s);
+                break;
+            }
+            catch(invalid_argument)
+            {
+                cerr << "'" << s << "'"
+                     << " is not a valid value for the iterations parameter, it has to be a positive integer"
+                     << endl;
+            }
         }
+        while(true);
+
+        // Read the delay parameter from stdin.
+        do
+        {
+            cout << "enter the delay between each greetings (in ms): ";
+            cin >> s;
+            try
+            {
+                delay = stoi(s);
+                break;
+            }
+            catch(invalid_argument)
+            {
+                cerr << "'" << s << "' is not a valid value for the delay parameter, it has to be a positive integer"
+                     << endl;
+                continue;
+            }
+
+            if(delay < 0)
+            {
+                delay = 500; // 500 milliseconds
+            }
+        }
+        while(true);
 
         for(int i = 0; i < count; i++)
         {
@@ -91,7 +131,7 @@ run(const shared_ptr<Ice::Communicator>& communicator)
             this_thread::sleep_for(chrono::milliseconds(delay));
         }
     }
-    while(cin.good() && s != "x");
+    while(cin.good());
 
     return 0;
 }

--- a/cpp11/IceDiscovery/replication/Client.cpp
+++ b/cpp11/IceDiscovery/replication/Client.cpp
@@ -78,52 +78,43 @@ run(const shared_ptr<Ice::Communicator>& communicator)
         int delay = 500;
 
         // Read the iterations parameter from stdin.
-        do
+        cout << "enter the number of iterations or 'x' to exit: ";
+        cin >> s;
+        if(s == "x")
         {
-            cout << "enter the number of iterations or 'x' to exit: ";
-            cin >> s;
-            if(s == "x")
-            {
-                return 0;
-            }
-
-            try
-            {
-                count = stoi(s);
-                break;
-            }
-            catch(invalid_argument)
-            {
-                cerr << "'" << s << "'"
-                     << " is not a valid value for the iterations parameter, it has to be a positive integer"
-                     << endl;
-            }
+            break;
         }
-        while(true);
+
+        try
+        {
+            count = stoi(s);
+        }
+        catch(invalid_argument)
+        {
+            cerr << "'" << s << "'"
+                 << " is not a valid value for the iterations parameter, it has to be a positive integer"
+                 << endl;
+            return 1;
+        }
 
         // Read the delay parameter from stdin.
-        do
+        cout << "enter the delay between each greetings (in ms): ";
+        cin >> s;
+        try
         {
-            cout << "enter the delay between each greetings (in ms): ";
-            cin >> s;
-            try
-            {
-                delay = stoi(s);
-                break;
-            }
-            catch(invalid_argument)
-            {
-                cerr << "'" << s << "' is not a valid value for the delay parameter, it has to be a positive integer"
-                     << endl;
-                continue;
-            }
-
-            if(delay < 0)
-            {
-                delay = 500; // 500 milliseconds
-            }
+            delay = stoi(s);
         }
-        while(true);
+        catch(invalid_argument)
+        {
+            cerr << "'" << s << "' is not a valid value for the delay parameter, it has to be a positive integer"
+                 << endl;
+            return 1;
+        }
+
+        if(delay < 0)
+        {
+            delay = 500; // 500 milliseconds
+        }
 
         for(int i = 0; i < count; i++)
         {

--- a/cpp11/IceGrid/replication/Client.cpp
+++ b/cpp11/IceGrid/replication/Client.cpp
@@ -81,52 +81,42 @@ run(const shared_ptr<Ice::Communicator>& communicator)
         int delay = 500;
 
         // Read the iterations parameter from stdin.
-        do
+        cout << "enter the number of iterations or 'x' to exit: ";
+        cin >> s;
+        if(s == "x")
         {
-            cout << "enter the number of iterations or 'x' to exit: ";
-            cin >> s;
-            if(s == "x")
-            {
-                return 0;
-            }
-
-            try
-            {
-                count = stoi(s);
-                break;
-            }
-            catch(invalid_argument)
-            {
-                cerr << "'" << s << "'"
-                     << " is not a valid value for the iterations parameter, it has to be a positive integer"
-                     << endl;
-            }
+            break;
         }
-        while(true);
 
-        // Read the delay parameter from stdin.
-        do
+        try
         {
-            cout << "enter the delay between each greetings (in ms): ";
-            cin >> s;
-            try
-            {
-                delay = stoi(s);
-                break;
-            }
-            catch(invalid_argument)
-            {
-                cerr << "'" << s << "' is not a valid value for the delay parameter, it has to be a positive integer"
-                     << endl;
-                continue;
-            }
-
-            if(delay < 0)
-            {
-                delay = 500; // 500 milliseconds
-            }
+            count = stoi(s);
         }
-        while(true);
+        catch(invalid_argument)
+        {
+            cerr << "'" << s << "'"
+                 << " is not a valid value for the iterations parameter, it has to be a positive integer"
+                 << endl;
+            return 1;
+        }
+
+        cout << "enter the delay between each greetings (in ms): ";
+        cin >> s;
+        try
+        {
+            delay = stoi(s);
+        }
+        catch(invalid_argument)
+        {
+            cerr << "'" << s << "' is not a valid value for the delay parameter, it has to be a positive integer"
+                 << endl;
+            return 1;
+        }
+
+        if(delay < 0)
+        {
+            delay = 500; // 500 milliseconds
+        }
 
         for(int i = 0; i < count; i++)
         {

--- a/cpp11/IceGrid/replication/Client.cpp
+++ b/cpp11/IceGrid/replication/Client.cpp
@@ -77,16 +77,56 @@ run(const shared_ptr<Ice::Communicator>& communicator)
     string s;
     do
     {
-        cout << "enter the number of iterations: ";
-        cin >> s;
-        const int count = stoi(s);
-        cout << "enter the delay between each greetings (in ms): ";
-        cin >> s;
-        int delay = stoi(s);
-        if(delay < 0)
+        int count;
+        int delay = 500;
+
+        // Read the iterations parameter from stdin.
+        do
         {
-            delay = 500; // 500 milliseconds
+            cout << "enter the number of iterations or 'x' to exit: ";
+            cin >> s;
+            if(s == "x")
+            {
+                return 0;
+            }
+
+            try
+            {
+                count = stoi(s);
+                break;
+            }
+            catch(invalid_argument)
+            {
+                cerr << "'" << s << "'"
+                     << " is not a valid value for the iterations parameter, it has to be a positive integer"
+                     << endl;
+            }
         }
+        while(true);
+
+        // Read the delay parameter from stdin.
+        do
+        {
+            cout << "enter the delay between each greetings (in ms): ";
+            cin >> s;
+            try
+            {
+                delay = stoi(s);
+                break;
+            }
+            catch(invalid_argument)
+            {
+                cerr << "'" << s << "' is not a valid value for the delay parameter, it has to be a positive integer"
+                     << endl;
+                continue;
+            }
+
+            if(delay < 0)
+            {
+                delay = 500; // 500 milliseconds
+            }
+        }
+        while(true);
 
         for(int i = 0; i < count; i++)
         {
@@ -94,7 +134,7 @@ run(const shared_ptr<Ice::Communicator>& communicator)
             this_thread::sleep_for(chrono::milliseconds(delay));
         }
     }
-    while(cin.good() && s != "x");
+    while(cin.good());
 
     return 0;
 }


### PR DESCRIPTION
This PR fixes `IceGrid/replication` and `IceDiscovery/replication` to correctly handle errors from `stoi`. It also updates the loop that reads the input parameters to make clear how to exit.

