### PR TITLE
Upgrade C# demos to use Nightly builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,11 +63,6 @@ jobs:
           working_directory: ice
           build_flags: ${{ runner.os == 'Windows' && '/t:BuildDist /p:Configuration=Release /p:Platform=x64' || 'srcs' }}
 
-      - name: Publish C# NuGet Packages
-        timeout-minutes: 5
-        working-directory: ice/csharp/msbuild
-        run: dotnet msbuild ice.proj /t:Publish /p:Configuration=Release /p:Platform=x64
-
       - name: Checkout repository
         uses: actions/checkout@v4
         with:

--- a/csharp/Directory.Build.props
+++ b/csharp/Directory.Build.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build"
     xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
-        <AppTargetFramework Condition="'$(AppTargetFramework)' == ''">net8.0</AppTargetFramework>
+        <IceVersion Condition="'$(IceVersion)' == ''">3.8.0-nightly.*</IceVersion>
         <ImplicitUsings>true</ImplicitUsings>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <!-- <AnalysisMode>All</AnalysisMode> -->

--- a/csharp/Glacier2/callback/msbuild/client/client.csproj
+++ b/csharp/Glacier2/callback/msbuild/client/client.csproj
@@ -17,7 +17,7 @@
         <Compile Include="../../CallbackI.cs" />
         <Compile Include="../../CallbackReceiverI.cs" />
         <SliceCompile Include="../../Callback.ice" />
-        <PackageReference Include="zeroc.ice.net" Version="3.8.0-alpha0" />
+        <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
         <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
 
         <!-- The 1.2 beta version is required for supporting the latest language features.

--- a/csharp/Glacier2/callback/msbuild/server/server.csproj
+++ b/csharp/Glacier2/callback/msbuild/server/server.csproj
@@ -11,7 +11,7 @@
         <Compile Include="../../CallbackI.cs" />
         <Compile Include="../../Server.cs" />
         <SliceCompile Include="../../Callback.ice" />
-        <PackageReference Include="zeroc.ice.net" Version="3.8.0-alpha0" />
+        <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
         <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
 
         <!-- The 1.2 beta version is required for supporting the latest language features.

--- a/csharp/Ice/Bidir/Client/Client.csproj
+++ b/csharp/Ice/Bidir/Client/Client.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <SliceCompile Include="../slice/AlarmClock.ice" />
-    <PackageReference Include="zeroc.ice.net" Version="3.8.0-alpha0" />
+    <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
     <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>

--- a/csharp/Ice/Bidir/Server/Server.csproj
+++ b/csharp/Ice/Bidir/Server/Server.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <SliceCompile Include="../slice/AlarmClock.ice" />
-    <PackageReference Include="zeroc.ice.net" Version="3.8.0-alpha0" />
+    <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
     <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>

--- a/csharp/Ice/Callback/Client/Client.csproj
+++ b/csharp/Ice/Callback/Client/Client.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <SliceCompile Include="../slice/AlarmClock.ice" />
-    <PackageReference Include="zeroc.ice.net" Version="3.8.0-alpha0" />
+    <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
     <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>

--- a/csharp/Ice/Callback/Server/Server.csproj
+++ b/csharp/Ice/Callback/Server/Server.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <SliceCompile Include="../slice/AlarmClock.ice" />
-    <PackageReference Include="zeroc.ice.net" Version="3.8.0-alpha0" />
+    <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
     <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>

--- a/csharp/Ice/Cancellation/Client/Client.csproj
+++ b/csharp/Ice/Cancellation/Client/Client.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <SliceCompile Include="../slice/Greeter.ice" />
-    <PackageReference Include="zeroc.ice.net" Version="3.8.0-alpha0" />
+    <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
     <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>

--- a/csharp/Ice/Cancellation/Server/Server.csproj
+++ b/csharp/Ice/Cancellation/Server/Server.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <SliceCompile Include="../slice/Greeter.ice" />
-    <PackageReference Include="zeroc.ice.net" Version="3.8.0-alpha0" />
+    <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
     <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>

--- a/csharp/Ice/Config/Client/Client.csproj
+++ b/csharp/Ice/Config/Client/Client.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <SliceCompile Include="../slice/Greeter.ice" />
-    <PackageReference Include="zeroc.ice.net" Version="3.8.0-alpha0" />
+    <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
     <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>

--- a/csharp/Ice/Config/Server/Server.csproj
+++ b/csharp/Ice/Config/Server/Server.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <SliceCompile Include="../slice/Greeter.ice" />
-    <PackageReference Include="zeroc.ice.net" Version="3.8.0-alpha0" />
+    <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
     <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>

--- a/csharp/Ice/Context/Client/Client.csproj
+++ b/csharp/Ice/Context/Client/Client.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <SliceCompile Include="../slice/Greeter.ice" />
-    <PackageReference Include="zeroc.ice.net" Version="3.8.0-alpha0" />
+    <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
     <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>

--- a/csharp/Ice/Context/Server/Server.csproj
+++ b/csharp/Ice/Context/Server/Server.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <SliceCompile Include="../slice/Greeter.ice" />
-    <PackageReference Include="zeroc.ice.net" Version="3.8.0-alpha0" />
+    <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
     <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>

--- a/csharp/Ice/Filesystem/Client/Client.csproj
+++ b/csharp/Ice/Filesystem/Client/Client.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <SliceCompile Include="../slice/Filesystem.ice" />
-    <PackageReference Include="zeroc.ice.net" Version="3.8.0-alpha0" />
+    <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
     <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>

--- a/csharp/Ice/Filesystem/Server/Server.csproj
+++ b/csharp/Ice/Filesystem/Server/Server.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <SliceCompile Include="../slice/Filesystem.ice" />
-    <PackageReference Include="zeroc.ice.net" Version="3.8.0-alpha0" />
+    <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
     <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>

--- a/csharp/Ice/Forwarder/Client/Client.csproj
+++ b/csharp/Ice/Forwarder/Client/Client.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <SliceCompile Include="../slice/Greeter.ice" />
-    <PackageReference Include="zeroc.ice.net" Version="3.8.0-alpha0" />
+    <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
     <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>

--- a/csharp/Ice/Forwarder/ForwardingServer/ForwardingServer.csproj
+++ b/csharp/Ice/Forwarder/ForwardingServer/ForwardingServer.csproj
@@ -9,7 +9,7 @@
     <CopyDebugSymbolFilesFromPackages>true</CopyDebugSymbolFilesFromPackages>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="zeroc.ice.net" Version="3.8.0-alpha0" />
+    <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/csharp/Ice/Forwarder/Server/Server.csproj
+++ b/csharp/Ice/Forwarder/Server/Server.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <SliceCompile Include="../slice/Greeter.ice" />
-    <PackageReference Include="zeroc.ice.net" Version="3.8.0-alpha0" />
+    <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
     <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>

--- a/csharp/Ice/Greeter/Client/Client.csproj
+++ b/csharp/Ice/Greeter/Client/Client.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <SliceCompile Include="../slice/Greeter.ice" />
-    <PackageReference Include="zeroc.ice.net" Version="3.8.0-alpha0" />
+    <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
     <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>

--- a/csharp/Ice/Greeter/Server/Server.csproj
+++ b/csharp/Ice/Greeter/Server/Server.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <SliceCompile Include="../slice/Greeter.ice" />
-    <PackageReference Include="zeroc.ice.net" Version="3.8.0-alpha0" />
+    <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
     <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>

--- a/csharp/Ice/Greeter/ServerAMD/ServerAMD.csproj
+++ b/csharp/Ice/Greeter/ServerAMD/ServerAMD.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <SliceCompile Include="../slice/GreeterAMD.ice" />
-    <PackageReference Include="zeroc.ice.net" Version="3.8.0-alpha0" />
+    <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
     <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>

--- a/csharp/Ice/Middleware/Client/Client.csproj
+++ b/csharp/Ice/Middleware/Client/Client.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <SliceCompile Include="../slice/Greeter.ice" />
-    <PackageReference Include="zeroc.ice.net" Version="3.8.0-alpha0" />
+    <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
     <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>

--- a/csharp/Ice/Middleware/Server/Server.csproj
+++ b/csharp/Ice/Middleware/Server/Server.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <SliceCompile Include="../slice/Greeter.ice" />
-    <PackageReference Include="zeroc.ice.net" Version="3.8.0-alpha0" />
+    <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
     <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>

--- a/csharp/Ice/interceptor/msbuild/client/client.csproj
+++ b/csharp/Ice/interceptor/msbuild/client/client.csproj
@@ -10,7 +10,7 @@
     <ItemGroup>
         <Compile Include="../../Client.cs" />
         <SliceCompile Include="../../Interceptor.ice" />
-        <PackageReference Include="zeroc.ice.net" Version="3.8.0-alpha0" />
+        <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
         <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
 
         <!-- The 1.2 beta version is required for supporting the latest language features.

--- a/csharp/Ice/interceptor/msbuild/server/server.csproj
+++ b/csharp/Ice/interceptor/msbuild/server/server.csproj
@@ -13,7 +13,7 @@
         <Compile Include="../../ThermostatI.cs" />
         <Compile Include="../../Server.cs" />
         <SliceCompile Include="../../Interceptor.ice" />
-        <PackageReference Include="zeroc.ice.net" Version="3.8.0-alpha0" />
+        <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
         <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
 
         <!-- The 1.2 beta version is required for supporting the latest language features.

--- a/csharp/Ice/multicast/msbuild/client/client.csproj
+++ b/csharp/Ice/multicast/msbuild/client/client.csproj
@@ -12,7 +12,7 @@
         <Compile Include="../../DiscoverReplyI.cs" />
         <SliceCompile Include="../../Discovery.ice" />
         <SliceCompile Include="../../Hello.ice" />
-        <PackageReference Include="zeroc.ice.net" Version="3.8.0-alpha0" />
+        <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
         <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
 
         <!-- The 1.2 beta version is required for supporting the latest language features.

--- a/csharp/Ice/multicast/msbuild/server/server.csproj
+++ b/csharp/Ice/multicast/msbuild/server/server.csproj
@@ -13,7 +13,7 @@
         <Compile Include="../../Server.cs" />
         <SliceCompile Include="../../Discovery.ice" />
         <SliceCompile Include="../../Hello.ice" />
-        <PackageReference Include="zeroc.ice.net" Version="3.8.0-alpha0" />
+        <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
         <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
 
         <!-- The 1.2 beta version is required for supporting the latest language features.

--- a/csharp/Ice/optional/msbuild/client/client.csproj
+++ b/csharp/Ice/optional/msbuild/client/client.csproj
@@ -11,7 +11,7 @@
     <ItemGroup>
         <Compile Include="../../Client.cs" />
         <SliceCompile Include="../../Contact.ice" />
-        <PackageReference Include="zeroc.ice.net" Version="3.8.0-alpha0" />
+        <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
         <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
 
         <!-- The 1.2 beta version is required for supporting the latest language features.

--- a/csharp/Ice/optional/msbuild/server/server.csproj
+++ b/csharp/Ice/optional/msbuild/server/server.csproj
@@ -11,7 +11,7 @@
         <Compile Include="../../ContactDBI.cs" />
         <Compile Include="../../Server.cs" />
         <SliceCompile Include="../../Contact.ice" />
-        <PackageReference Include="zeroc.ice.net" Version="3.8.0-alpha0" />
+        <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
         <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
 
         <!-- The 1.2 beta version is required for supporting the latest language features.

--- a/csharp/Ice/properties/msbuild/client/client.csproj
+++ b/csharp/Ice/properties/msbuild/client/client.csproj
@@ -10,7 +10,7 @@
     <ItemGroup>
         <Compile Include="../../Client.cs" />
         <SliceCompile Include="../../Props.ice" />
-        <PackageReference Include="zeroc.ice.net" Version="3.8.0-alpha0" />
+        <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
         <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
 
         <!-- The 1.2 beta version is required for supporting the latest language features.

--- a/csharp/Ice/properties/msbuild/server/server.csproj
+++ b/csharp/Ice/properties/msbuild/server/server.csproj
@@ -10,7 +10,7 @@
     <ItemGroup>
         <Compile Include="../../Server.cs" />
         <SliceCompile Include="../../Props.ice" />
-        <PackageReference Include="zeroc.ice.net" Version="3.8.0-alpha0" />
+        <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
         <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
 
         <!-- The 1.2 beta version is required for supporting the latest language features.

--- a/csharp/Ice/session/msbuild/client/client.csproj
+++ b/csharp/Ice/session/msbuild/client/client.csproj
@@ -10,7 +10,7 @@
     <ItemGroup>
         <Compile Include="../../Client.cs" />
         <SliceCompile Include="../../Session.ice" />
-        <PackageReference Include="zeroc.ice.net" Version="3.8.0-alpha0" />
+        <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
         <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
 
         <!-- The 1.2 beta version is required for supporting the latest language features.

--- a/csharp/Ice/session/msbuild/server/server.csproj
+++ b/csharp/Ice/session/msbuild/server/server.csproj
@@ -13,7 +13,7 @@
         <Compile Include="../../SessionFactoryI.cs" />
         <Compile Include="../../SessionI.cs" />
         <SliceCompile Include="../../Session.ice" />
-        <PackageReference Include="zeroc.ice.net" Version="3.8.0-alpha0" />
+        <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
         <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
 
         <!-- The 1.2 beta version is required for supporting the latest language features.

--- a/csharp/IceBox/hello/msbuild/client/client.csproj
+++ b/csharp/IceBox/hello/msbuild/client/client.csproj
@@ -10,7 +10,7 @@
     <ItemGroup>
         <Compile Include="../../Client.cs" />
         <SliceCompile Include="../../Hello.ice" />
-        <PackageReference Include="zeroc.ice.net" Version="3.8.0-alpha0" />
+        <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
         <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
 
         <!-- The 1.2 beta version is required for supporting the latest language features.

--- a/csharp/IceBox/hello/msbuild/helloservice/helloservice.csproj
+++ b/csharp/IceBox/hello/msbuild/helloservice/helloservice.csproj
@@ -10,7 +10,7 @@
         <Compile Include="../../HelloI.cs" />
         <Compile Include="../../HelloServiceI.cs" />
         <SliceCompile Include="../../Hello.ice" />
-        <PackageReference Include="zeroc.ice.net" Version="3.8.0-alpha0" />
+        <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
         <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
 
         <!-- The 1.2 beta version is required for supporting the latest language features.

--- a/csharp/IceDiscovery/hello/msbuild/client/client.csproj
+++ b/csharp/IceDiscovery/hello/msbuild/client/client.csproj
@@ -10,7 +10,7 @@
     <ItemGroup>
         <Compile Include="../../Client.cs" />
         <SliceCompile Include="../../Hello.ice" />
-        <PackageReference Include="zeroc.ice.net" Version="3.8.0-alpha0" />
+        <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
         <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
 
         <!-- The 1.2 beta version is required for supporting the latest language features.

--- a/csharp/IceDiscovery/hello/msbuild/server/server.csproj
+++ b/csharp/IceDiscovery/hello/msbuild/server/server.csproj
@@ -11,7 +11,7 @@
         <Compile Include="../../HelloI.cs" />
         <Compile Include="../../Server.cs" />
         <SliceCompile Include="../../Hello.ice" />
-        <PackageReference Include="zeroc.ice.net" Version="3.8.0-alpha0" />
+        <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
         <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
 
         <!-- The 1.2 beta version is required for supporting the latest language features.

--- a/csharp/IceDiscovery/replication/msbuild/client/client.csproj
+++ b/csharp/IceDiscovery/replication/msbuild/client/client.csproj
@@ -10,7 +10,7 @@
     <ItemGroup>
         <Compile Include="../../Client.cs" />
         <SliceCompile Include="../../Hello.ice" />
-        <PackageReference Include="zeroc.ice.net" Version="3.8.0-alpha0" />
+        <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
         <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
 
         <!-- The 1.2 beta version is required for supporting the latest language features.

--- a/csharp/IceDiscovery/replication/msbuild/server/server.csproj
+++ b/csharp/IceDiscovery/replication/msbuild/server/server.csproj
@@ -11,7 +11,7 @@
         <Compile Include="../../HelloI.cs" />
         <Compile Include="../../Server.cs" />
         <SliceCompile Include="../../Hello.ice" />
-        <PackageReference Include="zeroc.ice.net" Version="3.8.0-alpha0" />
+        <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
         <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
 
         <!-- The 1.2 beta version is required for supporting the latest language features.

--- a/csharp/IceGrid/icebox/msbuild/client/client.csproj
+++ b/csharp/IceGrid/icebox/msbuild/client/client.csproj
@@ -10,7 +10,7 @@
     <ItemGroup>
         <Compile Include="../../Client.cs" />
         <SliceCompile Include="../../Hello.ice" />
-        <PackageReference Include="zeroc.ice.net" Version="3.8.0-alpha0" />
+        <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
         <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
 
         <!-- The 1.2 beta version is required for supporting the latest language features.

--- a/csharp/IceGrid/icebox/msbuild/helloservice/helloservice.csproj
+++ b/csharp/IceGrid/icebox/msbuild/helloservice/helloservice.csproj
@@ -10,7 +10,7 @@
         <Compile Include="../../HelloI.cs" />
         <Compile Include="../../HelloServiceI.cs" />
         <SliceCompile Include="../../Hello.ice" />
-        <PackageReference Include="zeroc.ice.net" Version="3.8.0-alpha0" />
+        <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
         <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
 
         <!-- The 1.2 beta version is required for supporting the latest language features.

--- a/csharp/IceGrid/simple/msbuild/client/client.csproj
+++ b/csharp/IceGrid/simple/msbuild/client/client.csproj
@@ -10,7 +10,7 @@
     <ItemGroup>
         <Compile Include="../../Client.cs" />
         <SliceCompile Include="../../Hello.ice" />
-        <PackageReference Include="zeroc.ice.net" Version="3.8.0-alpha0" />
+        <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
         <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
 
         <!-- The 1.2 beta version is required for supporting the latest language features.

--- a/csharp/IceGrid/simple/msbuild/server/server.csproj
+++ b/csharp/IceGrid/simple/msbuild/server/server.csproj
@@ -11,7 +11,7 @@
         <Compile Include="../../HelloI.cs" />
         <Compile Include="../../Server.cs" />
         <SliceCompile Include="../../Hello.ice" />
-        <PackageReference Include="zeroc.ice.net" Version="3.8.0-alpha0" />
+        <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
         <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
 
         <!-- The 1.2 beta version is required for supporting the latest language features.

--- a/csharp/IceStorm/clock/msbuild/publisher/publisher.csproj
+++ b/csharp/IceStorm/clock/msbuild/publisher/publisher.csproj
@@ -10,7 +10,7 @@
     <ItemGroup>
         <Compile Include="../../Publisher.cs" />
         <SliceCompile Include="../../Clock.ice" />
-        <PackageReference Include="zeroc.ice.net" Version="3.8.0-alpha0" />
+        <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
         <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
 
         <!-- The 1.2 beta version is required for supporting the latest language features.

--- a/csharp/IceStorm/clock/msbuild/subscriber/subscriber.csproj
+++ b/csharp/IceStorm/clock/msbuild/subscriber/subscriber.csproj
@@ -10,7 +10,7 @@
     <ItemGroup>
         <Compile Include="../../Subscriber.cs" />
         <SliceCompile Include="../../Clock.ice" />
-        <PackageReference Include="zeroc.ice.net" Version="3.8.0-alpha0" />
+        <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
         <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
 
         <!-- The 1.2 beta version is required for supporting the latest language features.

--- a/csharp/README.md
+++ b/csharp/README.md
@@ -26,7 +26,7 @@ Each subdirectory includes a small demo focusing on a specific Ice component or 
 
 The top-level [Directory.Build.props](./Directory.Build.props) file sets `IceVersion` to
 `3.8.0-nightly.*` by default to pull the latest nightly build of Ice.
-You can override this on the command line or in your environment:
+You can override this on the command line:
 
 ```shell
 dotnet build -p:IceVersion="3.8.0~alpha0"

--- a/csharp/README.md
+++ b/csharp/README.md
@@ -2,64 +2,34 @@
 
 - [C# Demos](#c-demos)
   - [Overview](#overview)
-  - [Building and running the Demos](#building-and-running-the-demos)
-    - [Build Requirements](#build-requirements)
-    - [Building the demos](#building-the-demos)
-    - [Building the demos using a source build](#building-the-demos-using-a-source-build)
-    - [Running the Demos](#running-the-demos)
+  - [Building Requirements](#building-requirements)
+  - [Building the Demos](#building-the-demos)
 
 ## Overview
 
-This directory contains C# sample programs for various Ice components. These
-examples are provided to get you started on using a particular Ice feature or
-coding technique.
+This directory contains C# sample programs demonstrating how to use various features of
+[Ice](https://zeroc.com/products/ice) framework.
 
-Most of the subdirectories here correspond directly to Ice components, such as
-[Glacier2](./Glacier2), [IceBox](./IceBox), and so on. We've also included the
-following additional subdirectories:
+Each subdirectory includes a small demo focusing on a specific Ice component or coding technique.
 
-- [Manual](./Manual) contains complete examples for some of the code snippets
-in the [Ice manual][1].
+## Building Requirements
 
-- [Chat](./Chat) contains a .NET GUI client for the ZeroC [Chat Demo][2].
+1. **.NET SDK 8.0**
+   Download and install the .NET 8.0 SDK from
+   [dotnet.microsoft.com](https://dotnet.microsoft.com/en-us/download/dotnet).
 
-Refer to the [C++ demos)(../cpp) for more examples that use the Ice services
-(Glacier2, IceGrid, IceStorm).
+2. **ZeroC NuGet Feed**
+   The included [nuget.config](./nuget.config) file already adds the ZeroC NuGet feed to make
+   the ZeroC nightly builds available.
 
-## Building and running the Demos
+## Building the Demos
 
-### Build Requirements
-
-In order to build Ice for .NET sample programs, you need all of the following:
-
-- the [.NET SDK][3] version 8.0 or later
-
-You can build from the command-line or with Visual Studio 2022 for Windows.
-
-### Building the demos
-
-Open a command prompt and change to the `csharp` subdirectory:
+The top-level [Directory.Build.props](./Directory.Build.props) file sets `IceVersion` to
+`3.8.0-nightly.*` by default to pull the latest nightly build of Ice.
+You can override this on the command line or in your environment:
 
 ```shell
-cd csharp
+dotnet build -p:IceVersion="3.8.0~alpha0"
 ```
 
-To build the sample programs run:
-
-```shell
-dotnet build
-```
-
-### Running the Demos
-
-For most demos, you can simply run `server` and `client` in separate Command Prompt windows. Refer to the README.md
-file in each demo directory for the exact usage instructions.
-
-Some demos require Ice services such as IceGrid and IceStorm that are not included in the `zeroc.ice.net` NuGet
-package. To run these demos, the simplest is to first install the Ice binary distribution for your platform and add its
-bin directory to your PATH. Please refer to the [Release Notes][4] for additional information.
-
-[1]: https://doc.zeroc.com/ice/3.7/introduction
-[2]: https://doc.zeroc.com/technical-articles/general-topics/chat-demo
-[3]: https://download/dotnet/8.0
-[4]: https://doc.zeroc.com/rel/ice-releases/ice-3-7/ice-3-7-10-release-notes
+Check each demo’s README for detailed instructions on building and running that specific example.

--- a/csharp/nuget.config
+++ b/csharp/nuget.config
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <!-- Define the package sources, nuget.org and zeroc.com. -->
+  <!-- `clear` ensures no additional sources are inherited from another config file. -->
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="zeroc.com" value="https://download.zeroc.com/nexus/repository/nuget-nightly/" />
+  </packageSources>
+  
+  <!-- Define mappings by adding package patterns beneath the target source. -->
+  <!-- zeroc.* packages will be restored from zeroc.com, everything else from nuget.org. -->
+  <packageSourceMapping>
+    <packageSource key="nuget.org">
+      <package pattern="*" />
+    </packageSource>
+    <packageSource key="zeroc.com">
+      <package pattern="zeroc.*" />
+    </packageSource>
+  </packageSourceMapping>
+</configuration>


### PR DESCRIPTION
This PR upgrades C# builds to use the Nightly builds by default.

The `IceVersion` MSBuild property defined in `csharp/Directory.Build.props`  allows to override what version to use. See details in `csharp/README.md`

The `csharp/nuget.config` includes the nightly source to make the packages available. I added a package pattern so that `zeroc` prefixes packages are lookup only in this feed. This affects `zeroc.icebuilder.msbuild` used by the samples too.

One issue is that nightly uses a clean policy to delete packages older than 5 days, and this would require to re upload the builder ...