### PR TITLE
Remove setup-dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,12 +29,24 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     steps:
-      # We reuse the setup-dependencies action from the Ice repository
-      - name: Setup Ice Build Dependencies
-        uses: zeroc-ice/ice/.github/actions/setup-dependencies@main
-
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Setup .NET 8
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.x
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: "oracle"
+          java-version: "17"
 
       - name: Install Nightly Ice Builds
         uses: ./.github/actions/install-nightly-ice

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -52,6 +52,8 @@ jobs:
       - name: Run Clang Tidy
         timeout-minutes: 30
         working-directory: cpp
+        env:
+          CMAKE_BUILD_PARALLEL_LEVEL: 4
         run: |
           set -o pipefail
           find . -name CMakeLists.txt -type f | while IFS= read -r file; do

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -43,9 +43,6 @@ jobs:
           rm /tmp/llvm.sh
           clang-tidy-19 --version
 
-      - name: Setup Ice Build Dependencies
-        uses: zeroc-ice/ice/.github/actions/setup-dependencies@main
-
       - name: Checkout repository
         uses: actions/checkout@v4
 


### PR DESCRIPTION
We don't need setup-dependencies from Ice anymore. 

Question: Should we reuse `setup-<lang>` from Ice so that the versions match? I'm thinking probably not and just deal with these manually.