### PR TITLE
Do not dispose CTS until communicator is disposed

### DIFF
--- a/csharp/Ice/async/Server.cs
+++ b/csharp/Ice/async/Server.cs
@@ -9,40 +9,49 @@ public class Server
 {
     public static int Main(string[] args)
     {
-        if (args.Length > 0)
-        {
-            Console.WriteLine("too many arguments");
-            return 1;
-        }
+        int status = 0;
 
         try
         {
-            using (var cts = new CancellationTokenSource())
+            using (Ice.Communicator communicator = Ice.Util.initialize(ref args, "config.server"))
             {
-                using (Ice.Communicator communicator = Ice.Util.initialize(ref args, "config.server"))
+                if (args.Length > 0)
                 {
-                    Console.CancelKeyPress += (sender, eventArgs) =>
+                    Console.WriteLine("too many arguments");
+                    status = 1;
+                }
+                else
+                {
+                    using (var cts = new CancellationTokenSource())
                     {
-                        eventArgs.Cancel = true;
-                        cts.Cancel();
-                    };
+                        Console.CancelKeyPress += (sender, eventArgs) =>
+                        {
+                            eventArgs.Cancel = true;
+                            cts.Cancel();
+                        };
 
-                    Ice.ObjectAdapter adapter = communicator.createObjectAdapter("Hello");
-                    adapter.add(new HelloI(cts), Ice.Util.stringToIdentity("hello"));
-                    adapter.activate();
+                        Ice.ObjectAdapter adapter = communicator.createObjectAdapter("Hello");
+                        adapter.add(new HelloI(cts), Ice.Util.stringToIdentity("hello"));
+                        adapter.activate();
 
-                    // cts is canceled by Ctrl+C or a shutdown request.
-                    // With C# 7.1 and up, you should make Main async and call: await Task.Delay(-1, cts.Token)
-                    cts.Token.WaitHandle.WaitOne();
+                        // cts is canceled by Ctrl+C or a shutdown request.
+                        // With C# 7.1 and up, you should make Main async and call: await Task.Delay(-1, cts.Token)
+                        cts.Token.WaitHandle.WaitOne();
+
+                        // Wait for all dispatches to complete before disposing cts since the dispatches use cts or
+                        // cts.Token
+                        communicator.shutdown();
+                        communicator.waitForShutdown();
+                    }
                 }
             }
         }
         catch (Exception exception)
         {
             Console.WriteLine(exception);
-            return 1;
+            status = 1;
         }
 
-        return 0;
+        return status;
     }
 }


### PR DESCRIPTION
We should dispose the CTS only after the communicator is disposed of, otherwise request cancelation doesn't work. The CTS will no throw OCE after it is disposed. 