### PR TITLE
Update C# project to use new C# NuGet packaging

### DIFF
--- a/csharp/.gitignore
+++ b/csharp/.gitignore
@@ -3,3 +3,8 @@
 *.runtimeconfig.dev.json
 
 **/generated/**
+*.dll
+client
+server
+publisher
+subscriber

--- a/csharp/Glacier2/callback/msbuild/client/client.csproj
+++ b/csharp/Glacier2/callback/msbuild/client/client.csproj
@@ -17,8 +17,9 @@
         <Compile Include="../../CallbackI.cs" />
         <Compile Include="../../CallbackReceiverI.cs" />
         <SliceCompile Include="../../Callback.ice" />
-        <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-        <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
+        <PackageReference Include="ZeroC.Ice" Version="$(IceVersion)" />
+        <PackageReference Include="ZeroC.Glacier2" Version="$(IceVersion)" />
+        <PackageReference Include="ZeroC.Ice.Slice.Tools.CSharp" Version="$(IceVersion)" />
 
         <!-- The 1.2 beta version is required for supporting the latest language features.
              See: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3187 -->

--- a/csharp/Glacier2/callback/msbuild/server/server.csproj
+++ b/csharp/Glacier2/callback/msbuild/server/server.csproj
@@ -11,8 +11,9 @@
         <Compile Include="../../CallbackI.cs" />
         <Compile Include="../../Server.cs" />
         <SliceCompile Include="../../Callback.ice" />
-        <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-        <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
+        <PackageReference Include="ZeroC.Ice" Version="$(IceVersion)" />
+        <PackageReference Include="ZeroC.Glacier2" Version="$(IceVersion)" />
+        <PackageReference Include="ZeroC.Ice.Slice.Tools.CSharp" Version="$(IceVersion)" />
 
         <!-- The 1.2 beta version is required for supporting the latest language features.
              See: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3187 -->

--- a/csharp/Ice/Bidir/Client/Client.csproj
+++ b/csharp/Ice/Bidir/Client/Client.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
   <ItemGroup>
     <SliceCompile Include="../slice/AlarmClock.ice" />
-    <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-    <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
+    <PackageReference Include="ZeroC.Ice" Version="$(IceVersion)" />
+    <PackageReference Include="ZeroC.Ice.Slice.Tools.CSharp" Version="$(IceVersion)" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/csharp/Ice/Bidir/Server/Server.csproj
+++ b/csharp/Ice/Bidir/Server/Server.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
   <ItemGroup>
     <SliceCompile Include="../slice/AlarmClock.ice" />
-    <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-    <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
+    <PackageReference Include="ZeroC.Ice" Version="$(IceVersion)" />
+    <PackageReference Include="ZeroC.Ice.Slice.Tools.CSharp" Version="$(IceVersion)" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/csharp/Ice/Callback/Client/Client.csproj
+++ b/csharp/Ice/Callback/Client/Client.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
   <ItemGroup>
     <SliceCompile Include="../slice/AlarmClock.ice" />
-    <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-    <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
+    <PackageReference Include="ZeroC.Ice" Version="$(IceVersion)" />
+    <PackageReference Include="ZeroC.Ice.Slice.Tools.CSharp" Version="$(IceVersion)" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/csharp/Ice/Callback/Server/Server.csproj
+++ b/csharp/Ice/Callback/Server/Server.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
   <ItemGroup>
     <SliceCompile Include="../slice/AlarmClock.ice" />
-    <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-    <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
+    <PackageReference Include="ZeroC.Ice" Version="$(IceVersion)" />
+    <PackageReference Include="ZeroC.Ice.Slice.Tools.CSharp" Version="$(IceVersion)" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/csharp/Ice/Cancellation/Client/Client.csproj
+++ b/csharp/Ice/Cancellation/Client/Client.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
   <ItemGroup>
     <SliceCompile Include="../slice/Greeter.ice" />
-    <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-    <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
+    <PackageReference Include="ZeroC.Ice" Version="$(IceVersion)" />
+    <PackageReference Include="ZeroC.Ice.Slice.Tools.CSharp" Version="$(IceVersion)" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/csharp/Ice/Cancellation/Server/Server.csproj
+++ b/csharp/Ice/Cancellation/Server/Server.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
   <ItemGroup>
     <SliceCompile Include="../slice/Greeter.ice" />
-    <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-    <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
+    <PackageReference Include="ZeroC.Ice" Version="$(IceVersion)" />
+    <PackageReference Include="ZeroC.Ice.Slice.Tools.CSharp" Version="$(IceVersion)" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/csharp/Ice/Config/Client/Client.csproj
+++ b/csharp/Ice/Config/Client/Client.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
   <ItemGroup>
     <SliceCompile Include="../slice/Greeter.ice" />
-    <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-    <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
+    <PackageReference Include="ZeroC.Ice" Version="$(IceVersion)" />
+    <PackageReference Include="ZeroC.Ice.Slice.Tools.CSharp" Version="$(IceVersion)" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/csharp/Ice/Config/Server/Server.csproj
+++ b/csharp/Ice/Config/Server/Server.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
   <ItemGroup>
     <SliceCompile Include="../slice/Greeter.ice" />
-    <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-    <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
+    <PackageReference Include="ZeroC.Ice" Version="$(IceVersion)" />
+    <PackageReference Include="ZeroC.Ice.Slice.Tools.CSharp" Version="$(IceVersion)" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/csharp/Ice/Context/Client/Client.csproj
+++ b/csharp/Ice/Context/Client/Client.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
   <ItemGroup>
     <SliceCompile Include="../slice/Greeter.ice" />
-    <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-    <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
+    <PackageReference Include="ZeroC.Ice" Version="$(IceVersion)" />
+    <PackageReference Include="ZeroC.Ice.Slice.Tools.CSharp" Version="$(IceVersion)" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/csharp/Ice/Context/Server/Server.csproj
+++ b/csharp/Ice/Context/Server/Server.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
   <ItemGroup>
     <SliceCompile Include="../slice/Greeter.ice" />
-    <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-    <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
+    <PackageReference Include="ZeroC.Ice" Version="$(IceVersion)" />
+    <PackageReference Include="ZeroC.Ice.Slice.Tools.CSharp" Version="$(IceVersion)" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/csharp/Ice/Filesystem/Client/Client.csproj
+++ b/csharp/Ice/Filesystem/Client/Client.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
   <ItemGroup>
     <SliceCompile Include="../slice/Filesystem.ice" />
-    <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-    <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
+    <PackageReference Include="ZeroC.Ice" Version="$(IceVersion)" />
+    <PackageReference Include="ZeroC.Ice.Slice.Tools.CSharp" Version="$(IceVersion)" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/csharp/Ice/Filesystem/Server/Server.csproj
+++ b/csharp/Ice/Filesystem/Server/Server.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
   <ItemGroup>
     <SliceCompile Include="../slice/Filesystem.ice" />
-    <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-    <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
+    <PackageReference Include="ZeroC.Ice" Version="$(IceVersion)" />
+    <PackageReference Include="ZeroC.Ice.Slice.Tools.CSharp" Version="$(IceVersion)" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/csharp/Ice/Forwarder/Client/Client.csproj
+++ b/csharp/Ice/Forwarder/Client/Client.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
   <ItemGroup>
     <SliceCompile Include="../slice/Greeter.ice" />
-    <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-    <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
+    <PackageReference Include="ZeroC.Ice" Version="$(IceVersion)" />
+    <PackageReference Include="ZeroC.Ice.Slice.Tools.CSharp" Version="$(IceVersion)" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/csharp/Ice/Forwarder/ForwardingServer/ForwardingServer.csproj
+++ b/csharp/Ice/Forwarder/ForwardingServer/ForwardingServer.csproj
@@ -9,7 +9,7 @@
     <CopyDebugSymbolFilesFromPackages>true</CopyDebugSymbolFilesFromPackages>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
+    <PackageReference Include="ZeroC.Ice" Version="$(IceVersion)" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/csharp/Ice/Forwarder/Server/Server.csproj
+++ b/csharp/Ice/Forwarder/Server/Server.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
   <ItemGroup>
     <SliceCompile Include="../slice/Greeter.ice" />
-    <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-    <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
+    <PackageReference Include="ZeroC.Ice" Version="$(IceVersion)" />
+    <PackageReference Include="ZeroC.Ice.Slice.Tools.CSharp" Version="$(IceVersion)" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/csharp/Ice/Greeter/Client/Client.csproj
+++ b/csharp/Ice/Greeter/Client/Client.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
   <ItemGroup>
     <SliceCompile Include="../slice/Greeter.ice" />
-    <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-    <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
+    <PackageReference Include="ZeroC.Ice" Version="$(IceVersion)" />
+    <PackageReference Include="ZeroC.Ice.Slice.Tools.CSharp" Version="$(IceVersion)" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/csharp/Ice/Greeter/Server/Server.csproj
+++ b/csharp/Ice/Greeter/Server/Server.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
   <ItemGroup>
     <SliceCompile Include="../slice/Greeter.ice" />
-    <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-    <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
+    <PackageReference Include="ZeroC.Ice" Version="$(IceVersion)" />
+    <PackageReference Include="ZeroC.Ice.Slice.Tools.CSharp" Version="$(IceVersion)" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/csharp/Ice/Greeter/ServerAMD/ServerAMD.csproj
+++ b/csharp/Ice/Greeter/ServerAMD/ServerAMD.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
   <ItemGroup>
     <SliceCompile Include="../slice/GreeterAMD.ice" />
-    <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-    <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
+    <PackageReference Include="ZeroC.Ice" Version="$(IceVersion)" />
+    <PackageReference Include="ZeroC.Ice.Slice.Tools.CSharp" Version="$(IceVersion)" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/csharp/Ice/Middleware/Client/Client.csproj
+++ b/csharp/Ice/Middleware/Client/Client.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
   <ItemGroup>
     <SliceCompile Include="../slice/Greeter.ice" />
-    <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-    <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
+    <PackageReference Include="ZeroC.Ice" Version="$(IceVersion)" />
+    <PackageReference Include="ZeroC.Ice.Slice.Tools.CSharp" Version="$(IceVersion)" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/csharp/Ice/Middleware/Server/Server.csproj
+++ b/csharp/Ice/Middleware/Server/Server.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
   <ItemGroup>
     <SliceCompile Include="../slice/Greeter.ice" />
-    <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-    <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
+    <PackageReference Include="ZeroC.Ice" Version="$(IceVersion)" />
+    <PackageReference Include="ZeroC.Ice.Slice.Tools.CSharp" Version="$(IceVersion)" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/csharp/Ice/interceptor/msbuild/client/client.csproj
+++ b/csharp/Ice/interceptor/msbuild/client/client.csproj
@@ -10,8 +10,8 @@
     <ItemGroup>
         <Compile Include="../../Client.cs" />
         <SliceCompile Include="../../Interceptor.ice" />
-        <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-        <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
+        <PackageReference Include="ZeroC.Ice" Version="$(IceVersion)" />
+        <PackageReference Include="ZeroC.Ice.Slice.Tools.CSharp" Version="$(IceVersion)" />
 
         <!-- The 1.2 beta version is required for supporting the latest language features.
              See: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3187 -->

--- a/csharp/Ice/interceptor/msbuild/server/server.csproj
+++ b/csharp/Ice/interceptor/msbuild/server/server.csproj
@@ -13,8 +13,8 @@
         <Compile Include="../../ThermostatI.cs" />
         <Compile Include="../../Server.cs" />
         <SliceCompile Include="../../Interceptor.ice" />
-        <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-        <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
+        <PackageReference Include="ZeroC.Ice" Version="$(IceVersion)" />
+        <PackageReference Include="ZeroC.Ice.Slice.Tools.CSharp" Version="$(IceVersion)" />
 
         <!-- The 1.2 beta version is required for supporting the latest language features.
              See: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3187 -->

--- a/csharp/Ice/multicast/msbuild/client/client.csproj
+++ b/csharp/Ice/multicast/msbuild/client/client.csproj
@@ -12,8 +12,8 @@
         <Compile Include="../../DiscoverReplyI.cs" />
         <SliceCompile Include="../../Discovery.ice" />
         <SliceCompile Include="../../Hello.ice" />
-        <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-        <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
+        <PackageReference Include="ZeroC.Ice" Version="$(IceVersion)" />
+        <PackageReference Include="ZeroC.Ice.Slice.Tools.CSharp" Version="$(IceVersion)" />
 
         <!-- The 1.2 beta version is required for supporting the latest language features.
              See: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3187 -->

--- a/csharp/Ice/multicast/msbuild/server/server.csproj
+++ b/csharp/Ice/multicast/msbuild/server/server.csproj
@@ -13,8 +13,8 @@
         <Compile Include="../../Server.cs" />
         <SliceCompile Include="../../Discovery.ice" />
         <SliceCompile Include="../../Hello.ice" />
-        <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-        <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
+        <PackageReference Include="ZeroC.Ice" Version="$(IceVersion)" />
+        <PackageReference Include="ZeroC.Ice.Slice.Tools.CSharp" Version="$(IceVersion)" />
 
         <!-- The 1.2 beta version is required for supporting the latest language features.
              See: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3187 -->

--- a/csharp/Ice/optional/msbuild/client/client.csproj
+++ b/csharp/Ice/optional/msbuild/client/client.csproj
@@ -11,8 +11,8 @@
     <ItemGroup>
         <Compile Include="../../Client.cs" />
         <SliceCompile Include="../../Contact.ice" />
-        <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-        <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
+        <PackageReference Include="ZeroC.Ice" Version="$(IceVersion)" />
+        <PackageReference Include="ZeroC.Ice.Slice.Tools.CSharp" Version="$(IceVersion)" />
 
         <!-- The 1.2 beta version is required for supporting the latest language features.
              See: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3187 -->

--- a/csharp/Ice/optional/msbuild/server/server.csproj
+++ b/csharp/Ice/optional/msbuild/server/server.csproj
@@ -11,8 +11,8 @@
         <Compile Include="../../ContactDBI.cs" />
         <Compile Include="../../Server.cs" />
         <SliceCompile Include="../../Contact.ice" />
-        <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-        <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
+        <PackageReference Include="ZeroC.Ice" Version="$(IceVersion)" />
+        <PackageReference Include="ZeroC.Ice.Slice.Tools.CSharp" Version="$(IceVersion)" />
 
         <!-- The 1.2 beta version is required for supporting the latest language features.
              See: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3187 -->

--- a/csharp/Ice/properties/msbuild/client/client.csproj
+++ b/csharp/Ice/properties/msbuild/client/client.csproj
@@ -10,8 +10,8 @@
     <ItemGroup>
         <Compile Include="../../Client.cs" />
         <SliceCompile Include="../../Props.ice" />
-        <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-        <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
+        <PackageReference Include="ZeroC.Ice" Version="$(IceVersion)" />
+        <PackageReference Include="ZeroC.Ice.Slice.Tools.CSharp" Version="$(IceVersion)" />
 
         <!-- The 1.2 beta version is required for supporting the latest language features.
              See: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3187 -->

--- a/csharp/Ice/properties/msbuild/server/server.csproj
+++ b/csharp/Ice/properties/msbuild/server/server.csproj
@@ -10,8 +10,8 @@
     <ItemGroup>
         <Compile Include="../../Server.cs" />
         <SliceCompile Include="../../Props.ice" />
-        <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-        <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
+        <PackageReference Include="ZeroC.Ice" Version="$(IceVersion)" />
+        <PackageReference Include="ZeroC.Ice.Slice.Tools.CSharp" Version="$(IceVersion)" />
 
         <!-- The 1.2 beta version is required for supporting the latest language features.
              See: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3187 -->

--- a/csharp/Ice/session/msbuild/client/client.csproj
+++ b/csharp/Ice/session/msbuild/client/client.csproj
@@ -10,8 +10,8 @@
     <ItemGroup>
         <Compile Include="../../Client.cs" />
         <SliceCompile Include="../../Session.ice" />
-        <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-        <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
+        <PackageReference Include="ZeroC.Ice" Version="$(IceVersion)" />
+        <PackageReference Include="ZeroC.Ice.Slice.Tools.CSharp" Version="$(IceVersion)" />
 
         <!-- The 1.2 beta version is required for supporting the latest language features.
              See: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3187 -->

--- a/csharp/Ice/session/msbuild/server/server.csproj
+++ b/csharp/Ice/session/msbuild/server/server.csproj
@@ -13,8 +13,8 @@
         <Compile Include="../../SessionFactoryI.cs" />
         <Compile Include="../../SessionI.cs" />
         <SliceCompile Include="../../Session.ice" />
-        <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-        <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
+        <PackageReference Include="ZeroC.Ice" Version="$(IceVersion)" />
+        <PackageReference Include="ZeroC.Ice.Slice.Tools.CSharp" Version="$(IceVersion)" />
 
         <!-- The 1.2 beta version is required for supporting the latest language features.
              See: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3187 -->

--- a/csharp/IceBox/hello/msbuild/client/client.csproj
+++ b/csharp/IceBox/hello/msbuild/client/client.csproj
@@ -10,8 +10,8 @@
     <ItemGroup>
         <Compile Include="../../Client.cs" />
         <SliceCompile Include="../../Hello.ice" />
-        <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-        <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
+        <PackageReference Include="ZeroC.Ice" Version="$(IceVersion)" />
+        <PackageReference Include="ZeroC.Ice.Slice.Tools.CSharp" Version="$(IceVersion)" />
 
         <!-- The 1.2 beta version is required for supporting the latest language features.
              See: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3187 -->

--- a/csharp/IceBox/hello/msbuild/helloservice/helloservice.csproj
+++ b/csharp/IceBox/hello/msbuild/helloservice/helloservice.csproj
@@ -10,8 +10,9 @@
         <Compile Include="../../HelloI.cs" />
         <Compile Include="../../HelloServiceI.cs" />
         <SliceCompile Include="../../Hello.ice" />
-        <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-        <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
+        <PackageReference Include="ZeroC.Ice" Version="$(IceVersion)" />
+        <PackageReference Include="ZeroC.IceBox" Version="$(IceVersion)" />
+        <PackageReference Include="ZeroC.Ice.Slice.Tools.CSharp" Version="$(IceVersion)" />
 
         <!-- The 1.2 beta version is required for supporting the latest language features.
              See: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3187 -->

--- a/csharp/IceDiscovery/hello/msbuild/client/client.csproj
+++ b/csharp/IceDiscovery/hello/msbuild/client/client.csproj
@@ -10,8 +10,9 @@
     <ItemGroup>
         <Compile Include="../../Client.cs" />
         <SliceCompile Include="../../Hello.ice" />
-        <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-        <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
+        <PackageReference Include="ZeroC.Ice" Version="$(IceVersion)" />
+        <PackageReference Include="ZeroC.IceDiscovery" Version="$(IceVersion)" />
+        <PackageReference Include="ZeroC.Ice.Slice.Tools.CSharp" Version="$(IceVersion)" />
 
         <!-- The 1.2 beta version is required for supporting the latest language features.
              See: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3187 -->

--- a/csharp/IceDiscovery/hello/msbuild/server/server.csproj
+++ b/csharp/IceDiscovery/hello/msbuild/server/server.csproj
@@ -11,8 +11,9 @@
         <Compile Include="../../HelloI.cs" />
         <Compile Include="../../Server.cs" />
         <SliceCompile Include="../../Hello.ice" />
-        <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-        <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
+        <PackageReference Include="ZeroC.Ice" Version="$(IceVersion)" />
+        <PackageReference Include="ZeroC.IceDiscovery" Version="$(IceVersion)" />
+        <PackageReference Include="ZeroC.Ice.Slice.Tools.CSharp" Version="$(IceVersion)" />
 
         <!-- The 1.2 beta version is required for supporting the latest language features.
              See: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3187 -->

--- a/csharp/IceDiscovery/replication/msbuild/client/client.csproj
+++ b/csharp/IceDiscovery/replication/msbuild/client/client.csproj
@@ -10,8 +10,9 @@
     <ItemGroup>
         <Compile Include="../../Client.cs" />
         <SliceCompile Include="../../Hello.ice" />
-        <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-        <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
+        <PackageReference Include="ZeroC.Ice" Version="$(IceVersion)" />
+        <PackageReference Include="ZeroC.IceDiscovery" Version="$(IceVersion)" />
+        <PackageReference Include="ZeroC.Ice.Slice.Tools.CSharp" Version="$(IceVersion)" />
 
         <!-- The 1.2 beta version is required for supporting the latest language features.
              See: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3187 -->

--- a/csharp/IceDiscovery/replication/msbuild/server/server.csproj
+++ b/csharp/IceDiscovery/replication/msbuild/server/server.csproj
@@ -11,8 +11,9 @@
         <Compile Include="../../HelloI.cs" />
         <Compile Include="../../Server.cs" />
         <SliceCompile Include="../../Hello.ice" />
-        <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-        <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
+        <PackageReference Include="ZeroC.Ice" Version="$(IceVersion)" />
+        <PackageReference Include="ZeroC.IceDiscovery" Version="$(IceVersion)" />
+        <PackageReference Include="ZeroC.Ice.Slice.Tools.CSharp" Version="$(IceVersion)" />
 
         <!-- The 1.2 beta version is required for supporting the latest language features.
              See: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3187 -->

--- a/csharp/IceGrid/Greeter/Client/Client.csproj
+++ b/csharp/IceGrid/Greeter/Client/Client.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
   <ItemGroup>
     <SliceCompile Include="../slice/Greeter.ice" />
-    <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-    <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
+    <PackageReference Include="ZeroC.Ice" Version="$(IceVersion)" />
+    <PackageReference Include="ZeroC.Ice.Slice.Tools.CSharp" Version="$(IceVersion)" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/csharp/IceGrid/Greeter/Server/Server.csproj
+++ b/csharp/IceGrid/Greeter/Server/Server.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
   <ItemGroup>
     <SliceCompile Include="../slice/Greeter.ice" />
-    <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-    <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
+    <PackageReference Include="ZeroC.Ice" Version="$(IceVersion)" />
+    <PackageReference Include="ZeroC.Ice.Slice.Tools.CSharp" Version="$(IceVersion)" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/csharp/IceGrid/icebox/msbuild/client/client.csproj
+++ b/csharp/IceGrid/icebox/msbuild/client/client.csproj
@@ -10,8 +10,8 @@
     <ItemGroup>
         <Compile Include="../../Client.cs" />
         <SliceCompile Include="../../Hello.ice" />
-        <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-        <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
+        <PackageReference Include="ZeroC.Ice" Version="$(IceVersion)" />
+        <PackageReference Include="ZeroC.Ice.Slice.Tools.CSharp" Version="$(IceVersion)" />
 
         <!-- The 1.2 beta version is required for supporting the latest language features.
              See: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3187 -->

--- a/csharp/IceGrid/icebox/msbuild/helloservice/helloservice.csproj
+++ b/csharp/IceGrid/icebox/msbuild/helloservice/helloservice.csproj
@@ -10,8 +10,9 @@
         <Compile Include="../../HelloI.cs" />
         <Compile Include="../../HelloServiceI.cs" />
         <SliceCompile Include="../../Hello.ice" />
-        <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-        <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
+        <PackageReference Include="ZeroC.Ice" Version="$(IceVersion)" />
+        <PackageReference Include="ZeroC.IceBox" Version="$(IceVersion)" />
+        <PackageReference Include="ZeroC.Ice.Slice.Tools.CSharp" Version="$(IceVersion)" />
 
         <!-- The 1.2 beta version is required for supporting the latest language features.
              See: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3187 -->

--- a/csharp/IceGrid/simple/msbuild/client/client.csproj
+++ b/csharp/IceGrid/simple/msbuild/client/client.csproj
@@ -10,8 +10,9 @@
     <ItemGroup>
         <Compile Include="../../Client.cs" />
         <SliceCompile Include="../../Hello.ice" />
-        <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-        <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
+        <PackageReference Include="ZeroC.Ice" Version="$(IceVersion)" />
+        <PackageReference Include="ZeroC.IceGrid" Version="$(IceVersion)" />
+        <PackageReference Include="ZeroC.Ice.Slice.Tools.CSharp" Version="$(IceVersion)" />
 
         <!-- The 1.2 beta version is required for supporting the latest language features.
              See: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3187 -->

--- a/csharp/IceGrid/simple/msbuild/server/server.csproj
+++ b/csharp/IceGrid/simple/msbuild/server/server.csproj
@@ -11,8 +11,8 @@
         <Compile Include="../../HelloI.cs" />
         <Compile Include="../../Server.cs" />
         <SliceCompile Include="../../Hello.ice" />
-        <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-        <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
+        <PackageReference Include="ZeroC.Ice" Version="$(IceVersion)" />
+        <PackageReference Include="ZeroC.Ice.Slice.Tools.CSharp" Version="$(IceVersion)" />
 
         <!-- The 1.2 beta version is required for supporting the latest language features.
              See: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3187 -->

--- a/csharp/IceStorm/clock/msbuild/publisher/publisher.csproj
+++ b/csharp/IceStorm/clock/msbuild/publisher/publisher.csproj
@@ -10,8 +10,9 @@
     <ItemGroup>
         <Compile Include="../../Publisher.cs" />
         <SliceCompile Include="../../Clock.ice" />
-        <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-        <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
+        <PackageReference Include="ZeroC.Ice" Version="$(IceVersion)" />
+        <PackageReference Include="ZeroC.IceStorm" Version="$(IceVersion)" />
+        <PackageReference Include="ZeroC.Ice.Slice.Tools.CSharp" Version="$(IceVersion)" />
 
         <!-- The 1.2 beta version is required for supporting the latest language features.
              See: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3187 -->

--- a/csharp/IceStorm/clock/msbuild/subscriber/subscriber.csproj
+++ b/csharp/IceStorm/clock/msbuild/subscriber/subscriber.csproj
@@ -10,8 +10,9 @@
     <ItemGroup>
         <Compile Include="../../Subscriber.cs" />
         <SliceCompile Include="../../Clock.ice" />
-        <PackageReference Include="zeroc.ice.net" Version="$(IceVersion)" />
-        <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" />
+        <PackageReference Include="ZeroC.Ice" Version="$(IceVersion)" />
+        <PackageReference Include="ZeroC.IceStorm" Version="$(IceVersion)" />
+        <PackageReference Include="ZeroC.Ice.Slice.Tools.CSharp" Version="$(IceVersion)" />
 
         <!-- The 1.2 beta version is required for supporting the latest language features.
              See: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3187 -->

--- a/csharp/nuget.config
+++ b/csharp/nuget.config
@@ -15,7 +15,8 @@
       <package pattern="*" />
     </packageSource>
     <packageSource key="zeroc.com">
-      <package pattern="zeroc.ice.net" />
+      <package pattern="zeroc.*" />
+      <package pattern="iceboxnet" />
     </packageSource>
   </packageSourceMapping>
 </configuration>


### PR DESCRIPTION
Upgrades C# build to use new NuGet packages from https://github.com/zeroc-ice/ice/pull/3615

Expect the build to fail until the other PR is merge and the new packages are deployed.