### PR TITLE
Remove Ice::registerPlugin calls

### DIFF
--- a/cpp/Ice/multicast/Client.cpp
+++ b/cpp/Ice/multicast/Client.cpp
@@ -50,10 +50,6 @@ int run(const shared_ptr<Ice::Communicator>&, const string&);
 int
 main(int argc, char* argv[])
 {
-#ifdef ICE_STATIC_LIBS
-    Ice::registerIceUDP();
-#endif
-
     int status = 0;
 
     try

--- a/cpp/Ice/multicast/Server.cpp
+++ b/cpp/Ice/multicast/Server.cpp
@@ -41,10 +41,6 @@ private:
 int
 main(int argc, char* argv[])
 {
-#ifdef ICE_STATIC_LIBS
-    Ice::registerIceUDP();
-#endif
-
     int status = 0;
 
     try

--- a/cpp/IceDiscovery/greeter/Client.cpp
+++ b/cpp/IceDiscovery/greeter/Client.cpp
@@ -14,10 +14,12 @@ main(int argc, char* argv[])
 {
     // Register the IceDiscovery plugin. The plugin will be loaded during communicator initialization and will
     // install a default locator on the communicator.
-    Ice::registerIceDiscovery();
+    Ice::InitializationData initData;
+    initData.properties = Ice::createProperties(argc, argv);
+    initData.pluginFactories = {Ice::discoveryPluginFactory()};
 
     // Create an Ice communicator. We'll use this communicator to create proxies and manage outgoing connections.
-    Ice::CommunicatorPtr communicator = Ice::initialize(argc, argv);
+    Ice::CommunicatorPtr communicator = Ice::initialize(initData);
 
     // Make sure the communicator is destroyed at the end of this scope.
     Ice::CommunicatorHolder communicatorHolder{communicator};

--- a/cpp/IceDiscovery/greeter/Server.cpp
+++ b/cpp/IceDiscovery/greeter/Server.cpp
@@ -11,14 +11,16 @@ int
 main(int argc, char* argv[])
 {
     // Register the IceDiscovery plugin. The plugin will be loaded during communicator initialization.
-    Ice::registerIceDiscovery();
+    Ice::InitializationData initData;
+    initData.properties = Ice::createProperties(argc, argv);
+    initData.pluginFactories = {Ice::discoveryPluginFactory()};
 
     // CtrlCHandler is a helper class that handles Ctrl+C and similar signals. It must be constructed at the beginning
     // of the program, before creating an Ice communicator or starting any thread.
     Ice::CtrlCHandler ctrlCHandler;
 
     // Create an Ice communicator. We'll use this communicator to create an object adapter.
-    Ice::CommunicatorPtr communicator = Ice::initialize(argc, argv);
+    Ice::CommunicatorPtr communicator = Ice::initialize(initData);
 
     // Make sure the communicator is destroyed at the end of this scope.
     Ice::CommunicatorHolder communicatorHolder{communicator};

--- a/cpp/IceDiscovery/replication/Client.cpp
+++ b/cpp/IceDiscovery/replication/Client.cpp
@@ -14,10 +14,12 @@ main(int argc, char* argv[])
 {
     // Register the IceDiscovery plugin. The plugin will be loaded during communicator initialization and will
     // install a default locator on the communicator.
-    Ice::registerIceDiscovery();
+    Ice::InitializationData initData;
+    initData.properties = Ice::createProperties(argc, argv);
+    initData.pluginFactories = {Ice::discoveryPluginFactory()};
 
     // Create an Ice communicator. We'll use this communicator to create proxies and manage outgoing connections.
-    Ice::CommunicatorPtr communicator = Ice::initialize(argc, argv);
+    Ice::CommunicatorPtr communicator = Ice::initialize(initData);
 
     // Make sure the communicator is destroyed at the end of this scope.
     Ice::CommunicatorHolder communicatorHolder{communicator};

--- a/cpp/IceDiscovery/replication/Server.cpp
+++ b/cpp/IceDiscovery/replication/Server.cpp
@@ -11,7 +11,9 @@ int
 main(int argc, char* argv[])
 {
     // Register the IceDiscovery plugin. The plugin will be loaded during communicator initialization.
-    Ice::registerIceDiscovery();
+    Ice::InitializationData initData;
+    initData.properties = Ice::createProperties(argc, argv);
+    initData.pluginFactories = {Ice::discoveryPluginFactory()};
 
     // CtrlCHandler is a helper class that handles Ctrl+C and similar signals. It must be constructed at the beginning
     // of the program, before creating an Ice communicator or starting any thread.

--- a/cpp/IceGrid/allocate/Client.cpp
+++ b/cpp/IceGrid/allocate/Client.cpp
@@ -13,10 +13,6 @@ int run(const shared_ptr<Ice::Communicator>&);
 int
 main(int argc, char* argv[])
 {
-#ifdef ICE_STATIC_LIBS
-    Ice::registerIceLocatorDiscovery();
-#endif
-
     int status = 0;
 
     try

--- a/cpp/IceGrid/icebox/Client.cpp
+++ b/cpp/IceGrid/icebox/Client.cpp
@@ -12,10 +12,6 @@ int run(const shared_ptr<Ice::Communicator>&, const string&);
 int
 main(int argc, char* argv[])
 {
-#ifdef ICE_STATIC_LIBS
-    Ice::registerIceLocatorDiscovery();
-#endif
-
     int status = 0;
 
     try

--- a/cpp/IceGrid/replication/Client.cpp
+++ b/cpp/IceGrid/replication/Client.cpp
@@ -14,10 +14,6 @@ int run(const shared_ptr<Ice::Communicator>&);
 int
 main(int argc, char* argv[])
 {
-#ifdef ICE_STATIC_LIBS
-    Ice::registerIceLocatorDiscovery();
-#endif
-
     int status = 0;
 
     try

--- a/cpp/IceGrid/replication/Server.cpp
+++ b/cpp/IceGrid/replication/Server.cpp
@@ -9,10 +9,6 @@ using namespace std;
 int
 main(int argc, char* argv[])
 {
-#ifdef ICE_STATIC_LIBS
-    Ice::registerIceLocatorDiscovery();
-#endif
-
     int status = 0;
 
     try

--- a/cpp/IceGrid/secure/Client.cpp
+++ b/cpp/IceGrid/secure/Client.cpp
@@ -13,10 +13,6 @@ int run(const shared_ptr<Ice::Communicator>&);
 int
 main(int argc, char* argv[])
 {
-#ifdef ICE_STATIC_LIBS
-    Ice::registerIceLocatorDiscovery();
-#endif
-
     int status = 0;
 
     try

--- a/cpp/IceGrid/sessionActivation/Client.cpp
+++ b/cpp/IceGrid/sessionActivation/Client.cpp
@@ -13,10 +13,6 @@ int run(const shared_ptr<Ice::Communicator>&);
 int
 main(int argc, char* argv[])
 {
-#ifdef ICE_STATIC_LIBS
-    Ice::registerIceLocatorDiscovery();
-#endif
-
     int status = 0;
 
     try

--- a/cpp/IceGrid/simple/Client.cpp
+++ b/cpp/IceGrid/simple/Client.cpp
@@ -13,10 +13,6 @@ int run(const shared_ptr<Ice::Communicator>&);
 int
 main(int argc, char* argv[])
 {
-#ifdef ICE_STATIC_LIBS
-    Ice::registerIceLocatorDiscovery();
-#endif
-
     int status = 0;
 
     try

--- a/cpp/IceStorm/clock/Publisher.cpp
+++ b/cpp/IceStorm/clock/Publisher.cpp
@@ -23,10 +23,6 @@ usage(const char* name)
 int
 main(int argc, char* argv[])
 {
-#ifdef ICE_STATIC_LIBS
-    Ice::registerIceUDP();
-#endif
-
     // CtrlCHandler is a helper class that handles Ctrl+C and similar signals. It must be constructed at the beginning
     // of the program, before creating an Ice communicator or starting any thread.
     Ice::CtrlCHandler ctrlCHandler;

--- a/cpp/IceStorm/clock/Subscriber.cpp
+++ b/cpp/IceStorm/clock/Subscriber.cpp
@@ -27,10 +27,6 @@ usage(const char* name)
 int
 main(int argc, char* argv[])
 {
-#ifdef ICE_STATIC_LIBS
-    Ice::registerIceUDP();
-#endif
-
     // CtrlCHandler is a helper class that handles Ctrl+C and similar signals. It must be constructed at the beginning
     // of the program, before creating an Ice communicator or starting any thread.
     Ice::CtrlCHandler ctrlCHandler;

--- a/cpp/IceStorm/replicated/Publisher.cpp
+++ b/cpp/IceStorm/replicated/Publisher.cpp
@@ -17,10 +17,6 @@ int run(const shared_ptr<Ice::Communicator>& communicator, int argc, char* argv[
 int
 main(int argc, char* argv[])
 {
-#ifdef ICE_STATIC_LIBS
-    Ice::registerIceUDP();
-#endif
-
     int status = 0;
 
     try

--- a/cpp/IceStorm/replicated/Subscriber.cpp
+++ b/cpp/IceStorm/replicated/Subscriber.cpp
@@ -19,10 +19,6 @@ int run(const shared_ptr<Ice::Communicator>& communicator, int argc, char* argv[
 int
 main(int argc, char* argv[])
 {
-#ifdef ICE_STATIC_LIBS
-    Ice::registerIceUDP();
-#endif
-
     int status = 0;
 
     try

--- a/cpp/IceStorm/replicated2/Publisher.cpp
+++ b/cpp/IceStorm/replicated2/Publisher.cpp
@@ -17,10 +17,6 @@ int run(const shared_ptr<Ice::Communicator>& communicator, int argc, char* argv[
 int
 main(int argc, char* argv[])
 {
-#ifdef ICE_STATIC_LIBS
-    Ice::registerIceUDP();
-#endif
-
     int status = 0;
 
     try

--- a/cpp/IceStorm/replicated2/Subscriber.cpp
+++ b/cpp/IceStorm/replicated2/Subscriber.cpp
@@ -19,10 +19,6 @@ int run(const shared_ptr<Ice::Communicator>& communicator, int argc, char* argv[
 int
 main(int argc, char* argv[])
 {
-#ifdef ICE_STATIC_LIBS
-    Ice::registerIceUDP();
-#endif
-
     int status = 0;
 
     try


### PR DESCRIPTION
This PR removes all calls to `Ice::registerXXX` and updates (where necessary) the demo use the new InitData data member. 