### PR TITLE
Remove ExtraArgs: ['-std=c++17'] from clang-tidy config

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -13,7 +13,6 @@ HeaderFilterRegex: '.*'
 ExcludeHeaderFilterRegex: 'include/.*'
 UseColor: true
 FormatStyle: 'file'
-ExtraArgs: ['-std=c++17']
 CheckOptions:
   modernize-use-nullptr.NullMacros: 'NULL'
   # std::exception_ptr is a cheap to copy, pointer-like type; we pass it by value all the time.


### PR DESCRIPTION
We should instead disable suggestions to use c++20 features.