### PR TITLE
Fix obsolete warnings

### DIFF
--- a/csharp/Ice/interceptor/AuthenticatorI.cs
+++ b/csharp/Ice/interceptor/AuthenticatorI.cs
@@ -6,14 +6,13 @@ using Demo;
 using System;
 using System.Collections.Generic;
 using System.Security.Cryptography;
-using System.Text;
 
 class AuthenticatorI : AuthenticatorDisp_
 {
     internal AuthenticatorI()
     {
         _tokenStore = new Dictionary<string, DateTimeOffset>();
-        _rand = new RNGCryptoServiceProvider();
+        _rand = RandomNumberGenerator.Create();
     }
 
     public override string getToken(Ice.Current current)
@@ -69,6 +68,6 @@ class AuthenticatorI : AuthenticatorDisp_
         }
     }
 
-    private readonly RNGCryptoServiceProvider _rand;
+    private readonly RandomNumberGenerator _rand;
     private readonly Dictionary<string, DateTimeOffset> _tokenStore;
 }


### PR DESCRIPTION
This PR fixes obsolete warnings in the interceptor demo. I could not use the recommended static methods as they are not available with .NET Framework.

Fixes #182.
