### PR TITLE
Use "statically linked" plugins with MATLAB demos

### DIFF
--- a/matlab/IceDiscovery/greeter/client.m
+++ b/matlab/IceDiscovery/greeter/client.m
@@ -17,7 +17,7 @@ function client(args)
     % locator on the communicator.
     initData = Ice.InitializationData();
     initData.properties_ = Ice.createProperties(args);
-    initData.properties_.setProperty('Ice.Plugin.Discovery', 'IceDiscovery:createIceDiscovery');
+    initData.properties_.setProperty('Ice.Plugin.IceDiscovery', '1');
 
     % Create an Ice communicator. We'll use this communicator to create proxies and manage outgoing connections.
     communicator = Ice.initialize(initData);

--- a/matlab/IceGrid/locatorDiscovery/client.m
+++ b/matlab/IceGrid/locatorDiscovery/client.m
@@ -18,7 +18,7 @@ function client(args)
     % this communicator.
     initData = Ice.InitializationData();
     initData.properties_ = Ice.createProperties(args);
-    initData.properties_.setProperty('Ice.Plugin.LocatorDiscovery', 'IceLocatorDiscovery:createIceLocatorDiscovery');
+    initData.properties_.setProperty('Ice.Plugin.IceLocatorDiscovery', '1');
 
     % Create an Ice communicator. We'll use this communicator to create proxies and manage outgoing connections.
     communicator = Ice.initialize(initData);


### PR DESCRIPTION
This PR updates the IceDiscovery and IceLocatorDiscovery demos to use the (so-called) statically linked plugins.