### PR TITLE
Update C++ greeter server to use waitForShutdown

### DIFF
--- a/cpp/Ice/greeter/Server.cpp
+++ b/cpp/Ice/greeter/Server.cpp
@@ -13,10 +13,11 @@ main(int argc, char* argv[])
     // of the program, before creating an Ice communicator or starting any thread.
     Ice::CtrlCHandler ctrlCHandler;
 
-    // Create an Ice communicator to initialize the Ice runtime. The CommunicatorHolder is a RAII helper that creates
-    // the communicator in its constructor and destroys it when it goes out of scope.
-    const Ice::CommunicatorHolder communicatorHolder{argc, argv};
-    const Ice::CommunicatorPtr& communicator = communicatorHolder.communicator();
+    // Create an Ice communicator to initialize the Ice runtime.
+    Ice::CommunicatorPtr communicator = Ice::initialize(argc, argv);
+
+    // Make sure the communicator is destroyed at the end of this scope.
+    Ice::CommunicatorHolder communicatorHolder{communicator};
 
     // Create an object adapter that listens for incoming requests and dispatches them to servants.
     auto adapter = communicator->createObjectAdapterWithEndpoints("GreeterAdapter", "tcp -p 4061");
@@ -28,9 +29,16 @@ main(int argc, char* argv[])
     adapter->activate();
     cout << "Listening on port 4061..." << endl;
 
-    // Wait until the user presses Ctrl+C.
-    int signal = ctrlCHandler.wait();
-    cout << "Caught signal " << signal << ", exiting..." << endl;
+    // Shut down the communicator when the user presses Ctrl+C.
+    ctrlCHandler.setCallback(
+        [communicator](int signal)
+        {
+            cout << "Caught signal " << signal << ", shutting down..." << endl;
+            communicator->shutdown();
+        });
+
+    // Wait until the communicator is shut down. Here, this occurs when the user presses Ctrl+C.
+    communicator->waitForShutdown();
 
     return 0;
 }

--- a/cpp/Ice/greeter/ServerAMD.cpp
+++ b/cpp/Ice/greeter/ServerAMD.cpp
@@ -13,10 +13,11 @@ main(int argc, char* argv[])
     // of the program, before creating an Ice communicator or starting any thread.
     Ice::CtrlCHandler ctrlCHandler;
 
-    // Create an Ice communicator to initialize the Ice runtime. The CommunicatorHolder is a RAII helper that creates
-    // the communicator in its constructor and destroys it when it goes out of scope.
-    const Ice::CommunicatorHolder communicatorHolder{argc, argv};
-    const Ice::CommunicatorPtr& communicator = communicatorHolder.communicator();
+    // Create an Ice communicator to initialize the Ice runtime.
+    Ice::CommunicatorPtr communicator = Ice::initialize(argc, argv);
+
+    // Call destroy on the communicator the end of this scope.
+    Ice::CommunicatorHolder communicatorHolder{communicator};
 
     // Create an object adapter that listens for incoming requests and dispatches them to servants.
     auto adapter = communicator->createObjectAdapterWithEndpoints("GreeterAdapter", "tcp -p 4061");
@@ -28,9 +29,16 @@ main(int argc, char* argv[])
     adapter->activate();
     cout << "Listening on port 4061..." << endl;
 
-    // Wait until the user presses Ctrl+C.
-    int signal = ctrlCHandler.wait();
-    cout << "Caught signal " << signal << ", exiting..." << endl;
+    // Shut down the communicator when the user presses Ctrl+C.
+    ctrlCHandler.setCallback(
+        [communicator](int signal)
+        {
+            cout << "Caught signal " << signal << ", shutting down..." << endl;
+            communicator->shutdown();
+        });
+
+    // Wait until the communicator is shut down. Here, this occurs when the user presses Ctrl+C.
+    communicator->waitForShutdown();
 
     return 0;
 }


### PR DESCRIPTION
This PR updates the greeter servers to use `waitForShutdown` to avoid returning from main prematurely.

Once we have the model right, we should update all the demos to use it.

