### PR TITLE
Fix dispatch cancellation in Cancellation demo

### DIFF
--- a/csharp/Ice/Cancellation/Server/Program.cs
+++ b/csharp/Ice/Cancellation/Server/Program.cs
@@ -23,10 +23,10 @@ Console.CancelKeyPress += (sender, eventArgs) =>
     eventArgs.Cancel = true; // don't terminate the process
     Console.WriteLine("Caught Ctrl+C, shutting down...");
     communicator.shutdown(); // starts shutting down
+
+    // Cancel outstanding dispatches "stuck" in the slow greeter.
+    dispatchCts.Cancel();
 };
 
 // Wait until the communicator is shut down. Here, this occurs when the user presses Ctrl+C.
 await communicator.shutdownCompleted;
-
-// Cancel outstanding dispatches "stuck" in the slow greeter.
-dispatchCts.Cancel();


### PR DESCRIPTION
This PR fixes the dispatch cancellation of the Cancellation demo, that was broken by a previous PR.

Output (with fix):
```
Server % dotnet run
Listening on port 4061...
Dispatching greet request { name = 'bernard' }
Dispatching greet request { name = 'alice' }
Dispatching greet request { name = 'bob' }
Dispatching greet request { name = 'carol' }
Dispatching greet request { name = 'dave' }
^CCaught Ctrl+C, shutting down...
greet dispatch canceled { name = 'dave' }
greet dispatch canceled { name = 'alice' }
greet dispatch canceled { name = 'bob' }
-! 3/29/2025 10:08:44:555 Server: warning: failed to dispatch greet to slowGreeter over ::ffff:127.0.0.1:4061<->::ffff:127.0.0.1:49876:
   System.Threading.Tasks.TaskCanceledException: A task was canceled.
      at Server.Chatbot.GreetAsync(String name, Current current) in /Users/bernard/builds/ice-demos/csharp/Ice/Cancellation/Server/Chatbot.cs:line 20
      at VisitorCenter.Greeter.iceD_GreetAsync(Greeter obj, IncomingRequest request) in /Users/bernard/builds/ice-demos/csharp/Ice/Cancellation/Server/generated/Greeter.cs:line 200
      at Ice.Internal.ServantManager.dispatchAsync(IncomingRequest request) in D:\a\ice\ice\csharp\src\Ice\Internal\ServantManager.cs:line 27
      at Ice.Internal.LoggerMiddleware.dispatchAsync(IncomingRequest request) in D:\a\ice\ice\csharp\src\Ice\Internal\LoggerMiddleware.cs:line 25
-! 3/29/2025 10:08:44:556 Server: warning: failed to dispatch greet to slowGreeter over ::ffff:127.0.0.1:4061<->::ffff:127.0.0.1:49876:
   System.Threading.Tasks.TaskCanceledException: A task was canceled.
      at Server.Chatbot.GreetAsync(String name, Current current) in /Users/bernard/builds/ice-demos/csharp/Ice/Cancellation/Server/Chatbot.cs:line 20
      at VisitorCenter.Greeter.iceD_GreetAsync(Greeter obj, IncomingRequest request) in /Users/bernard/builds/ice-demos/csharp/Ice/Cancellation/Server/generated/Greeter.cs:line 200
      at Ice.Internal.ServantManager.dispatchAsync(IncomingRequest request) in D:\a\ice\ice\csharp\src\Ice\Internal\ServantManager.cs:line 27
      at Ice.Internal.LoggerMiddleware.dispatchAsync(IncomingRequest request) in D:\a\ice\ice\csharp\src\Ice\Internal\LoggerMiddleware.cs:line 25
-! 3/29/2025 10:08:44:556 Server: warning: failed to dispatch greet to slowGreeter over ::ffff:127.0.0.1:4061<->::ffff:127.0.0.1:49876:
   System.Threading.Tasks.TaskCanceledException: A task was canceled.
      at Server.Chatbot.GreetAsync(String name, Current current) in /Users/bernard/builds/ice-demos/csharp/Ice/Cancellation/Server/Chatbot.cs:line 20
      at VisitorCenter.Greeter.iceD_GreetAsync(Greeter obj, IncomingRequest request) in /Users/bernard/builds/ice-demos/csharp/Ice/Cancellation/Server/generated/Greeter.cs:line 200
      at Ice.Internal.ServantManager.dispatchAsync(IncomingRequest request) in D:\a\ice\ice\csharp\src\Ice\Internal\ServantManager.cs:line 27
      at Ice.Internal.LoggerMiddleware.dispatchAsync(IncomingRequest request) in D:\a\ice\ice\csharp\src\Ice\Internal\LoggerMiddleware.cs:line 25
```

```
Client % dotnet run
Hello, bernard!
Caught InvocationTimeoutException, as expected: Invocation timed out.
Caught InvocationCanceledException, as expected: Invocation canceled.
Hello, carol!
Please press Ctrl+C in the server's terminal to cancel the slow greeter dispatch.
UnknownException, as expected: Dispatch failed with System.Threading.Tasks.TaskCanceledException: A task was canceled.
```

Note: I don't think we can/should send a different exception to the client. This corresponds to InternalError in IceRPC - the dispatch failed due to an internal service/server error. And naturally, the client doesn't know if any of the operation executed or not.

The logging is the default behavior:
https://github.com/zeroc-ice/ice/blob/f1010db2e81766204841a3df1a647c7c7af39e72/csharp/src/Ice/Internal/LoggerMiddleware.cs#L72

Not sure if or how we could change the logic to suppress it in this demo. We could nevertheless explain this "surprising" logging in the code or in the README.
