### PR TITLE
Upgrade C# projects to not depend on zeroc.icebuilder.msbuild

### DIFF
--- a/csharp/Glacier2/callback/msbuild/client/client.csproj
+++ b/csharp/Glacier2/callback/msbuild/client/client.csproj
@@ -18,7 +18,6 @@
         <Compile Include="../../CallbackReceiverI.cs" />
         <SliceCompile Include="../../Callback.ice" />
         <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-        <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
 
         <!-- The 1.2 beta version is required for supporting the latest language features.
              See: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3187 -->

--- a/csharp/Glacier2/callback/msbuild/server/server.csproj
+++ b/csharp/Glacier2/callback/msbuild/server/server.csproj
@@ -12,7 +12,6 @@
         <Compile Include="../../Server.cs" />
         <SliceCompile Include="../../Callback.ice" />
         <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-        <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
 
         <!-- The 1.2 beta version is required for supporting the latest language features.
              See: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3187 -->

--- a/csharp/Ice/Bidir/Client/Client.csproj
+++ b/csharp/Ice/Bidir/Client/Client.csproj
@@ -11,7 +11,6 @@
   <ItemGroup>
     <SliceCompile Include="../slice/AlarmClock.ice" />
     <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-    <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/csharp/Ice/Bidir/Server/Server.csproj
+++ b/csharp/Ice/Bidir/Server/Server.csproj
@@ -11,7 +11,6 @@
   <ItemGroup>
     <SliceCompile Include="../slice/AlarmClock.ice" />
     <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-    <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/csharp/Ice/Callback/Client/Client.csproj
+++ b/csharp/Ice/Callback/Client/Client.csproj
@@ -11,7 +11,6 @@
   <ItemGroup>
     <SliceCompile Include="../slice/AlarmClock.ice" />
     <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-    <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/csharp/Ice/Callback/Server/Server.csproj
+++ b/csharp/Ice/Callback/Server/Server.csproj
@@ -11,7 +11,6 @@
   <ItemGroup>
     <SliceCompile Include="../slice/AlarmClock.ice" />
     <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-    <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/csharp/Ice/Cancellation/Client/Client.csproj
+++ b/csharp/Ice/Cancellation/Client/Client.csproj
@@ -11,7 +11,6 @@
   <ItemGroup>
     <SliceCompile Include="../slice/Greeter.ice" />
     <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-    <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/csharp/Ice/Cancellation/Server/Server.csproj
+++ b/csharp/Ice/Cancellation/Server/Server.csproj
@@ -11,7 +11,6 @@
   <ItemGroup>
     <SliceCompile Include="../slice/Greeter.ice" />
     <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-    <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/csharp/Ice/Config/Client/Client.csproj
+++ b/csharp/Ice/Config/Client/Client.csproj
@@ -11,7 +11,6 @@
   <ItemGroup>
     <SliceCompile Include="../slice/Greeter.ice" />
     <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-    <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/csharp/Ice/Config/Server/Server.csproj
+++ b/csharp/Ice/Config/Server/Server.csproj
@@ -11,7 +11,6 @@
   <ItemGroup>
     <SliceCompile Include="../slice/Greeter.ice" />
     <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-    <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/csharp/Ice/Context/Client/Client.csproj
+++ b/csharp/Ice/Context/Client/Client.csproj
@@ -11,7 +11,6 @@
   <ItemGroup>
     <SliceCompile Include="../slice/Greeter.ice" />
     <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-    <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/csharp/Ice/Context/Server/Server.csproj
+++ b/csharp/Ice/Context/Server/Server.csproj
@@ -11,7 +11,6 @@
   <ItemGroup>
     <SliceCompile Include="../slice/Greeter.ice" />
     <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-    <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/csharp/Ice/Filesystem/Client/Client.csproj
+++ b/csharp/Ice/Filesystem/Client/Client.csproj
@@ -11,7 +11,6 @@
   <ItemGroup>
     <SliceCompile Include="../slice/Filesystem.ice" />
     <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-    <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/csharp/Ice/Filesystem/Server/Server.csproj
+++ b/csharp/Ice/Filesystem/Server/Server.csproj
@@ -11,7 +11,6 @@
   <ItemGroup>
     <SliceCompile Include="../slice/Filesystem.ice" />
     <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-    <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/csharp/Ice/Forwarder/Client/Client.csproj
+++ b/csharp/Ice/Forwarder/Client/Client.csproj
@@ -11,7 +11,6 @@
   <ItemGroup>
     <SliceCompile Include="../slice/Greeter.ice" />
     <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-    <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/csharp/Ice/Forwarder/Server/Server.csproj
+++ b/csharp/Ice/Forwarder/Server/Server.csproj
@@ -11,7 +11,6 @@
   <ItemGroup>
     <SliceCompile Include="../slice/Greeter.ice" />
     <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-    <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/csharp/Ice/Greeter/Client/Client.csproj
+++ b/csharp/Ice/Greeter/Client/Client.csproj
@@ -11,7 +11,6 @@
   <ItemGroup>
     <SliceCompile Include="../slice/Greeter.ice" />
     <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-    <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/csharp/Ice/Greeter/Server/Server.csproj
+++ b/csharp/Ice/Greeter/Server/Server.csproj
@@ -11,7 +11,6 @@
   <ItemGroup>
     <SliceCompile Include="../slice/Greeter.ice" />
     <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-    <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/csharp/Ice/Greeter/ServerAMD/ServerAMD.csproj
+++ b/csharp/Ice/Greeter/ServerAMD/ServerAMD.csproj
@@ -11,7 +11,6 @@
   <ItemGroup>
     <SliceCompile Include="../slice/GreeterAMD.ice" />
     <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-    <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/csharp/Ice/Middleware/Client/Client.csproj
+++ b/csharp/Ice/Middleware/Client/Client.csproj
@@ -11,7 +11,6 @@
   <ItemGroup>
     <SliceCompile Include="../slice/Greeter.ice" />
     <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-    <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/csharp/Ice/Middleware/Server/Server.csproj
+++ b/csharp/Ice/Middleware/Server/Server.csproj
@@ -11,7 +11,6 @@
   <ItemGroup>
     <SliceCompile Include="../slice/Greeter.ice" />
     <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-    <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/csharp/Ice/interceptor/msbuild/client/client.csproj
+++ b/csharp/Ice/interceptor/msbuild/client/client.csproj
@@ -11,7 +11,6 @@
         <Compile Include="../../Client.cs" />
         <SliceCompile Include="../../Interceptor.ice" />
         <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-        <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
 
         <!-- The 1.2 beta version is required for supporting the latest language features.
              See: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3187 -->

--- a/csharp/Ice/interceptor/msbuild/server/server.csproj
+++ b/csharp/Ice/interceptor/msbuild/server/server.csproj
@@ -14,7 +14,6 @@
         <Compile Include="../../Server.cs" />
         <SliceCompile Include="../../Interceptor.ice" />
         <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-        <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
 
         <!-- The 1.2 beta version is required for supporting the latest language features.
              See: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3187 -->

--- a/csharp/Ice/multicast/msbuild/client/client.csproj
+++ b/csharp/Ice/multicast/msbuild/client/client.csproj
@@ -13,7 +13,6 @@
         <SliceCompile Include="../../Discovery.ice" />
         <SliceCompile Include="../../Hello.ice" />
         <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-        <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
 
         <!-- The 1.2 beta version is required for supporting the latest language features.
              See: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3187 -->

--- a/csharp/Ice/multicast/msbuild/server/server.csproj
+++ b/csharp/Ice/multicast/msbuild/server/server.csproj
@@ -14,7 +14,6 @@
         <SliceCompile Include="../../Discovery.ice" />
         <SliceCompile Include="../../Hello.ice" />
         <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-        <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
 
         <!-- The 1.2 beta version is required for supporting the latest language features.
              See: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3187 -->

--- a/csharp/Ice/optional/msbuild/client/client.csproj
+++ b/csharp/Ice/optional/msbuild/client/client.csproj
@@ -12,7 +12,6 @@
         <Compile Include="../../Client.cs" />
         <SliceCompile Include="../../Contact.ice" />
         <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-        <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
 
         <!-- The 1.2 beta version is required for supporting the latest language features.
              See: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3187 -->

--- a/csharp/Ice/optional/msbuild/server/server.csproj
+++ b/csharp/Ice/optional/msbuild/server/server.csproj
@@ -12,7 +12,6 @@
         <Compile Include="../../Server.cs" />
         <SliceCompile Include="../../Contact.ice" />
         <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-        <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
 
         <!-- The 1.2 beta version is required for supporting the latest language features.
              See: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3187 -->

--- a/csharp/Ice/properties/msbuild/client/client.csproj
+++ b/csharp/Ice/properties/msbuild/client/client.csproj
@@ -11,7 +11,6 @@
         <Compile Include="../../Client.cs" />
         <SliceCompile Include="../../Props.ice" />
         <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-        <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
 
         <!-- The 1.2 beta version is required for supporting the latest language features.
              See: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3187 -->

--- a/csharp/Ice/properties/msbuild/server/server.csproj
+++ b/csharp/Ice/properties/msbuild/server/server.csproj
@@ -11,7 +11,6 @@
         <Compile Include="../../Server.cs" />
         <SliceCompile Include="../../Props.ice" />
         <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-        <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
 
         <!-- The 1.2 beta version is required for supporting the latest language features.
              See: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3187 -->

--- a/csharp/Ice/session/msbuild/client/client.csproj
+++ b/csharp/Ice/session/msbuild/client/client.csproj
@@ -11,7 +11,6 @@
         <Compile Include="../../Client.cs" />
         <SliceCompile Include="../../Session.ice" />
         <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-        <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
 
         <!-- The 1.2 beta version is required for supporting the latest language features.
              See: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3187 -->

--- a/csharp/Ice/session/msbuild/server/server.csproj
+++ b/csharp/Ice/session/msbuild/server/server.csproj
@@ -14,7 +14,6 @@
         <Compile Include="../../SessionI.cs" />
         <SliceCompile Include="../../Session.ice" />
         <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-        <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
 
         <!-- The 1.2 beta version is required for supporting the latest language features.
              See: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3187 -->

--- a/csharp/IceBox/hello/msbuild/client/client.csproj
+++ b/csharp/IceBox/hello/msbuild/client/client.csproj
@@ -11,7 +11,6 @@
         <Compile Include="../../Client.cs" />
         <SliceCompile Include="../../Hello.ice" />
         <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-        <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
 
         <!-- The 1.2 beta version is required for supporting the latest language features.
              See: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3187 -->

--- a/csharp/IceBox/hello/msbuild/helloservice/helloservice.csproj
+++ b/csharp/IceBox/hello/msbuild/helloservice/helloservice.csproj
@@ -11,7 +11,6 @@
         <Compile Include="../../HelloServiceI.cs" />
         <SliceCompile Include="../../Hello.ice" />
         <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-        <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
 
         <!-- The 1.2 beta version is required for supporting the latest language features.
              See: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3187 -->

--- a/csharp/IceDiscovery/hello/msbuild/client/client.csproj
+++ b/csharp/IceDiscovery/hello/msbuild/client/client.csproj
@@ -11,7 +11,6 @@
         <Compile Include="../../Client.cs" />
         <SliceCompile Include="../../Hello.ice" />
         <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-        <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
 
         <!-- The 1.2 beta version is required for supporting the latest language features.
              See: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3187 -->

--- a/csharp/IceDiscovery/hello/msbuild/server/server.csproj
+++ b/csharp/IceDiscovery/hello/msbuild/server/server.csproj
@@ -12,7 +12,6 @@
         <Compile Include="../../Server.cs" />
         <SliceCompile Include="../../Hello.ice" />
         <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-        <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
 
         <!-- The 1.2 beta version is required for supporting the latest language features.
              See: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3187 -->

--- a/csharp/IceDiscovery/replication/msbuild/client/client.csproj
+++ b/csharp/IceDiscovery/replication/msbuild/client/client.csproj
@@ -11,7 +11,6 @@
         <Compile Include="../../Client.cs" />
         <SliceCompile Include="../../Hello.ice" />
         <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-        <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
 
         <!-- The 1.2 beta version is required for supporting the latest language features.
              See: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3187 -->

--- a/csharp/IceDiscovery/replication/msbuild/server/server.csproj
+++ b/csharp/IceDiscovery/replication/msbuild/server/server.csproj
@@ -12,7 +12,6 @@
         <Compile Include="../../Server.cs" />
         <SliceCompile Include="../../Hello.ice" />
         <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-        <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
 
         <!-- The 1.2 beta version is required for supporting the latest language features.
              See: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3187 -->

--- a/csharp/IceGrid/icebox/msbuild/client/client.csproj
+++ b/csharp/IceGrid/icebox/msbuild/client/client.csproj
@@ -11,7 +11,6 @@
         <Compile Include="../../Client.cs" />
         <SliceCompile Include="../../Hello.ice" />
         <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-        <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
 
         <!-- The 1.2 beta version is required for supporting the latest language features.
              See: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3187 -->

--- a/csharp/IceGrid/icebox/msbuild/helloservice/helloservice.csproj
+++ b/csharp/IceGrid/icebox/msbuild/helloservice/helloservice.csproj
@@ -11,7 +11,6 @@
         <Compile Include="../../HelloServiceI.cs" />
         <SliceCompile Include="../../Hello.ice" />
         <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-        <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
 
         <!-- The 1.2 beta version is required for supporting the latest language features.
              See: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3187 -->

--- a/csharp/IceGrid/simple/msbuild/client/client.csproj
+++ b/csharp/IceGrid/simple/msbuild/client/client.csproj
@@ -11,7 +11,6 @@
         <Compile Include="../../Client.cs" />
         <SliceCompile Include="../../Hello.ice" />
         <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-        <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
 
         <!-- The 1.2 beta version is required for supporting the latest language features.
              See: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3187 -->

--- a/csharp/IceGrid/simple/msbuild/server/server.csproj
+++ b/csharp/IceGrid/simple/msbuild/server/server.csproj
@@ -12,7 +12,6 @@
         <Compile Include="../../Server.cs" />
         <SliceCompile Include="../../Hello.ice" />
         <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-        <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
 
         <!-- The 1.2 beta version is required for supporting the latest language features.
              See: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3187 -->

--- a/csharp/IceStorm/clock/msbuild/publisher/publisher.csproj
+++ b/csharp/IceStorm/clock/msbuild/publisher/publisher.csproj
@@ -11,7 +11,6 @@
         <Compile Include="../../Publisher.cs" />
         <SliceCompile Include="../../Clock.ice" />
         <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-        <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
 
         <!-- The 1.2 beta version is required for supporting the latest language features.
              See: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3187 -->

--- a/csharp/IceStorm/clock/msbuild/subscriber/subscriber.csproj
+++ b/csharp/IceStorm/clock/msbuild/subscriber/subscriber.csproj
@@ -11,7 +11,6 @@
         <Compile Include="../../Subscriber.cs" />
         <SliceCompile Include="../../Clock.ice" />
         <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-        <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
 
         <!-- The 1.2 beta version is required for supporting the latest language features.
              See: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3187 -->


### PR DESCRIPTION
The zeroc.icebuilder.msbuild package is no longer required, the builder has been bundled with zeroc.ice.net.