### PR TITLE
Update IceGrid/secure `makedemocerts.py` to always set a password

### DIFF
--- a/cpp11/IceGrid/secure/README.md
+++ b/cpp11/IceGrid/secure/README.md
@@ -30,20 +30,6 @@ generate Java KeyStore files so you need to add the JDK bin directory
 to your PATH (if it's not found, `makedemocerts.py` will print
 a warning).
 
-For simplicity, the certificates created by `makedemocerts.py` are not
-protected with a password. In a real world deployment, to ensure that
-only privileged users can create new certificates and start the
-IceGrid components, you would typically use a password for the
-certificate authority, the IceGrid registry and node certificates and
-the Glacier2 certificate.
-
-You could also protect the server certificate with a password and
-specify the password in the server configuration in clear text.
-However, this would not improve security as you would still rely on
-filesystem permissions to restrict access to the configuration file,
-so you might as well use a certificate without a password and rely on
-the filesystem permissions to restrict access to the certificate.
-
 Once the certificates are generated, you can start the IceGrid
 registries, node, and Glacier2 router:
 

--- a/cpp11/IceGrid/secure/makedemocerts.py
+++ b/cpp11/IceGrid/secure/makedemocerts.py
@@ -47,10 +47,10 @@ while True:
 factory = IceCertUtils.CertificateFactory(dn=dn)
 
 # Save the CA certificate
-factory.getCA().save(os.path.join("certs", "ca.pem"))
+factory.getCA().save(os.path.join("certs", "ca.pem"), password="password")
 
 try:
-    factory.getCA().save(os.path.join("certs", "ca.jks"))
+    factory.getCA().save(os.path.join("certs", "ca.jks"), password="password")
 except Exception as ex:
     print("warning: couldn't generate JKS certificate `ca.jks':\n" + str(ex))
 
@@ -63,10 +63,10 @@ except Exception as ex:
 eku = "serverAuth,clientAuth"
 
 # Create and the certificates for the different components
-factory.create("Master", dns="localhost", extendedKeyUsage=eku).save(os.path.join("certs", "master.p12"))
-factory.create("Slave", dns="localhost", extendedKeyUsage=eku).save(os.path.join("certs", "slave.p12"))
-factory.create("Node", dns="localhost", extendedKeyUsage=eku).save(os.path.join("certs", "node.p12"))
-factory.create("Glacier2", dns="localhost", extendedKeyUsage=eku).save(os.path.join("certs", "glacier2.p12"))
-factory.create("Server", dns="localhost", extendedKeyUsage=eku).save(os.path.join("certs", "server.p12"))
+factory.create("Master", dns="localhost", extendedKeyUsage=eku).save(os.path.join("certs", "master.p12"), password="password")
+factory.create("Slave", dns="localhost", extendedKeyUsage=eku).save(os.path.join("certs", "slave.p12"), password="password")
+factory.create("Node", dns="localhost", extendedKeyUsage=eku).save(os.path.join("certs", "node.p12"), password="password")
+factory.create("Glacier2", dns="localhost", extendedKeyUsage=eku).save(os.path.join("certs", "glacier2.p12"), password="password")
+factory.create("Server", dns="localhost", extendedKeyUsage=eku).save(os.path.join("certs", "server.p12"), password="password")
 
 factory.destroy()

--- a/cpp98/IceGrid/secure/README.md
+++ b/cpp98/IceGrid/secure/README.md
@@ -30,20 +30,6 @@ generate Java KeyStore files so you need to add the JDK bin directory
 to your PATH (if it's not found, `makedemocerts.py` will print
 a warning).
 
-For simplicity, the certificates created by `makedemocerts.py` are not
-protected with a password. In a real world deployment, to ensure that
-only privileged users can create new certificates and start the
-IceGrid components, you would typically use a password for the
-certificate authority, the IceGrid registry and node certificates and
-the Glacier2 certificate.
-
-You could also protect the server certificate with a password and
-specify the password in the server configuration in clear text.
-However, this would not improve security as you would still rely on
-filesystem permissions to restrict access to the configuration file,
-so you might as well use a certificate without a password and rely on
-the filesystem permissions to restrict access to the certificate.
-
 Once the certificates are generated, you can start the IceGrid
 registries, node, and Glacier2 router:
 

--- a/cpp98/IceGrid/secure/makedemocerts.py
+++ b/cpp98/IceGrid/secure/makedemocerts.py
@@ -47,10 +47,10 @@ while True:
 factory = IceCertUtils.CertificateFactory(dn=dn)
 
 # Save the CA certificate
-factory.getCA().save(os.path.join("certs", "ca.pem"))
+factory.getCA().save(os.path.join("certs", "ca.pem"), password="password")
 
 try:
-    factory.getCA().save(os.path.join("certs", "ca.jks"))
+    factory.getCA().save(os.path.join("certs", "ca.jks"), password="password")
 except Exception as ex:
     print("warning: couldn't generate JKS certificate `ca.jks':\n" + str(ex))
 
@@ -63,10 +63,10 @@ except Exception as ex:
 eku = "serverAuth,clientAuth"
 
 # Create and the certificates for the different components
-factory.create("Master", dns="localhost", extendedKeyUsage=eku).save(os.path.join("certs", "master.p12"))
-factory.create("Slave", dns="localhost", extendedKeyUsage=eku).save(os.path.join("certs", "slave.p12"))
-factory.create("Node", dns="localhost", extendedKeyUsage=eku).save(os.path.join("certs", "node.p12"))
-factory.create("Glacier2", dns="localhost", extendedKeyUsage=eku).save(os.path.join("certs", "glacier2.p12"))
-factory.create("Server", dns="localhost", extendedKeyUsage=eku).save(os.path.join("certs", "server.p12"))
+factory.create("Master", dns="localhost", extendedKeyUsage=eku).save(os.path.join("certs", "master.p12"), password="password")
+factory.create("Slave", dns="localhost", extendedKeyUsage=eku).save(os.path.join("certs", "slave.p12"), password="password")
+factory.create("Node", dns="localhost", extendedKeyUsage=eku).save(os.path.join("certs", "node.p12"), password="password")
+factory.create("Glacier2", dns="localhost", extendedKeyUsage=eku).save(os.path.join("certs", "glacier2.p12"), password="password")
+factory.create("Server", dns="localhost", extendedKeyUsage=eku).save(os.path.join("certs", "server.p12"), password="password")
 
 factory.destroy()


### PR DESCRIPTION
We were previously relying the a behavior of `zeroc-icecertutils` that always set a password of `password`.  A recent updated change this behavior. The comment in the README was inaccurate, as we require a certificate. 

Fixes #402