### PR TITLE
Update demos to build with latest tool packages

### DIFF
--- a/cpp/cmake/common.cmake
+++ b/cpp/cmake/common.cmake
@@ -7,7 +7,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Ice for C++ on Windows is shipped as a NuGet package.
 if(WIN32)
-  set(Ice_NUGET_NAME "zeroc.ice.v143")
+  set(Ice_NUGET_NAME "ZeroC.Ice.Cpp")
   set(Ice_NUGET_DIR "${CMAKE_CURRENT_LIST_DIR}/packages/${Ice_NUGET_NAME}")
 
   if(NOT EXISTS ${Ice_NUGET_DIR})

--- a/csharp/Glacier2/Callback/Client/Client.csproj
+++ b/csharp/Glacier2/Callback/Client/Client.csproj
@@ -12,7 +12,7 @@
     <SliceCompile Include="../slice/AlarmClock.ice" />
     <PackageReference Include="ZeroC.Ice" Version="$(IceVersion)" />
     <PackageReference Include="ZeroC.Glacier2" Version="$(IceVersion)" />
-    <PackageReference Include="ZeroC.Ice.Slice.Tools.CSharp" Version="$(IceVersion)" />
+    <PackageReference Include="ZeroC.Ice.Slice.Tools" Version="$(IceVersion)" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/csharp/Glacier2/Callback/Server/Server.csproj
+++ b/csharp/Glacier2/Callback/Server/Server.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <SliceCompile Include="../slice/AlarmClock.ice" />
     <PackageReference Include="ZeroC.Ice" Version="$(IceVersion)" />
-    <PackageReference Include="ZeroC.Ice.Slice.Tools.CSharp" Version="$(IceVersion)" />
+    <PackageReference Include="ZeroC.Ice.Slice.Tools" Version="$(IceVersion)" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/csharp/Ice/Bidir/Client/Client.csproj
+++ b/csharp/Ice/Bidir/Client/Client.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <SliceCompile Include="../slice/AlarmClock.ice" />
     <PackageReference Include="ZeroC.Ice" Version="$(IceVersion)" />
-    <PackageReference Include="ZeroC.Ice.Slice.Tools.CSharp" Version="$(IceVersion)" />
+    <PackageReference Include="ZeroC.Ice.Slice.Tools" Version="$(IceVersion)" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/csharp/Ice/Bidir/Server/Server.csproj
+++ b/csharp/Ice/Bidir/Server/Server.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <SliceCompile Include="../slice/AlarmClock.ice" />
     <PackageReference Include="ZeroC.Ice" Version="$(IceVersion)" />
-    <PackageReference Include="ZeroC.Ice.Slice.Tools.CSharp" Version="$(IceVersion)" />
+    <PackageReference Include="ZeroC.Ice.Slice.Tools" Version="$(IceVersion)" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/csharp/Ice/Callback/Client/Client.csproj
+++ b/csharp/Ice/Callback/Client/Client.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <SliceCompile Include="../slice/AlarmClock.ice" />
     <PackageReference Include="ZeroC.Ice" Version="$(IceVersion)" />
-    <PackageReference Include="ZeroC.Ice.Slice.Tools.CSharp" Version="$(IceVersion)" />
+    <PackageReference Include="ZeroC.Ice.Slice.Tools" Version="$(IceVersion)" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/csharp/Ice/Callback/Server/Server.csproj
+++ b/csharp/Ice/Callback/Server/Server.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <SliceCompile Include="../slice/AlarmClock.ice" />
     <PackageReference Include="ZeroC.Ice" Version="$(IceVersion)" />
-    <PackageReference Include="ZeroC.Ice.Slice.Tools.CSharp" Version="$(IceVersion)" />
+    <PackageReference Include="ZeroC.Ice.Slice.Tools" Version="$(IceVersion)" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/csharp/Ice/Cancellation/Client/Client.csproj
+++ b/csharp/Ice/Cancellation/Client/Client.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <SliceCompile Include="../slice/Greeter.ice" />
     <PackageReference Include="ZeroC.Ice" Version="$(IceVersion)" />
-    <PackageReference Include="ZeroC.Ice.Slice.Tools.CSharp" Version="$(IceVersion)" />
+    <PackageReference Include="ZeroC.Ice.Slice.Tools" Version="$(IceVersion)" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/csharp/Ice/Cancellation/Server/Server.csproj
+++ b/csharp/Ice/Cancellation/Server/Server.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <SliceCompile Include="../slice/Greeter.ice" />
     <PackageReference Include="ZeroC.Ice" Version="$(IceVersion)" />
-    <PackageReference Include="ZeroC.Ice.Slice.Tools.CSharp" Version="$(IceVersion)" />
+    <PackageReference Include="ZeroC.Ice.Slice.Tools" Version="$(IceVersion)" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/csharp/Ice/Config/Client/Client.csproj
+++ b/csharp/Ice/Config/Client/Client.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <SliceCompile Include="../slice/Greeter.ice" />
     <PackageReference Include="ZeroC.Ice" Version="$(IceVersion)" />
-    <PackageReference Include="ZeroC.Ice.Slice.Tools.CSharp" Version="$(IceVersion)" />
+    <PackageReference Include="ZeroC.Ice.Slice.Tools" Version="$(IceVersion)" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/csharp/Ice/Config/Server/Server.csproj
+++ b/csharp/Ice/Config/Server/Server.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <SliceCompile Include="../slice/Greeter.ice" />
     <PackageReference Include="ZeroC.Ice" Version="$(IceVersion)" />
-    <PackageReference Include="ZeroC.Ice.Slice.Tools.CSharp" Version="$(IceVersion)" />
+    <PackageReference Include="ZeroC.Ice.Slice.Tools" Version="$(IceVersion)" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/csharp/Ice/Context/Client/Client.csproj
+++ b/csharp/Ice/Context/Client/Client.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <SliceCompile Include="../slice/Greeter.ice" />
     <PackageReference Include="ZeroC.Ice" Version="$(IceVersion)" />
-    <PackageReference Include="ZeroC.Ice.Slice.Tools.CSharp" Version="$(IceVersion)" />
+    <PackageReference Include="ZeroC.Ice.Slice.Tools" Version="$(IceVersion)" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/csharp/Ice/Context/Server/Server.csproj
+++ b/csharp/Ice/Context/Server/Server.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <SliceCompile Include="../slice/Greeter.ice" />
     <PackageReference Include="ZeroC.Ice" Version="$(IceVersion)" />
-    <PackageReference Include="ZeroC.Ice.Slice.Tools.CSharp" Version="$(IceVersion)" />
+    <PackageReference Include="ZeroC.Ice.Slice.Tools" Version="$(IceVersion)" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/csharp/Ice/Filesystem/Client/Client.csproj
+++ b/csharp/Ice/Filesystem/Client/Client.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <SliceCompile Include="../slice/Filesystem.ice" />
     <PackageReference Include="ZeroC.Ice" Version="$(IceVersion)" />
-    <PackageReference Include="ZeroC.Ice.Slice.Tools.CSharp" Version="$(IceVersion)" />
+    <PackageReference Include="ZeroC.Ice.Slice.Tools" Version="$(IceVersion)" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/csharp/Ice/Filesystem/Server/Server.csproj
+++ b/csharp/Ice/Filesystem/Server/Server.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <SliceCompile Include="../slice/Filesystem.ice" />
     <PackageReference Include="ZeroC.Ice" Version="$(IceVersion)" />
-    <PackageReference Include="ZeroC.Ice.Slice.Tools.CSharp" Version="$(IceVersion)" />
+    <PackageReference Include="ZeroC.Ice.Slice.Tools" Version="$(IceVersion)" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/csharp/Ice/Forwarder/Client/Client.csproj
+++ b/csharp/Ice/Forwarder/Client/Client.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <SliceCompile Include="../slice/Greeter.ice" />
     <PackageReference Include="ZeroC.Ice" Version="$(IceVersion)" />
-    <PackageReference Include="ZeroC.Ice.Slice.Tools.CSharp" Version="$(IceVersion)" />
+    <PackageReference Include="ZeroC.Ice.Slice.Tools" Version="$(IceVersion)" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/csharp/Ice/Forwarder/Server/Server.csproj
+++ b/csharp/Ice/Forwarder/Server/Server.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <SliceCompile Include="../slice/Greeter.ice" />
     <PackageReference Include="ZeroC.Ice" Version="$(IceVersion)" />
-    <PackageReference Include="ZeroC.Ice.Slice.Tools.CSharp" Version="$(IceVersion)" />
+    <PackageReference Include="ZeroC.Ice.Slice.Tools" Version="$(IceVersion)" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/csharp/Ice/Greeter/Client/Client.csproj
+++ b/csharp/Ice/Greeter/Client/Client.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <SliceCompile Include="../slice/Greeter.ice" />
     <PackageReference Include="ZeroC.Ice" Version="$(IceVersion)" />
-    <PackageReference Include="ZeroC.Ice.Slice.Tools.CSharp" Version="$(IceVersion)" />
+    <PackageReference Include="ZeroC.Ice.Slice.Tools" Version="$(IceVersion)" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/csharp/Ice/Greeter/Server/Server.csproj
+++ b/csharp/Ice/Greeter/Server/Server.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <SliceCompile Include="../slice/Greeter.ice" />
     <PackageReference Include="ZeroC.Ice" Version="$(IceVersion)" />
-    <PackageReference Include="ZeroC.Ice.Slice.Tools.CSharp" Version="$(IceVersion)" />
+    <PackageReference Include="ZeroC.Ice.Slice.Tools" Version="$(IceVersion)" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/csharp/Ice/Greeter/ServerAMD/ServerAMD.csproj
+++ b/csharp/Ice/Greeter/ServerAMD/ServerAMD.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <SliceCompile Include="../slice/GreeterAMD.ice" />
     <PackageReference Include="ZeroC.Ice" Version="$(IceVersion)" />
-    <PackageReference Include="ZeroC.Ice.Slice.Tools.CSharp" Version="$(IceVersion)" />
+    <PackageReference Include="ZeroC.Ice.Slice.Tools" Version="$(IceVersion)" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/csharp/Ice/Middleware/Client/Client.csproj
+++ b/csharp/Ice/Middleware/Client/Client.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <SliceCompile Include="../slice/Greeter.ice" />
     <PackageReference Include="ZeroC.Ice" Version="$(IceVersion)" />
-    <PackageReference Include="ZeroC.Ice.Slice.Tools.CSharp" Version="$(IceVersion)" />
+    <PackageReference Include="ZeroC.Ice.Slice.Tools" Version="$(IceVersion)" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/csharp/Ice/Middleware/Server/Server.csproj
+++ b/csharp/Ice/Middleware/Server/Server.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <SliceCompile Include="../slice/Greeter.ice" />
     <PackageReference Include="ZeroC.Ice" Version="$(IceVersion)" />
-    <PackageReference Include="ZeroC.Ice.Slice.Tools.CSharp" Version="$(IceVersion)" />
+    <PackageReference Include="ZeroC.Ice.Slice.Tools" Version="$(IceVersion)" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/csharp/Ice/Optional/Client1/Client1.csproj
+++ b/csharp/Ice/Optional/Client1/Client1.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <SliceCompile Include="../slice/WeatherStation1.ice" />
     <PackageReference Include="ZeroC.Ice" Version="$(IceVersion)" />
-    <PackageReference Include="ZeroC.Ice.Slice.Tools.CSharp" Version="$(IceVersion)" />
+    <PackageReference Include="ZeroC.Ice.Slice.Tools" Version="$(IceVersion)" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/csharp/Ice/Optional/Client2/Client2.csproj
+++ b/csharp/Ice/Optional/Client2/Client2.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <SliceCompile Include="../slice/WeatherStation2.ice" />
     <PackageReference Include="ZeroC.Ice" Version="$(IceVersion)" />
-    <PackageReference Include="ZeroC.Ice.Slice.Tools.CSharp" Version="$(IceVersion)" />
+    <PackageReference Include="ZeroC.Ice.Slice.Tools" Version="$(IceVersion)" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/csharp/Ice/Optional/Server1/Server1.csproj
+++ b/csharp/Ice/Optional/Server1/Server1.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <SliceCompile Include="../slice/WeatherStation1.ice" />
     <PackageReference Include="ZeroC.Ice" Version="$(IceVersion)" />
-    <PackageReference Include="ZeroC.Ice.Slice.Tools.CSharp" Version="$(IceVersion)" />
+    <PackageReference Include="ZeroC.Ice.Slice.Tools" Version="$(IceVersion)" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/csharp/Ice/Optional/Server2/Server2.csproj
+++ b/csharp/Ice/Optional/Server2/Server2.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <SliceCompile Include="../slice/WeatherStation2.ice" />
     <PackageReference Include="ZeroC.Ice" Version="$(IceVersion)" />
-    <PackageReference Include="ZeroC.Ice.Slice.Tools.CSharp" Version="$(IceVersion)" />
+    <PackageReference Include="ZeroC.Ice.Slice.Tools" Version="$(IceVersion)" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/csharp/IceBox/Greeter/Client/Client.csproj
+++ b/csharp/IceBox/Greeter/Client/Client.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <SliceCompile Include="../slice/Greeter.ice" />
     <PackageReference Include="ZeroC.Ice" Version="$(IceVersion)" />
-    <PackageReference Include="ZeroC.Ice.Slice.Tools.CSharp" Version="$(IceVersion)" />
+    <PackageReference Include="ZeroC.Ice.Slice.Tools" Version="$(IceVersion)" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/csharp/IceBox/Greeter/Service/Service.csproj
+++ b/csharp/IceBox/Greeter/Service/Service.csproj
@@ -12,7 +12,7 @@
     <SliceCompile Include="../slice/Greeter.ice" />
     <PackageReference Include="ZeroC.Ice" Version="$(IceVersion)" />
     <PackageReference Include="ZeroC.IceBox" Version="$(IceVersion)" />
-    <PackageReference Include="ZeroC.Ice.Slice.Tools.CSharp" Version="$(IceVersion)" />
+    <PackageReference Include="ZeroC.Ice.Slice.Tools" Version="$(IceVersion)" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/csharp/IceDiscovery/Greeter/Client/Client.csproj
+++ b/csharp/IceDiscovery/Greeter/Client/Client.csproj
@@ -12,7 +12,7 @@
     <SliceCompile Include="../slice/Greeter.ice" />
     <PackageReference Include="ZeroC.Ice" Version="$(IceVersion)" />
     <PackageReference Include="ZeroC.IceDiscovery" Version="$(IceVersion)" />
-    <PackageReference Include="ZeroC.Ice.Slice.Tools.CSharp" Version="$(IceVersion)" />
+    <PackageReference Include="ZeroC.Ice.Slice.Tools" Version="$(IceVersion)" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/csharp/IceDiscovery/Greeter/Server/Server.csproj
+++ b/csharp/IceDiscovery/Greeter/Server/Server.csproj
@@ -12,7 +12,7 @@
     <SliceCompile Include="../slice/Greeter.ice" />
     <PackageReference Include="ZeroC.Ice" Version="$(IceVersion)" />
     <PackageReference Include="ZeroC.IceDiscovery" Version="$(IceVersion)" />
-    <PackageReference Include="ZeroC.Ice.Slice.Tools.CSharp" Version="$(IceVersion)" />
+    <PackageReference Include="ZeroC.Ice.Slice.Tools" Version="$(IceVersion)" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/csharp/IceDiscovery/Replication/Client/Client.csproj
+++ b/csharp/IceDiscovery/Replication/Client/Client.csproj
@@ -12,7 +12,7 @@
     <SliceCompile Include="../slice/Greeter.ice" />
     <PackageReference Include="ZeroC.Ice" Version="$(IceVersion)" />
     <PackageReference Include="ZeroC.IceDiscovery" Version="$(IceVersion)" />
-    <PackageReference Include="ZeroC.Ice.Slice.Tools.CSharp" Version="$(IceVersion)" />
+    <PackageReference Include="ZeroC.Ice.Slice.Tools" Version="$(IceVersion)" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/csharp/IceDiscovery/Replication/Server/Server.csproj
+++ b/csharp/IceDiscovery/Replication/Server/Server.csproj
@@ -12,7 +12,7 @@
     <SliceCompile Include="../slice/Greeter.ice" />
     <PackageReference Include="ZeroC.Ice" Version="$(IceVersion)" />
     <PackageReference Include="ZeroC.IceDiscovery" Version="$(IceVersion)" />
-    <PackageReference Include="ZeroC.Ice.Slice.Tools.CSharp" Version="$(IceVersion)" />
+    <PackageReference Include="ZeroC.Ice.Slice.Tools" Version="$(IceVersion)" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/csharp/IceGrid/Greeter/Client/Client.csproj
+++ b/csharp/IceGrid/Greeter/Client/Client.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <SliceCompile Include="../slice/Greeter.ice" />
     <PackageReference Include="ZeroC.Ice" Version="$(IceVersion)" />
-    <PackageReference Include="ZeroC.Ice.Slice.Tools.CSharp" Version="$(IceVersion)" />
+    <PackageReference Include="ZeroC.Ice.Slice.Tools" Version="$(IceVersion)" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/csharp/IceGrid/Greeter/Server/Server.csproj
+++ b/csharp/IceGrid/Greeter/Server/Server.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <SliceCompile Include="../slice/Greeter.ice" />
     <PackageReference Include="ZeroC.Ice" Version="$(IceVersion)" />
-    <PackageReference Include="ZeroC.Ice.Slice.Tools.CSharp" Version="$(IceVersion)" />
+    <PackageReference Include="ZeroC.Ice.Slice.Tools" Version="$(IceVersion)" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/csharp/IceGrid/IceBox/Client/Client.csproj
+++ b/csharp/IceGrid/IceBox/Client/Client.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <SliceCompile Include="../slice/Greeter.ice" />
     <PackageReference Include="ZeroC.Ice" Version="$(IceVersion)" />
-    <PackageReference Include="ZeroC.Ice.Slice.Tools.CSharp" Version="$(IceVersion)" />
+    <PackageReference Include="ZeroC.Ice.Slice.Tools" Version="$(IceVersion)" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/csharp/IceGrid/IceBox/Service/Service.csproj
+++ b/csharp/IceGrid/IceBox/Service/Service.csproj
@@ -12,7 +12,7 @@
     <SliceCompile Include="../slice/Greeter.ice" />
     <PackageReference Include="ZeroC.Ice" Version="$(IceVersion)" />
     <PackageReference Include="ZeroC.IceBox" Version="$(IceVersion)" />
-    <PackageReference Include="ZeroC.Ice.Slice.Tools.CSharp" Version="$(IceVersion)" />
+    <PackageReference Include="ZeroC.Ice.Slice.Tools" Version="$(IceVersion)" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/csharp/IceGrid/LocatorDiscovery/Client/Client.csproj
+++ b/csharp/IceGrid/LocatorDiscovery/Client/Client.csproj
@@ -12,7 +12,7 @@
     <SliceCompile Include="../../Greeter/slice/Greeter.ice" />
     <PackageReference Include="ZeroC.Ice" Version="$(IceVersion)" />
      <PackageReference Include="ZeroC.IceLocatorDiscovery" Version="$(IceVersion)" />
-    <PackageReference Include="ZeroC.Ice.Slice.Tools.CSharp" Version="$(IceVersion)" />
+    <PackageReference Include="ZeroC.Ice.Slice.Tools" Version="$(IceVersion)" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/csharp/IceGrid/Query/Client/Client.csproj
+++ b/csharp/IceGrid/Query/Client/Client.csproj
@@ -12,7 +12,7 @@
     <SliceCompile Include="../slice/Greeter.ice" />
     <PackageReference Include="ZeroC.Ice" Version="$(IceVersion)" />
     <PackageReference Include="ZeroC.IceGrid" Version="$(IceVersion)" />
-    <PackageReference Include="ZeroC.Ice.Slice.Tools.CSharp" Version="$(IceVersion)" />
+    <PackageReference Include="ZeroC.Ice.Slice.Tools" Version="$(IceVersion)" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/csharp/IceGrid/Query/Server/Server.csproj
+++ b/csharp/IceGrid/Query/Server/Server.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <SliceCompile Include="../slice/Greeter.ice" />
     <PackageReference Include="ZeroC.Ice" Version="$(IceVersion)" />
-    <PackageReference Include="ZeroC.Ice.Slice.Tools.CSharp" Version="$(IceVersion)" />
+    <PackageReference Include="ZeroC.Ice.Slice.Tools" Version="$(IceVersion)" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/csharp/IceStorm/Weather/Sensor/Sensor.csproj
+++ b/csharp/IceStorm/Weather/Sensor/Sensor.csproj
@@ -12,7 +12,7 @@
     <SliceCompile Include="../slice/WeatherStation.ice" />
     <PackageReference Include="ZeroC.Ice" Version="$(IceVersion)" />
     <PackageReference Include="ZeroC.IceStorm" Version="$(IceVersion)" />
-    <PackageReference Include="ZeroC.Ice.Slice.Tools.CSharp" Version="$(IceVersion)" />
+    <PackageReference Include="ZeroC.Ice.Slice.Tools" Version="$(IceVersion)" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/csharp/IceStorm/Weather/Station/Station.csproj
+++ b/csharp/IceStorm/Weather/Station/Station.csproj
@@ -12,7 +12,7 @@
     <SliceCompile Include="../slice/WeatherStation.ice" />
     <PackageReference Include="ZeroC.Ice" Version="$(IceVersion)" />
     <PackageReference Include="ZeroC.IceStorm" Version="$(IceVersion)" />
-    <PackageReference Include="ZeroC.Ice.Slice.Tools.CSharp" Version="$(IceVersion)" />
+    <PackageReference Include="ZeroC.Ice.Slice.Tools" Version="$(IceVersion)" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/java/Ice/greeter/build.gradle.kts
+++ b/java/Ice/greeter/build.gradle.kts
@@ -3,7 +3,7 @@
 plugins {
     // Register the Ice Builder plugin without applying it here.
     // The plugin will be applied to all subprojects in the `subprojects` block below.
-    id("com.zeroc.gradle.ice-builder.slice") version "1.5.2" apply false
+    id("com.zeroc.ice.slice-tools") version "3.8.0-+" apply false
 }
 
 subprojects {
@@ -11,7 +11,7 @@ subprojects {
     apply(plugin = "application")
 
     // Apply the Gradle Ice Builder plugin to enable Slice compilation in all subprojects.
-    apply(plugin = "com.zeroc.gradle.ice-builder.slice")
+    apply(plugin = "com.zeroc.ice.slice-tools")
 
     repositories {
         // Add the ZeroC Nightly repository for downloading Ice runtime and development artifacts.

--- a/java/Ice/greeter/client/build.gradle.kts
+++ b/java/Ice/greeter/client/build.gradle.kts
@@ -6,12 +6,14 @@ dependencies {
 }
 
 
-slice {
-    java {
-        // Configure the default Slice source set to compile the Greeter.ice file from the parent slice directory
-        // during the build process.
-        create("default") {
-            files = listOf(file("../slice/Greeter.ice"))
+sourceSets {
+    main {
+        // Add the Greeter.ice file from the parent slice directory the main source set.
+        slice {
+            srcDirs("../slice")
+            // By default a Slice source set includes all Slice files in the srcDirs directories
+            // Here we override the default behavior by specifying the list of Slice files to include.
+            setIncludes(listOf("Greeter.ice"))
         }
     }
 }

--- a/java/Ice/greeter/server/build.gradle.kts
+++ b/java/Ice/greeter/server/build.gradle.kts
@@ -5,12 +5,14 @@ dependencies {
     implementation("com.zeroc:ice:3.8.0-nightly-+")
 }
 
-slice {
-    java {
-        // Configure the default Slice source set to compile the Greeter.ice file from the parent slice directory
-        // during the build process.
-        create("default") {
-            files = listOf(file("../slice/Greeter.ice"))
+sourceSets {
+    main {
+        // Add the Greeter.ice file from the parent slice directory the main source set.
+        slice {
+            srcDirs("../slice")
+            // By default a Slice source set includes all Slice files in the srcDirs directories
+            // Here we override the default behavior by specifying the list of Slice files to include.
+            setIncludes(listOf("Greeter.ice"))
         }
     }
 }

--- a/java/Ice/greeter/serveramd/build.gradle.kts
+++ b/java/Ice/greeter/serveramd/build.gradle.kts
@@ -5,12 +5,14 @@ dependencies {
     implementation("com.zeroc:ice:3.8.0-nightly-+")
 }
 
-slice {
-    java {
-        // Configure the default Slice source set to compile the GreeterAMD.ice file from the parent slice directory
-        // during the build process.
-        create("amd") {
-            files = listOf(file("../slice/GreeterAMD.ice"))
+sourceSets {
+    main {
+        // Add the GreeterAMD.ice file from the parent slice directory the main source set.
+        slice {
+            srcDirs("../slice")
+            // By default a Slice source set includes all Slice files in the srcDirs directories
+            // Here we override the default behavior by specifying the list of Slice files to include.
+            setIncludes(listOf("GreeterAMD.ice"))
         }
     }
 }

--- a/java/Ice/greeter/settings.gradle.kts
+++ b/java/Ice/greeter/settings.gradle.kts
@@ -1,5 +1,12 @@
 // Copyright (c) ZeroC, Inc.
 
+pluginManagement {
+    repositories {
+        mavenLocal()
+        gradlePluginPortal() // Keep this to allow fetching other plugins
+    }
+}
+
 rootProject.name = "greeter"
 include("client")
 include("server")


### PR DESCRIPTION
This PR upgrade demos to used the updated Slice Tools, and NuGet packages:

- For C# the tools package was renamed to ZeroC.Ice.Slice.Tools
- For C++ Windows builds the C++ NuGet package was renamed to ZeroC.Ice.Cpp
- For Java updated greeter to use the new Gradle plugin `com.zeroc.ice.slice-tools`
