### PR TITLE
Restore waitForShutdown

### DIFF
--- a/csharp/Ice/async/Server.cs
+++ b/csharp/Ice/async/Server.cs
@@ -37,7 +37,6 @@ public class Server
                         // cts is canceled by Ctrl+C or a shutdown request.
                         // With C# 7.1 and up, you should make Main async and call: await Task.Delay(-1, cts.Token)
                         cts.Token.WaitHandle.WaitOne();
-                        communicator.shutdown();
                     }
                 }
             }

--- a/csharp/Ice/asyncInvocation/CalculatorI.cs
+++ b/csharp/Ice/asyncInvocation/CalculatorI.cs
@@ -4,12 +4,9 @@
 
 using Demo;
 using System;
-using System.Threading;
 
 internal class CalculatorI : CalculatorDisp_
 {
-    private readonly ManualResetEventSlim _shutdownRequested;
-
     public override int add(int x, int y, Ice.Current current)
     {
         return x + y;
@@ -46,11 +43,6 @@ internal class CalculatorI : CalculatorDisp_
 
     public override void shutdown(Ice.Current current)
     {
-        _shutdownRequested.Set();
-    }
-
-    internal CalculatorI(ManualResetEventSlim shutdownRequested)
-    {
-        _shutdownRequested = shutdownRequested;
+       current.adapter.getCommunicator().shutdown();
     }
 }

--- a/csharp/Ice/asyncInvocation/Server.cs
+++ b/csharp/Ice/asyncInvocation/Server.cs
@@ -3,7 +3,6 @@
 //
 
 using System;
-using System.Threading;
 
 public class Server
 {
@@ -22,20 +21,17 @@ public class Server
                 }
                 else
                 {
-                    var shutdownRequested = new ManualResetEventSlim();
                     Console.CancelKeyPress += (sender, eventArgs) =>
                     {
                         eventArgs.Cancel = true;
-                        shutdownRequested.Set();
+                        communicator.shutdown();
                     };
 
                     Ice.ObjectAdapter adapter = communicator.createObjectAdapter("Calculator");
-                    adapter.add(new CalculatorI(shutdownRequested), Ice.Util.stringToIdentity("calculator"));
+                    adapter.add(new CalculatorI(), Ice.Util.stringToIdentity("calculator"));
                     adapter.activate();
 
-                    // Wait until shutdown is requested by Ctrl+C or a shutdown request.
-                    shutdownRequested.Wait();
-                    communicator.shutdown();
+                    communicator.waitForShutdown();
                 }
             }
         }


### PR DESCRIPTION
This PR restores waitForShutdown in the asyncInvocation demo (see #186).

It also removes an unnecessary call to shutdown in the async demo. I don't see a way to meaningfully switch back to waitForShutdown in that demo.

See also #181.