### PR TITLE
New Invoke demo in C#

### DIFF
--- a/csharp/Ice/Invoke2/Client/Client.csproj
+++ b/csharp/Ice/Invoke2/Client/Client.csproj
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <!-- Copy the PDBs from the NuGet packages to get file names and line numbers in stack traces. -->
+    <CopyDebugSymbolFilesFromPackages>true</CopyDebugSymbolFilesFromPackages>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="zeroc.ice.net" Version="3.8.0-alpha0" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+</Project>

--- a/csharp/Ice/Invoke2/Client/Program.cs
+++ b/csharp/Ice/Invoke2/Client/Program.cs
@@ -1,0 +1,39 @@
+// Copyright (c) ZeroC, Inc.
+
+// Create an Ice communicator to initialize the Ice runtime.
+using Ice.Communicator communicator = Ice.Util.initialize(ref args);
+
+// Create a plain proxy to the remote object.
+Ice.ObjectPrx greeter = Ice.ObjectPrxHelper.createProxy(communicator, "greeter:tcp -h localhost -p 4061");
+
+// Create an encapsulation for the input parameter (the user name).
+var outputStream = new Ice.OutputStream();
+outputStream.startEncapsulation();
+outputStream.writeString(Environment.UserName);
+outputStream.endEncapsulation();
+
+// Send a request using ice_invokeAsync and wait for the response. ice_invokeAsync can throws exceptions such as
+// Ice.ConnectionRefusedException (an Ice local exception), or Ice.ObjectNotExistException (another Ice local exception
+// reported by the server).
+(bool success, byte[] encapsulation) =
+    await greeter.ice_invokeAsync(
+        operation: "greet",
+        mode: Ice.OperationMode.Normal, // as opposed to Idempotent
+        inEncaps: outputStream.finished());
+
+if (success)
+{
+    // Unmarshal the encapsulation to get the greeting.
+    var inputStream = new Ice.InputStream(communicator, encapsulation);
+    _ = inputStream.startEncapsulation();
+    string greeting = inputStream.readString();
+    inputStream.endEncapsulation();
+
+    Console.WriteLine(greeting);
+}
+else
+{
+    // success = false means the encapsulation holds a user exception. This should not happen since our implementation
+    // does not throw/return any user exception.
+    Console.WriteLine("greet failed with an unexpected user exception");
+}

--- a/csharp/Ice/Invoke2/Invoke.sln
+++ b/csharp/Ice/Invoke2/Invoke.sln
@@ -1,0 +1,36 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.4.33122.133
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Client", "Client\Client.csproj", "{BBF1199A-46A4-4AE9-AFFE-4D8DD59EB874}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Server", "Server\Server.csproj", "{527EEA4D-77B9-4252-A2CD-C641A25CAD53}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{FBDAF448-665A-4595-98D3-4538C56A666D}"
+	ProjectSection(SolutionItems) = preProject
+		README.md = README.md
+	EndProjectSection
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{BBF1199A-46A4-4AE9-AFFE-4D8DD59EB874}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BBF1199A-46A4-4AE9-AFFE-4D8DD59EB874}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BBF1199A-46A4-4AE9-AFFE-4D8DD59EB874}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BBF1199A-46A4-4AE9-AFFE-4D8DD59EB874}.Release|Any CPU.Build.0 = Release|Any CPU
+		{527EEA4D-77B9-4252-A2CD-C641A25CAD53}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{527EEA4D-77B9-4252-A2CD-C641A25CAD53}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{527EEA4D-77B9-4252-A2CD-C641A25CAD53}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{527EEA4D-77B9-4252-A2CD-C641A25CAD53}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {0B36F1E1-0592-4A15-9981-67BC4A653EC4}
+	EndGlobalSection
+EndGlobal

--- a/csharp/Ice/Invoke2/README.md
+++ b/csharp/Ice/Invoke2/README.md
@@ -1,0 +1,27 @@
+# Invoke
+
+The Invoke shows how to implement a Greeter client and server using [Dynamic Ice][1]. This demo does not use any
+Slice definition or generated code; the client and server are nevertheless compatible with the client and server from
+the Greeter demo.
+
+You can build the client and server applications with:
+
+``` shell
+dotnet build
+```
+
+First start the Server program:
+
+```shell
+cd Server
+dotnet run
+```
+
+In a separate terminal, start the Client program:
+
+```shell
+cd Client
+dotnet run
+```
+
+[1]: https://doc.zeroc.com/ice/3.7/client-server-features/dynamic-ice

--- a/csharp/Ice/Invoke2/Server/Chatbot.cs
+++ b/csharp/Ice/Invoke2/Server/Chatbot.cs
@@ -1,0 +1,38 @@
+// Copyright (c) ZeroC, Inc.
+
+using Ice;
+
+namespace InvokeServer;
+
+/// <summary>A Chatbot is an Ice servant that implements operation greet directly, without generated code.</summary>
+internal class Chatbot : Ice.Object
+{
+    // Implements abstract method dispatchAsync from the Object interface. There is no synchronous version of dispatch.
+    public ValueTask<OutgoingResponse> dispatchAsync(IncomingRequest request)
+    {
+        if (request.current.operation == "greet")
+        {
+            // Unmarshal the input parameter (the user name).
+            request.inputStream.startEncapsulation();
+            string name = request.inputStream.readString();
+            request.inputStream.endEncapsulation();
+
+            Console.WriteLine($"Dispatching greet request {{ name = '{name}' }}");
+
+            // Create an Ice encapsulation for the return value (the greeting).
+            var outputStream = request.current.startReplyStream(); // for reply status Ok
+            outputStream.startEncapsulation();
+            outputStream.writeString($"Hello, {name}!");
+            outputStream.endEncapsulation();
+
+            // Return the response wrapped in a ValueTask.
+            return new(new OutgoingResponse(outputStream));
+        }
+        else
+        {
+            // Chatbot only implements greet. It could also implement ice_ping, ice_isA and other ice_ operations, but
+            // here we decided not to implement them.
+            throw new OperationNotExistException();
+        }
+    }
+}

--- a/csharp/Ice/Invoke2/Server/Program.cs
+++ b/csharp/Ice/Invoke2/Server/Program.cs
@@ -1,0 +1,20 @@
+// Copyright (c) ZeroC, Inc.
+
+using InvokeServer;
+
+// Create an Ice communicator to initialize the Ice runtime. The communicator is disposed before the program exits.
+using Ice.Communicator communicator = Ice.Util.initialize(ref args);
+
+// Create an object adapter that listens for incoming requests and dispatches them to servants.
+Ice.ObjectAdapter adapter = communicator.createObjectAdapterWithEndpoints("GreeterAdapter", "tcp -p 4061");
+
+// Register the Chatbot servant with the adapter.
+adapter.add(new Chatbot(), Ice.Util.stringToIdentity("greeter"));
+
+// Start dispatching requests.
+adapter.activate();
+Console.WriteLine("Listening on port 4061...");
+
+// Wait until the user presses Ctrl+C.
+await CancelKeyPressed;
+Console.WriteLine("Caught Ctrl+C, exiting...");

--- a/csharp/Ice/Invoke2/Server/Server.csproj
+++ b/csharp/Ice/Invoke2/Server/Server.csproj
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <!-- Copy the PDBs from the NuGet packages to get file names and line numbers in stack traces. -->
+    <CopyDebugSymbolFilesFromPackages>true</CopyDebugSymbolFilesFromPackages>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="zeroc.ice.net" Version="3.8.0-alpha0" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <Compile Include="../../../Common/Program.CancelKeyPressed.cs" Link="Program.CancelKeyPressed.cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
This PR implements a new Invoke demo in C# (Invoke2 for now, until we retire invoke).

I initially wanted to call it "SliceFree" and provide a Slice-free demo. However, even though this demo does not provide any Slice definition or use any generated code, it still uses InputStream / OutputStream to marshal/unmarshal data (strings) using the Ice encoding.

Using InputStream / OutputStream is unavoidable with Ice, even if we just want to transfer bytes.

This demo is primarily about demonstrating `ice_invokeAsync` (on Ice.ObjectPrx) and `dispatchAsync` (on Ice.Object).
In practice, these methods are more useful to build a Forwarding servant than to send Slice requests "by hand". Maybe we should drop this Invoke demo and provide a Forwarder demo instead?