### PR TITLE
Update IceDiscovery C# demos to use registerIceDiscovery

### DIFF
--- a/cpp/IceDiscovery/greeter/Client.cpp
+++ b/cpp/IceDiscovery/greeter/Client.cpp
@@ -12,11 +12,12 @@ using namespace std;
 int
 main(int argc, char* argv[])
 {
-    // Register the IceDiscovery plugin. The plugin will be loaded during communicator initialization and will
-    // install a default locator on the communicator.
+    // Register the IceDiscovery plugin. The plugin will be loaded during communicator initialization.
     Ice::registerIceDiscovery();
 
     // Create an Ice communicator. We'll use this communicator to create proxies and manage outgoing connections.
+    // The IceDiscovery plugin is created and initialized by initialize, and sets the default locator on the new
+    // communicator.
     Ice::CommunicatorPtr communicator = Ice::initialize(argc, argv);
 
     // Make sure the communicator is destroyed at the end of this scope.

--- a/cpp/IceDiscovery/greeter/Server.cpp
+++ b/cpp/IceDiscovery/greeter/Server.cpp
@@ -18,6 +18,8 @@ main(int argc, char* argv[])
     Ice::CtrlCHandler ctrlCHandler;
 
     // Create an Ice communicator. We'll use this communicator to create an object adapter.
+    // The IceDiscovery plugin is created and initialized by initialize, and sets the default locator on the new
+    // communicator.
     Ice::CommunicatorPtr communicator = Ice::initialize(argc, argv);
 
     // Make sure the communicator is destroyed at the end of this scope.

--- a/cpp/IceDiscovery/replication/Client.cpp
+++ b/cpp/IceDiscovery/replication/Client.cpp
@@ -12,11 +12,12 @@ using namespace std;
 int
 main(int argc, char* argv[])
 {
-    // Register the IceDiscovery plugin. The plugin will be loaded during communicator initialization and will
-    // install a default locator on the communicator.
+    // Register the IceDiscovery plugin. The plugin will be loaded during communicator initialization.
     Ice::registerIceDiscovery();
 
     // Create an Ice communicator. We'll use this communicator to create proxies and manage outgoing connections.
+    // The IceDiscovery plugin is created and initialized by initialize, and sets the default locator on the new
+    // communicator.
     Ice::CommunicatorPtr communicator = Ice::initialize(argc, argv);
 
     // Make sure the communicator is destroyed at the end of this scope.

--- a/cpp/IceDiscovery/replication/Server.cpp
+++ b/cpp/IceDiscovery/replication/Server.cpp
@@ -18,6 +18,8 @@ main(int argc, char* argv[])
     Ice::CtrlCHandler ctrlCHandler;
 
     // Create an Ice communicator. We'll use this communicator to create an object adapter.
+    // The IceDiscovery plugin is created and initialized by initialize, and sets the default locator on the new
+    // communicator.
     Ice::CommunicatorPtr communicator = Ice::initialize(argc, argv);
 
     // Make sure the communicator is destroyed at the end of this scope.

--- a/csharp/IceDiscovery/Greeter/Client/Program.cs
+++ b/csharp/IceDiscovery/Greeter/Client/Program.cs
@@ -3,16 +3,13 @@
 // Slice module VisitorCenter in Greeter.ice maps to C# namespace VisitorCenter.
 using VisitorCenter;
 
-// Configure the communicator to load the IceDiscovery plugin during initialization. This plugin installs a default
-// locator on the communicator.
-var initData = new Ice.InitializationData
-{
-    properties = new Ice.Properties(ref args)
-};
-initData.properties.setProperty("Ice.Plugin.Discovery", "IceDiscovery:IceDiscovery.PluginFactory");
+// Register the IceDiscovery plugin. The plugin will be loaded during communicator initialization.
+IceDiscovery.Util.registerIceDiscovery(loadOnInitialize: true);
 
 // Create an Ice communicator. We'll use this communicator to create proxies and manage outgoing connections.
-await using Ice.Communicator communicator = Ice.Util.initialize(initData);
+// The IceDiscovery plugin is created and initialized by initialize, and sets the default locator on the new
+// communicator.
+await using Ice.Communicator communicator = Ice.Util.initialize(ref args);
 
 // Create a proxy to the Greeter object hosted by the server. "greeter" is a stringified proxy with no addressing
 // information, also known as a well-known proxy. It's resolved by the default locator installed by the IceDiscovery

--- a/csharp/IceDiscovery/Greeter/Server/Program.cs
+++ b/csharp/IceDiscovery/Greeter/Server/Program.cs
@@ -1,26 +1,26 @@
 // Copyright (c) ZeroC, Inc.
 
-// Configure the communicator to load the IceDiscovery plugin during initialization. This plugin installs a default
-// locator on the communicator.
-var initData = new Ice.InitializationData
-{
-    properties = new Ice.Properties(ref args)
-};
-initData.properties.setProperty("Ice.Plugin.Discovery", "IceDiscovery:IceDiscovery.PluginFactory");
+// Register the IceDiscovery plugin. The plugin will be loaded during communicator initialization.
+IceDiscovery.Util.registerIceDiscovery(loadOnInitialize: true);
+
+// Create an Ice communicator. We'll use this communicator to create an object adapter.
+// The IceDiscovery plugin is created and initialized by initialize, and sets the default locator on the new
+// communicator.
+await using Ice.Communicator communicator = Ice.Util.initialize(ref args);
+
+// Get the communicator's properties. We'll use this object to set the properties of our object adapter.
+var properties = communicator.getProperties();
 
 // Configure the object adapter GreeterAdapter. It must be an indirect object adapter (i.e., with an AdapterId
 // property); otherwise, the IceDiscovery plugin can't make it discoverable by IceDiscovery clients.
-initData.properties.setProperty("GreeterAdapter.AdapterId", "greeterAdapterId");
+properties.setProperty("GreeterAdapter.AdapterId", "greeterAdapterId");
 
 // Configure the GreeterAdapter to listen on TCP with an OS-assigned port. We don't need a fixed port since the clients
 // discover this object adapter.
-initData.properties.setProperty("GreeterAdapter.Endpoints", "tcp");
-
-// Create an Ice communicator. We'll use this communicator to create an object adapter.
-await using Ice.Communicator communicator = Ice.Util.initialize(initData);
+properties.setProperty("GreeterAdapter.Endpoints", "tcp");
 
 // Create an object adapter that listens for incoming requests and dispatches them to servants. "GreeterAdapter" is a
-// key into the configuration properties set above.
+// key into the properties set above.
 Ice.ObjectAdapter adapter = communicator.createObjectAdapter("GreeterAdapter");
 
 // Register the Chatbot servant with the adapter.

--- a/csharp/IceDiscovery/Replication/Client/Program.cs
+++ b/csharp/IceDiscovery/Replication/Client/Program.cs
@@ -3,16 +3,13 @@
 // Slice module VisitorCenter in Greeter.ice maps to C# namespace VisitorCenter.
 using VisitorCenter;
 
-// Configure the communicator to load the IceDiscovery plugin during initialization. This plugin installs a default
-// locator on the communicator.
-var initData = new Ice.InitializationData
-{
-    properties = new Ice.Properties(ref args)
-};
-initData.properties.setProperty("Ice.Plugin.Discovery", "IceDiscovery:IceDiscovery.PluginFactory");
+// Register the IceDiscovery plugin. The plugin will be loaded during communicator initialization.
+IceDiscovery.Util.registerIceDiscovery(loadOnInitialize: true);
 
 // Create an Ice communicator. We'll use this communicator to create proxies and manage outgoing connections.
-await using Ice.Communicator communicator = Ice.Util.initialize(initData);
+// The IceDiscovery plugin is created and initialized by initialize, and sets the default locator on the new
+// communicator.
+await using Ice.Communicator communicator = Ice.Util.initialize(ref args);
 
 // Create a proxy to the Greeter object hosted by the server. "greeter" is a stringified proxy with no addressing
 // information, also known as a well-known proxy. It's resolved by the default locator installed by the IceDiscovery


### PR DESCRIPTION
This PR updates the IceDiscovery demos for C# to use registerIceDiscovery like the C++ demos.