### PR TITLE
Improvements to IceConfig.cmake

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,14 +61,14 @@ jobs:
       - name: Setup Ice Build Dependencies
         uses: ./ice/.github/actions/setup-dependencies
 
-      - name: Build Ice on ${{ matrix.os }}
+      - name: Build Ice
         uses: ./ice/.github/actions/build
         timeout-minutes: 60
         with:
           working_directory: ice
           build_flags: ${{ runner.os == 'Windows' && '/t:BuildDist' || 'srcs' }}
 
-      - name: Publish C# NuGet Packages on ${{ matrix.os }}
+      - name: Publish C# NuGet Packages
         timeout-minutes: 5
         working-directory: ice/csharp/msbuild
         run: dotnet msbuild ice.proj /t:Publish
@@ -78,17 +78,30 @@ jobs:
         with:
           path: ice-demos
 
-      - name: Generate C++ Build Systems on ${{ matrix.os }}
-        timeout-minutes: 5
-        working-directory: ice-demos/cpp
-        run: find . -name CMakeLists.txt -execdir cmake -B build -S . ";"
-
-      - name: Build C++ Demos on ${{ matrix.os }}
+      - name: Build C++ Demos
         timeout-minutes: 20
         working-directory: ice-demos/cpp
-        run: find . -name CMakeLists.txt -type d -execdir cmake --build build ";"
+        run: |
+          set -o pipefail
+          find . -name CMakeLists.txt -type f | while IFS= read -r file; do
+            dir=$(dirname "$file");
+            cmake -B "$dir/build" -S "$dir" -DIce_DEBUG=ON
+            cmake --build "$dir/build" --config Release
+          done
+        if: runner.os != 'Windows'
 
-      - name: Build C# Demos on ${{ matrix.os }}
+      - name: Build C++ Demos
+        timeout-minutes: 20
+        working-directory: ice-demos/cpp
+        run: |
+            Get-ChildItem -Recurse -Filter CMakeLists.txt | ForEach-Object {
+              $dir = $_.DirectoryName
+              cmake -B "$dir/build" -S "$dir" -DIce_DEBUG=ON
+              cmake --build "$dir/build" --config Release
+            }
+        if: runner.os == 'Windows'
+
+      - name: Build C# Demos
         timeout-minutes: 20
         working-directory: ice-demos/csharp
         run: dotnet build
@@ -97,7 +110,7 @@ jobs:
         run: dotnet format --verify-no-changes "./ice-demos/csharp/C# NET demos.sln"
         if: runner.os == 'Linux'
 
-      - name: Build Java Demos on ${{ matrix.os }}
+      - name: Build Java Demos
         timeout-minutes: 20
         working-directory: ice-demos/java
         env:
@@ -106,7 +119,7 @@ jobs:
           CPP_CONFIGURATION: Release
         run: ./gradlew build
 
-      - name: Build JavaScript Demos on ${{ matrix.os }}
+      - name: Build JavaScript Demos
         timeout-minutes: 20
         working-directory: ice-demos/js
         env:
@@ -117,8 +130,12 @@ jobs:
           npm install
           npx gulp build
 
-      - name: Build Swift Demos on ${{ matrix.os }}
+      - name: Build Swift Demos
         timeout-minutes: 20
         working-directory: ice-demos/swift
-        run: find . -name Package.swift -execdir swift build \;
+        run: |
+          set -o pipefail
+          find . -name Package.swift -type f | while IFS= read -r file; do
+              swift build --package-path "$(dirname "$file")"
+          done
         if: runner.os == 'macOS'

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -27,6 +27,7 @@ jobs:
 
       - name: Run Clang Format
         run: |
+          set -o pipefail
           find . -name "*.h" -o -name "*.cpp" | xargs clang-format-19 --style=file --fallback-style=none --Werror --dry-run
 
   clang-tidy:
@@ -72,10 +73,18 @@ jobs:
         timeout-minutes: 30
         working-directory: ice-demos/cpp
         run: |
-          find . -name CMakeLists.txt -execdir cmake -B build -S . -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DIce_DEBUG=ON \;
-          find . -name CMakeLists.txt -execdir cmake --build build --config Release \;
+          set -o pipefail
+          find . -name CMakeLists.txt -type f | while IFS= read -r file; do
+            dir=$(dirname "$file");
+            cmake -B "$dir/build" -S "$dir" -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DIce_DEBUG=ON
+            cmake --build "$dir/build" --config Release
+          done
 
       - name: Run Clang Tidy
         working-directory: ice-demos/cpp
         run: |
-          find . -name compile_commands.json -execdir run-clang-tidy-19 -j$(nproc) -quiet \;
+          set -o pipefail
+          find . -name compile_commands.json -type f | while IFS= read -r file; do
+            dir=$(dirname "$file");
+            run-clang-tidy-19 -p "$dir" -quiet
+          done

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -86,5 +86,5 @@ jobs:
           set -o pipefail
           find . -name compile_commands.json -type f | while IFS= read -r file; do
             dir=$(dirname "$file");
-            run-clang-tidy-19 -p "$dir" -quiet
+            run-clang-tidy-19 -p "$dir" -j$(nproc) -quiet
           done


### PR DESCRIPTION
- Lots of improvements IceConfig.cake
- Fix workflow to not used `find -exec` as failure from the exec command do not cause find to return with an error.