### PR TITLE
New IceGrid/LocatorDiscovery demo (C#)

### DIFF
--- a/csharp/IceGrid/Greeter/README.md
+++ b/csharp/IceGrid/Greeter/README.md
@@ -22,7 +22,7 @@ icegridregistry --Ice.Config=config.registry
 icegridnode --Ice.Config=config.node
 ```
 
-4. Deploy the "VisitorCenter" application in this IceGrid deployment:
+4. Deploy the "GreeterHall" application in this IceGrid deployment:
 
 ```shell
 icegridadmin --Ice.Config=config.admin -e "application add application.xml"
@@ -34,6 +34,9 @@ with:
 ```shell
 icegridadmin --Ice.Config=config.admin -e "application add application-with-replication.xml"
 ```
+
+> [!TIP]
+> Use `update` instead of `add` to update an existing application.
 
 5. Run the client application:
 

--- a/csharp/IceGrid/LocatorDiscovery/Client/Client.csproj
+++ b/csharp/IceGrid/LocatorDiscovery/Client/Client.csproj
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <!-- Copy the PDBs from the NuGet packages to get file names and line numbers in stack traces. -->
+    <CopyDebugSymbolFilesFromPackages>true</CopyDebugSymbolFilesFromPackages>
+  </PropertyGroup>
+  <ItemGroup>
+    <SliceCompile Include="../../Greeter/slice/Greeter.ice" />
+    <PackageReference Include="ZeroC.Ice" Version="$(IceVersion)" />
+     <PackageReference Include="ZeroC.IceLocatorDiscovery" Version="$(IceVersion)" />
+    <PackageReference Include="ZeroC.Ice.Slice.Tools.CSharp" Version="$(IceVersion)" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+</Project>

--- a/csharp/IceGrid/LocatorDiscovery/Client/Program.cs
+++ b/csharp/IceGrid/LocatorDiscovery/Client/Program.cs
@@ -1,0 +1,33 @@
+// Copyright (c) ZeroC, Inc.
+
+// Slice module VisitorCenter in Greeter.ice maps to C# namespace VisitorCenter.
+using VisitorCenter;
+
+// Configure the communicator to load the LocatorDiscovery plugin during initialization. We don't configure a locator
+// or Ice.Default.Locator in this client.
+var initData = new Ice.InitializationData
+{
+    properties = new Ice.Properties(ref args)
+};
+
+initData.properties.setProperty(
+    "Ice.Plugin.IceLocatorDiscovery",
+    "IceLocatorDiscovery:IceLocatorDiscovery.PluginFactory");
+
+// Create an Ice communicator to initialize the Ice runtime. The communicator is disposed before the program exits.
+using Ice.Communicator communicator = Ice.Util.initialize(initData);
+
+// Create proxy to the Greeter object hosted by the server. "greeter" is a stringified proxy with no addressing
+// information, also known as a well-known proxy. It's specified by the <object> element in the IceGrid XML file.
+// The IceGrid registry resolves this well-known proxy and returns the actual address (endpoint) of the server to this
+// client.
+GreeterPrx greeter = GreeterPrxHelper.createProxy(communicator, "greeter");
+
+// Send a request to the remote object and get the response.
+string greeting = await greeter.GreetAsync(Environment.UserName);
+Console.WriteLine(greeting);
+
+// Send another request to the remote object. With the default configuration we use for this client, this request
+// reuses the connection and reaches the same server, even when we have multiple replicated servers.
+greeting = await greeter.GreetAsync("alice");
+Console.WriteLine(greeting);

--- a/csharp/IceGrid/LocatorDiscovery/Client/Program.cs
+++ b/csharp/IceGrid/LocatorDiscovery/Client/Program.cs
@@ -3,8 +3,9 @@
 // Slice module VisitorCenter in Greeter.ice maps to C# namespace VisitorCenter.
 using VisitorCenter;
 
-// Configure the communicator to load the LocatorDiscovery plugin during initialization. We don't configure a locator
-// or Ice.Default.Locator in this client.
+// Configure the communicator to load the LocatorDiscovery plugin during initialization. This plugin will discover the
+// locator (IceGrid registry) to use using UDP multicast. As a result, we don't need to configure the default locator on
+// this communicator.
 var initData = new Ice.InitializationData
 {
     properties = new Ice.Properties(ref args)

--- a/csharp/IceGrid/LocatorDiscovery/LocatorDiscovery.sln
+++ b/csharp/IceGrid/LocatorDiscovery/LocatorDiscovery.sln
@@ -1,0 +1,30 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.4.33122.133
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Client", "Client\Client.csproj", "{BBF1199A-46A4-4AE9-AFFE-4D8DD59EB874}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{FBDAF448-665A-4595-98D3-4538C56A666D}"
+	ProjectSection(SolutionItems) = preProject
+		README.md = README.md
+	EndProjectSection
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{BBF1199A-46A4-4AE9-AFFE-4D8DD59EB874}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BBF1199A-46A4-4AE9-AFFE-4D8DD59EB874}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BBF1199A-46A4-4AE9-AFFE-4D8DD59EB874}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BBF1199A-46A4-4AE9-AFFE-4D8DD59EB874}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {0B36F1E1-0592-4A15-9981-67BC4A653EC4}
+	EndGlobalSection
+EndGlobal

--- a/csharp/IceGrid/LocatorDiscovery/README.md
+++ b/csharp/IceGrid/LocatorDiscovery/README.md
@@ -1,0 +1,20 @@
+# LocatorDiscovery
+
+The LocatorDiscovery demo shows how to write a client application that configures its locator using the
+LocatorDiscovery plugin.
+
+This demo provides a new client application for the IceGrid/Greeter demo, and relies on IceGrid/Greeter for everything
+else.
+
+Follow these steps to build and run the demo:
+
+1. Build the [IceGrid/Greeter](../Greeter) demo.
+
+2. Run icegridregistry, icegridregistry, and configure IceGrid using icegridadmin as per the Greeter demo instructions.
+
+3. Build and run the client application:
+
+```shell
+cd Client
+dotnet run
+```


### PR DESCRIPTION
This PR adds a new IceGrid/LocatorDiscovery demo (C#).

This demo provides only a client. Everything else comes from Greeter.

Alternatively:
 - we could copy everything else from Greeter (except Client) in here ... but this is a lot of duplication, and the user may not see immediately what's different

 - add a second client in IceGrid/Greeter - the LocatorDiscoveryClient. Downside: this makes Greeter more complicated
