### PR TITLE
Add new Ice/config demo for MATLAB

### DIFF
--- a/matlab/.gitignore
+++ b/matlab/.gitignore
@@ -1,2 +1,3 @@
 *.asv
+*.log
 **/+VisitorCenter/**

--- a/matlab/Ice/config/Greeter.ice
+++ b/matlab/Ice/config/Greeter.ice
@@ -1,0 +1,15 @@
+// Copyright (c) ZeroC, Inc.
+
+#pragma once
+
+module VisitorCenter
+{
+    /// Represents a simple greeter.
+    interface Greeter
+    {
+        /// Creates a personalized greeting.
+        /// @param name The name of the person to greet.
+        /// @return The greeting.
+        string greet(string name);
+    }
+}

--- a/matlab/Ice/config/README.md
+++ b/matlab/Ice/config/README.md
@@ -1,0 +1,37 @@
+# Ice Config
+
+This demo shows how to configure a client application using an Ice configuration file.
+
+Ice for MATLAB supports only client-side applications. As a result, you first need to start a Config server implemented
+in a language with server-side support, such as Python, Java, or C#.
+
+Then, in the MATLAB console:
+
+- Go to the Ice/config directory
+
+```shell
+cd matlab/Ice/config
+```
+
+- Compile the Greeter.ice file with the Slice compiler for MATLAB
+
+```shell
+slice2matlab Greeter.ice
+```
+
+- Run the client application
+
+```shell
+client
+```
+
+> [!NOTE]
+> The client writes log messages to file client.log.
+
+You can pass `--Ice` arguments to set additional properties or override the properties set in the configuration file.
+
+For example:
+
+```shell
+client({'--Ice.Trace.Network=2', '--Ice.LogFile=verbose.log'})
+```

--- a/matlab/Ice/config/client.m
+++ b/matlab/Ice/config/client.m
@@ -1,0 +1,31 @@
+% Copyright (c) ZeroC, Inc.
+
+function client(args)
+    % The Slice module VisitorCenter maps to a MATLAB package with the same name.
+    import VisitorCenter.*
+
+    if nargin == 0
+        args = {};
+    end
+
+    % Load the Ice library if it is not already loaded.
+    if ~libisloaded('ice')
+        loadlibrary('ice', @iceproto);
+    end
+
+    % Create an Ice communicator. We'll use this communicator to create proxies and manage outgoing connections. The
+    % communicator gets its configuration properties from file config.client in the client's current working directory.
+    % The communicator initialization also parses args to find and set additional properties.
+    communicator = Ice.initialize(args, 'config.client');
+
+    % Destroy the communicator when the function exits.
+    cleanup = onCleanup(@() communicator.destroy());
+
+    % We create a Greeter proxy using the value of the Greeter.Proxy property in config.client.
+    % It's null if the property is not set.
+    greeter = GreeterPrx.uncheckedCast(communicator.propertyToProxy('Greeter.Proxy'));
+
+    % Send a request to the remote object and get the response.
+    greeting = greeter.greet(char(java.lang.System.getProperty('user.name')));
+    fprintf('%s\n', greeting);
+end

--- a/matlab/Ice/config/config.client
+++ b/matlab/Ice/config/config.client
@@ -1,0 +1,39 @@
+#
+# Application-specific configuration
+#
+
+# The address of the target object. `default` is replaced by the value of Ice.Default.Protocol.
+Greeter.Proxy=greeter:default -h localhost -p 4061
+
+#
+# Ice configuration
+#
+
+# The transport protocol to use for Ice communications when `default` is specified.
+# You can set it to tcp, ssl, ws, or wss. Leaving it unset is equivalent to setting it to tcp.
+# Make sure you use the same value in config.client and config.server.
+Ice.Default.Protocol=ssl
+
+# Direct all log messages to file client.log.
+# This is necessary when we run the client in the MATLAB Command Window: the log messages go to stderr by default and
+# the Command Window does not show stderr output.
+Ice.LogFile=client.log
+
+#
+# IceSSL configuration
+#
+
+# The directory where the application finds certificates and other files.
+IceSSL.DefaultDir=../../../certs
+
+# The certificate authority file.
+IceSSL.CAs=cacert.pem
+
+# The client's certificate file.
+IceSSL.CertFile=client.p12
+
+# TODO: switch to password-less certificates
+IceSSL.Password=password
+
+# Turn on security logging/tracing.
+IceSSL.Trace.Security=1

--- a/matlab/Ice/context/client.m
+++ b/matlab/Ice/context/client.m
@@ -16,8 +16,7 @@ function client(args)
     % Set the Ice.ImplicitContext property to 'Shared' before calling Ice.initialize.
     % This is only necessary for the implicit context API (see below).
     initData = Ice.InitializationData();
-    [props, ~] = Ice.createProperties(args);
-    initData.properties_ = props;
+    initData.properties_ = Ice.createProperties(args);
     initData.properties_.setProperty('Ice.ImplicitContext', 'Shared');
 
     % Create an Ice communicator. We'll use this communicator to create proxies and manage outgoing connections.

--- a/matlab/Ice/context/client.m
+++ b/matlab/Ice/context/client.m
@@ -20,7 +20,7 @@ function client(args)
     initData.properties_ = props;
     initData.properties_.setProperty('Ice.ImplicitContext', 'Shared');
 
-    % Create an Ice communicator to initialize the Ice runtime.
+    % Create an Ice communicator. We'll use this communicator to create proxies and manage outgoing connections.
     communicator = Ice.initialize(initData);
 
     % Destroy the communicator when the function exits.

--- a/matlab/Ice/greeter/client.m
+++ b/matlab/Ice/greeter/client.m
@@ -13,7 +13,7 @@ function client(args)
         loadlibrary('ice', @iceproto);
     end
 
-    % Create an Ice communicator to initialize the Ice runtime.
+    % Create an Ice communicator. We'll use this communicator to create proxies and manage outgoing connections.
     communicator = Ice.initialize(args);
 
     % Destroy the communicator when the function exits.


### PR DESCRIPTION
Ice parses the all the args but always treats the first one as the program name for logging, which results in odd logs:

```
-- 4/1/2025 16:34:45.975 --Ice.Trace.Network=2: Network: established ssl connection
   local address = 127.0.0.1:62513
   remote address = 127.0.0.1:4061
-- 4/1/2025 16:34:45.978 --Ice.Trace.Network=2: Network: closed ssl connection
   local address = 127.0.0.1:62513
   remote address = 127.0.0.1:4061
```

Here, `--Ice.Trace.Network=2` is treated as argv[0] == program name. Is this as expected?
