### PR TITLE
Oops! Adds & modifies README.md files for the Ruby Config demo

### DIFF
--- a/ruby/Ice/README.md
+++ b/ruby/Ice/README.md
@@ -6,6 +6,10 @@ Demos in this directory:
   well as how to invoke oneway operations, use datagrams, secure
   invocations, and how to use batched invocations.
 
+- [config](./config/)
+
+  The Config demo shows off how to use a config file to create a client proxy.
+
 - [latency](./latency)
 
   A simple latency test that measures the basic call dispatch delay of

--- a/ruby/Ice/config/README.md
+++ b/ruby/Ice/config/README.md
@@ -1,0 +1,20 @@
+# Config
+
+The Config demo shows off how to use a config file to create a client proxy.
+
+Ice for Ruby supports only client-side applications. As a result, you first need to start a Config server implemented
+in a language with server-side support, such as Python, Java, or C#.
+
+Then, in a separate window:
+
+- Compile Greeter.ice with the Slice to Ruby compiler into Greeter.rb
+
+```shell
+slice2rb Greeter.ice
+```
+
+- Run the client application
+
+```shell
+ruby client.rb
+```


### PR DESCRIPTION
Looks like I forgot to add `ruby/Ice/config/README.md` and adjust `./ruby/Ice/README.md` for the Config demo. This PR is intended to rectify this, included with a simple explanation of the purpose of the Config demo.