### PR TITLE
Improvements to CMake builds on Windows

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -53,21 +53,13 @@ jobs:
       - name: Setup Ice Build Dependencies
         uses: ./ice/.github/actions/setup-dependencies
 
-      - name: Build Ice
-        uses: ./ice/.github/actions/build
-        timeout-minutes: 90
-        with:
-          working_directory: ice/cpp
-          build_flags: srcs
-
-      - name: Set ICE_HOME
-        run: |
-          echo "ICE_HOME=${{ github.workspace }}/ice" >> $GITHUB_ENV
-
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           path: ice-demos
+
+      - name: Install Nightly Ice Builds
+        uses: ./ice-demos/.github/actions/install-nightly-ice
 
       - name: Build C++ Demos
         timeout-minutes: 30

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -36,8 +36,5 @@
         "${workspaceFolder}/cpp/IceStorm/counter",
         "${workspaceFolder}/cpp/IceStorm/replicated",
         "${workspaceFolder}/cpp/IceStorm/replicated2",
-    ],
-    "cmake.configureSettings": {
-        "Ice_HOME": "${workspaceFolder}/../ice",
-    }
+    ]
 }

--- a/cpp/Ice/greeter/CMakeLists.txt
+++ b/cpp/Ice/greeter/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.21)
 
 project(greeter CXX)
 
@@ -7,11 +7,23 @@ include(../../cmake/common.cmake)
 add_executable(client Client.cpp Greeter.ice)
 slice2cpp_generate(client)
 target_link_libraries(client Ice::Ice)
+add_custom_command(TARGET client POST_BUILD
+  COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:client> $<TARGET_RUNTIME_DLLS:client>
+  COMMAND_EXPAND_LISTS
+)
 
 add_executable(server Server.cpp Chatbot.cpp Chatbot.h Greeter.ice)
 slice2cpp_generate(server)
 target_link_libraries(server Ice::Ice)
+add_custom_command(TARGET server POST_BUILD
+  COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:server> $<TARGET_RUNTIME_DLLS:server>
+  COMMAND_EXPAND_LISTS
+)
 
 add_executable(serveramd ServerAMD.cpp ChatbotAMD.cpp ChatbotAMD.h GreeterAMD.ice)
 slice2cpp_generate(serveramd)
 target_link_libraries(serveramd Ice::Ice)
+add_custom_command(TARGET serveramd POST_BUILD
+  COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:serveramd> $<TARGET_RUNTIME_DLLS:serveramd>
+  COMMAND_EXPAND_LISTS
+)

--- a/cpp/cmake/.gitignore
+++ b/cpp/cmake/.gitignore
@@ -1,0 +1,1 @@
+packages

--- a/cpp/cmake/IceConfig.cmake
+++ b/cpp/cmake/IceConfig.cmake
@@ -20,41 +20,18 @@ if(NOT DEFINED Ice_ARCHITECTURE)
   endif()
 endif()
 
-if(EXISTS ${Ice_HOME}/cpp)
-  set(Ice_SOURCE_BUILD ON)
-endif()
+list(APPEND ice_include_path_suffixes "include")
+list(APPEND ice_bin_path_suffixes "bin")
+list(APPEND ice_lib_path_suffixes "lib")
 
-if(Ice_SOURCE_BUILD)
-  list(APPEND ice_include_path_suffixes "cpp/include")
-  list(APPEND ice_bin_path_suffixes "cpp/bin")
-  list(APPEND ice_lib_path_suffixes "cpp/lib")
-
-  if (Ice_ARCHITECTURE)
-    list(APPEND ice_lib_path_suffixes "cpp/lib/${Ice_ARCHITECTURE}")
-  endif()
-
-  if(WIN32)
-    list(APPEND ice_bin_path_suffixes "cpp/bin/${Ice_ARCHITECTURE}/Release" "cpp/bin/${Ice_ARCHITECTURE}/Debug")
-    list(APPEND ice_lib_path_suffixes_release "cpp/lib/${Ice_ARCHITECTURE}/Release")
-    list(APPEND ice_lib_path_suffixes_debug "cpp/lib/${Ice_ARCHITECTURE}/Debug")
-  endif()
-
-else()
-
-  list(APPEND ice_include_path_suffixes "include")
-  list(APPEND ice_bin_path_suffixes "bin")
-  list(APPEND ice_lib_path_suffixes "lib")
-
-  if(WIN32)
-    # NuGet packages
-    list(APPEND ice_include_path_suffixes "build/native/include")
-    list(APPEND ice_bin_path_suffixes "tools")
-    list(APPEND ice_bin_path_suffixes_release "build/native/bin/${Ice_ARCHITECTURE}/Release")
-    list(APPEND ice_bin_path_suffixes_debug "build/native/bin/${Ice_ARCHITECTURE}/Debug")
-    list(APPEND ice_lib_path_suffixes_release "build/native/lib/${Ice_ARCHITECTURE}/Release")
-    list(APPEND ice_lib_path_suffixes_debug "build/native/lib/${Ice_ARCHITECTURE}/Debug")
-  endif()
-
+if(WIN32)
+  # NuGet packages
+  list(APPEND ice_include_path_suffixes "build/native/include")
+  list(APPEND ice_bin_path_suffixes "tools")
+  list(APPEND ice_bin_path_suffixes_release "build/native/bin/${Ice_ARCHITECTURE}/Release")
+  list(APPEND ice_bin_path_suffixes_debug "build/native/bin/${Ice_ARCHITECTURE}/Debug")
+  list(APPEND ice_lib_path_suffixes_release "build/native/lib/${Ice_ARCHITECTURE}/Release")
+  list(APPEND ice_lib_path_suffixes_debug "build/native/lib/${Ice_ARCHITECTURE}/Debug")
 endif()
 
 # Ice include directory
@@ -62,29 +39,10 @@ if(NOT DEFINED Ice_INCLUDE_DIR)
   find_path(Ice_INCLUDE_DIR NAMES Ice/Ice.h HINTS ${Ice_HOME} PATH_SUFFIXES ${ice_include_path_suffixes} CACHE PATH "Path to the Ice include directory")
 endif()
 
-# Ice include directories include the generated directory(s)
+# Ice include directories
 if(NOT DEFINED Ice_INCLUDE_DIRS)
   set(Ice_INCLUDE_DIRS ${Ice_INCLUDE_DIR})
-
-  if(Ice_SOURCE_BUILD)
-    #  Only the Windows build has separate Debug and Release directories for the generated files
-    if(WIN32)
-      set(Ice_GENERATED_INCLUDE_DIR_RELEASE ${Ice_INCLUDE_DIR}/generated/${Ice_ARCHITECTURE}/Release)
-      if (EXISTS ${Ice_GENERATED_INCLUDE_DIR_RELEASE})
-        list(APPEND Ice_INCLUDE_DIRS $<$<CONFIG:Release>:${Ice_GENERATED_INCLUDE_DIR_RELEASE}>)
-      endif()
-
-      set(Ice_GENERATED_INCLUDE_DIR_DEBUG ${Ice_INCLUDE_DIR}/generated/${Ice_ARCHITECTURE}/Debug)
-      if (EXISTS ${Ice_GENERATED_INCLUDE_DIR_DEBUG})
-        list(APPEND Ice_INCLUDE_DIRS $<$<CONFIG:Debug>:${Ice_GENERATED_INCLUDE_DIR_DEBUG}>)
-      endif()
-    else()
-        list(APPEND Ice_INCLUDE_DIRS ${Ice_INCLUDE_DIR}/generated)
-    endif()
-  endif()
-
   set(Ice_INCLUDE_DIRS ${Ice_INCLUDE_DIRS} CACHE STRING "Ice include directories")
-
 endif()
 
 # Read Ice version variables from Ice/Config.h

--- a/cpp/cmake/IceConfig.cmake
+++ b/cpp/cmake/IceConfig.cmake
@@ -147,9 +147,10 @@ foreach(component ${Ice_FIND_COMPONENTS})
         HINTS ${Ice_HOME}
         PATH_SUFFIXES ${ice_bin_path_suffixes_debug}
       )
+
     else()
-      # On Linux/macOS, there is only one library for both Debug and Release configurations
-      find_library(Ice_${component}_LIBRARY
+      # On Linux/macOS, there is only one library for both Debug and Release configurations.
+      find_library(Ice_${component}_LIBRARY_RELEASE
         NAMES ${component} ${component}${Ice_SO_VERSION}
         HINTS ${Ice_HOME}
         PATH_SUFFIXES ${ice_lib_path_suffixes}
@@ -161,7 +162,6 @@ foreach(component ${Ice_FIND_COMPONENTS})
     select_library_configurations(Ice_${component})
 
     if(Ice_${component}_LIBRARY)
-
       # Create an imported target for the component
       add_library(Ice::${component} SHARED IMPORTED)
       set_target_properties(Ice::${component} PROPERTIES

--- a/cpp/cmake/IceConfig.cmake
+++ b/cpp/cmake/IceConfig.cmake
@@ -5,6 +5,9 @@ if (NOT Ice_HOME)
   endif()
 endif()
 
+include(CMakeFindDependencyMacro)
+find_package(Threads REQUIRED)
+
 if(NOT DEFINED Ice_ARCHITECTURE)
   if (CMAKE_LIBRARY_ARCHITECTURE)
     set(Ice_ARCHITECTURE ${CMAKE_LIBRARY_ARCHITECTURE} CACHE STRING "Library architecture")
@@ -24,10 +27,10 @@ endif()
 if(Ice_SOURCE_BUILD)
   list(APPEND ice_include_path_suffixes "cpp/include")
   list(APPEND ice_bin_path_suffixes "cpp/bin")
-  list(APPEND ice_lib_path_suffixes_release "cpp/lib")
+  list(APPEND ice_lib_path_suffixes "cpp/lib")
 
   if (Ice_ARCHITECTURE)
-    list(APPEND ice_lib_path_suffixes_release "cpp/lib/${Ice_ARCHITECTURE}")
+    list(APPEND ice_lib_path_suffixes "cpp/lib/${Ice_ARCHITECTURE}")
   endif()
 
   if(WIN32)
@@ -40,12 +43,14 @@ else()
 
   list(APPEND ice_include_path_suffixes "include")
   list(APPEND ice_bin_path_suffixes "bin")
-  list(APPEND ice_lib_path_suffixes_release "lib")
+  list(APPEND ice_lib_path_suffixes "lib")
 
   if(WIN32)
     # NuGet packages
     list(APPEND ice_include_path_suffixes "build/native/include")
     list(APPEND ice_bin_path_suffixes "tools")
+    list(APPEND ice_bin_path_suffixes_release "build/native/bin/${Ice_ARCHITECTURE}/Release")
+    list(APPEND ice_bin_path_suffixes_debug "build/native/bin/${Ice_ARCHITECTURE}/Debug")
     list(APPEND ice_lib_path_suffixes_release "build/native/lib/${Ice_ARCHITECTURE}/Release")
     list(APPEND ice_lib_path_suffixes_debug "build/native/lib/${Ice_ARCHITECTURE}/Debug")
   endif()
@@ -112,20 +117,44 @@ if(NOT DEFINED Ice_SLICE_DIR)
   find_path(Ice_SLICE_DIR NAMES Ice/Identity.ice HINTS ${Ice_HOME} PATH_SUFFIXES slice share/ice/slice CACHE PATH "Path to the Ice Slice files directory")
 endif()
 
+# Create a target for each requested component
 foreach(component ${Ice_FIND_COMPONENTS})
   if(NOT TARGET Ice::${component})
 
-    find_library(Ice_${component}_LIBRARY_RELEASE
-      NAMES ${component} ${component}${Ice_SO_VERSION}
-      HINTS ${Ice_HOME}
-      PATH_SUFFIXES ${ice_lib_path_suffixes_release}
-    )
+    # Find the dll and import library for the component for both Debug and Release configurations.
+    if (WIN32)
+      # Set the import libraries to the library found above
+      find_library(Ice_${component}_IMPLIB_RELEASE
+        NAMES ${component} ${component}${Ice_SO_VERSION}
+        HINTS ${Ice_HOME}
+        PATH_SUFFIXES ${ice_lib_path_suffixes_release}
+      )
 
-    find_library(Ice_${component}_LIBRARY_DEBUG
-      NAMES ${component}d ${component}${Ice_SO_VERSION}d
-      HINTS ${Ice_HOME}
-      PATH_SUFFIXES lib ${ice_lib_path_suffixes_debug}
-    )
+      find_library(Ice_${component}_IMPLIB_DEBUG
+        NAMES ${component}d ${component}${Ice_SO_VERSION}d
+        HINTS ${Ice_HOME}
+        PATH_SUFFIXES lib ${ice_lib_path_suffixes_debug}
+      )
+
+      find_file(Ice_${component}_LIBRARY_RELEASE
+        NAMES ${component}${Ice_SO_VERSION}.dll
+        HINTS ${Ice_HOME}
+        PATH_SUFFIXES ${ice_bin_path_suffixes_release}
+      )
+
+      find_file(Ice_${component}_LIBRARY_DEBUG
+        NAMES ${component}${Ice_SO_VERSION}d.dll
+        HINTS ${Ice_HOME}
+        PATH_SUFFIXES ${ice_bin_path_suffixes_debug}
+      )
+    else()
+      # On Linux/macOS, there is only one library for both Debug and Release configurations
+      find_library(Ice_${component}_LIBRARY
+        NAMES ${component} ${component}${Ice_SO_VERSION}
+        HINTS ${Ice_HOME}
+        PATH_SUFFIXES ${ice_lib_path_suffixes}
+      )
+    endif()
 
     # Select the appropriate library configuration based on platform and build type
     include(SelectLibraryConfigurations)
@@ -134,32 +163,36 @@ foreach(component ${Ice_FIND_COMPONENTS})
     if(Ice_${component}_LIBRARY)
 
       # Create an imported target for the component
-      add_library(Ice::${component} UNKNOWN IMPORTED)
+      add_library(Ice::${component} SHARED IMPORTED)
       set_target_properties(Ice::${component} PROPERTIES
         INTERFACE_INCLUDE_DIRECTORIES "${Ice_INCLUDE_DIRS}"
       )
 
-      if(Ice_${component}_LIBRARY_RELEASE)
-        set_property(TARGET Ice::${component} APPEND PROPERTY
-          IMPORTED_CONFIGURATIONS RELEASE
-        )
+      # Add the library to the target. On Windows we set both the IMPORTED_LOCATION and IMPORTED_IMPLIB properties.
+      # This necessary to support CMake's TARGET_RUNTIME_DLLS generator expression.
+      # On other platforms, we only set the IMPORTED_LOCATION property.
+      if (WIN32)
+        if(Ice_${component}_LIBRARY_RELEASE)
+          set_target_properties(Ice::${component} PROPERTIES
+            IMPORTED_CONFIGURATIONS RELEASE
+            IMPORTED_IMPLIB_RELEASE "${Ice_${component}_IMPLIB_RELEASE}"
+            IMPORTED_LOCATION_RELEASE "${Ice_${component}_LIBRARY_RELEASE}"
+          )
+        endif()
+        if(Ice_${component}_LIBRARY_DEBUG)
+          set_target_properties(Ice::${component} PROPERTIES
+            IMPORTED_CONFIGURATIONS DEBUG
+            IMPORTED_IMPLIB_DEBUG "${Ice_${component}_IMPLIB_DEBUG}"
+            IMPORTED_LOCATION_DEBUG "${Ice_${component}_LIBRARY_DEBUG}"
+          )
+        endif()
+      else()
         set_target_properties(Ice::${component} PROPERTIES
-          IMPORTED_LOCATION_RELEASE "${Ice_${component}_LIBRARY_RELEASE}"
+          IMPORTED_LOCATION "${Ice_${component}_LIBRARY}"
         )
       endif()
-
-      if(Ice_${component}_LIBRARY_DEBUG)
-        set_property(TARGET Ice::${component} APPEND PROPERTY
-          IMPORTED_CONFIGURATIONS DEBUG
-        )
-        set_target_properties(Ice::${component} PROPERTIES
-          IMPORTED_LOCATION_DEBUG "${Ice_${component}_LIBRARY_DEBUG}"
-        )
-      endif()
-
     endif()
   endif()
-
 endforeach()
 
 if(Ice_DEBUG)
@@ -180,11 +213,19 @@ if(Ice_DEBUG)
     if(Ice_${component}_LIBRARY_DEBUG)
       message(STATUS "Ice_${component}_LIBRARY_DEBUG: ${Ice_${component}_LIBRARY_DEBUG}")
     endif()
+
+    if(Ice_${component}_IMPLIB_RELEASE)
+      message(STATUS "Ice_${component}_IMPLIB_RELEASE: ${Ice_${component}_IMPLIB_RELEASE}")
+    endif()
+    if(Ice_${component}_IMPLIB_DEBUG)
+      message(STATUS "Ice_${component}_IMPLIB_DEBUG: ${Ice_${component}_IMPLIB_DEBUG}")
+    endif()
   endforeach()
 endif()
 
 unset(ice_include_path_suffixes)
 unset(ice_bin_path_suffixes)
+unset(ice_lib_path_suffixes)
 unset(ice_lib_path_suffixes_release)
 unset(ice_lib_path_suffixes_debug)
 

--- a/cpp/cmake/common.cmake
+++ b/cpp/cmake/common.cmake
@@ -1,52 +1,58 @@
-cmake_minimum_required(VERSION 3.24)
+cmake_minimum_required(VERSION 3.21)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+if (WIN32)
+  set(Ice_NUGET_NAME "zeroc.ice.v143")
+  set(Ice_NUGET_DIR "${CMAKE_CURRENT_LIST_DIR}/packages/${Ice_NUGET_NAME}")
 
-if (WIN32 AND NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/packages)
+  if(NOT EXISTS ${Ice_NUGET_DIR})
     message(STATUS "Downloading Ice NuGet package")
-    # option(ICE_NUGET_INSTALL "Use NuGet to install Ice during configuration" ON)
-    set(ICE_NUGET_SOURCE "https://download.zeroc.com/nexus/repository/nuget-nightly/" CACHE STRING "Ice NuGet package source")
-    # if (ICE_NUGET_INSTALL)
-    execute_process(
-        COMMAND nuget install -Source ${ICE_NUGET_SOURCE} -OutputDirectory ${CMAKE_CURRENT_BINARY_DIR}/packages zeroc.ice.v143 -Prerelease -ExcludeVersion
-        RESULT_VARIABLE nuget_result
-        OUTPUT_VARIABLE nuget_output
-        ERROR_VARIABLE nuget_error)
-    if (nuget_result)
-        message(FATAL_ERROR "Failed to download Ice NuGet package: ${nuget_error}")
-    endif()
-    # endif()
 
-    set(Ice_HOME "${CMAKE_CURRENT_BINARY_DIR}/packages/zeroc.ice.v143" CACHE PATH "Path to Ice installation directory")
+    set(ICE_NUGET_SOURCE "https://download.zeroc.com/nexus/repository/nuget-nightly/" CACHE STRING "Ice NuGet package source")
+
+    execute_process(
+      COMMAND nuget install -Source ${ICE_NUGET_SOURCE} -OutputDirectory ${CMAKE_CURRENT_LIST_DIR}/packages ${Ice_NUGET_NAME} -Prerelease -ExcludeVersion
+      RESULT_VARIABLE nuget_result
+      OUTPUT_VARIABLE nuget_output
+      ERROR_VARIABLE nuget_error)
+    if (nuget_result)
+      message(FATAL_ERROR "Failed to download Ice NuGet package: ${nuget_error}")
+    endif()
+
+  endif()
+
+  # Set Ice_HOME to the path where the Ice NuGet package was downloaded
+
+  set(Ice_HOME "${Ice_NUGET_DIR}" CACHE PATH "Path to Ice installation directory")
+
+  message(STATUS "Ice_HOME: ${Ice_HOME}")
 endif()
 
 # We use these flags over presets to avoid having to create a CMakePreset.json file in every project.
 # If you want to disable, set this option to OFF (`-DICE_DEMO_WARNINGS=OFF`) when configuring CMake.
 option(ICE_DEMO_WARNINGS "Ice Demo C++ warning flags" ON)
 if(ICE_DEMO_WARNINGS)
-    if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-        add_compile_options(-Wall -Wextra -Wredundant-decls -Wdeprecated)
-    elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-        add_compile_options(
-            -Wall
-            -Wextra
-            -Wredundant-decls
-            -Wdeprecated
-            -Wstrict-prototypes
-            -Wconversion
-            -Wdocumentation
-            -Wreorder-init-list
-        )
-    elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-        add_compile_options(/W4)
-    endif()
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    add_compile_options(-Wall -Wextra -Wredundant-decls -Wdeprecated)
+  elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    add_compile_options(
+      -Wall
+      -Wextra
+      -Wredundant-decls
+      -Wdeprecated
+      -Wstrict-prototypes
+      -Wconversion
+      -Wdocumentation
+      -Wreorder-init-list
+    )
+  elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    add_compile_options(/W4)
+  endif()
 endif()
-
-find_package(Threads REQUIRED)
 
 set(Ice_DIR ${CMAKE_CURRENT_LIST_DIR} CACHE PATH "Path to Ice CMake configuration file")
 
 # IceBT is an optional component as it is not available in all distributions.
-find_package(Ice REQUIRED CONFIG COMPONENTS Ice DataStorm Glacier2 IceGrid IceBox IceStorm OPTIONAL_COMPONENTS IceBT)
+find_package(Ice CONFIG REQUIRED COMPONENTS Ice DataStorm Glacier2 IceGrid IceBox IceStorm OPTIONAL_COMPONENTS IceBT)


### PR DESCRIPTION
This PR adds several improvements for the CMake builds on Windows.

- Add support for [TARGET_RUNTIME_DLLS](https://cmake.org/cmake/help/latest/manual/cmake-generator-expressions.7.html#genex:TARGET_RUNTIME_DLLS) generator expressions. This required some restructuring to tell cmake about the dlls and the libs. Now we can configure cmake to copy a target dependencies next to the target post build. No need for users to add a random NuGet dir to their PATH.
- The unzipped Ice nuget is pretty big. Instead of a per config "cmake build folder" copy of the nuget, we now keep (git ignored) a shared one in `cpp/cmake/packages`