### PR TITLE
Fix namespace terminology in MATLAB

### DIFF
--- a/matlab/Glacier2/greeter/client.m
+++ b/matlab/Glacier2/greeter/client.m
@@ -1,7 +1,7 @@
 % Copyright (c) ZeroC, Inc.
 
 function client(args)
-    % The Slice module VisitorCenter maps to a MATLAB package with the same name.
+    % The Slice module VisitorCenter maps to a MATLAB namespace with the same name.
     import VisitorCenter.*
 
     if nargin == 0

--- a/matlab/Ice/config/client.m
+++ b/matlab/Ice/config/client.m
@@ -1,7 +1,7 @@
 % Copyright (c) ZeroC, Inc.
 
 function client(args)
-    % The Slice module VisitorCenter maps to a MATLAB package with the same name.
+    % The Slice module VisitorCenter maps to a MATLAB namespace with the same name.
     import VisitorCenter.*
 
     if nargin == 0

--- a/matlab/Ice/context/client.m
+++ b/matlab/Ice/context/client.m
@@ -1,7 +1,7 @@
 % Copyright (c) ZeroC, Inc.
 
 function client(args)
-   % The Slice module VisitorCenter maps to a MATLAB package with the same name.
+   % The Slice module VisitorCenter maps to a MATLAB namespace with the same name.
    import VisitorCenter.*
 
    if nargin == 0

--- a/matlab/Ice/filesystem/client.m
+++ b/matlab/Ice/filesystem/client.m
@@ -1,7 +1,7 @@
 % Copyright (c) ZeroC, Inc.
 
 function client(args)
-    % The Slice module Filesystem maps to a MATLAB package with the same name.
+    % The Slice module Filesystem maps to a MATLAB namespace with the same name.
     import Filesystem.*
 
     if nargin == 0

--- a/matlab/Ice/greeter/client.m
+++ b/matlab/Ice/greeter/client.m
@@ -1,7 +1,7 @@
 % Copyright (c) ZeroC, Inc.
 
 function client(args)
-    % The Slice module VisitorCenter maps to a MATLAB package with the same name.
+    % The Slice module VisitorCenter maps to a MATLAB namespace with the same name.
     import VisitorCenter.*
 
     if nargin == 0

--- a/matlab/Ice/invocationTimeout/client.m
+++ b/matlab/Ice/invocationTimeout/client.m
@@ -1,7 +1,7 @@
 % Copyright (c) ZeroC, Inc.
 
 function client(args)
-    % The Slice module VisitorCenter maps to a MATLAB package with the same name.
+    % The Slice module VisitorCenter maps to a MATLAB namespace with the same name.
     import VisitorCenter.*
 
     if nargin == 0

--- a/matlab/Ice/optional/client1/client.m
+++ b/matlab/Ice/optional/client1/client.m
@@ -1,7 +1,7 @@
 % Copyright (c) ZeroC, Inc.
 
 function client(args)
-    % The Slice module ClearSky in WeatherStation.ice maps a MATLAB package with the same name.
+    % The Slice module ClearSky in WeatherStation.ice maps a MATLAB namespace with the same name.
     import ClearSky.*
 
     if nargin == 0

--- a/matlab/Ice/optional/client2/client.m
+++ b/matlab/Ice/optional/client2/client.m
@@ -1,7 +1,7 @@
 % Copyright (c) ZeroC, Inc.
 
 function client(args)
-    % The Slice module ClearSky in WeatherStation.ice maps a MATLAB package with the same name.
+    % The Slice module ClearSky in WeatherStation.ice maps a MATLAB namespace with the same name.
     import ClearSky.*
 
     if nargin == 0

--- a/matlab/IceDiscovery/greeter/client.m
+++ b/matlab/IceDiscovery/greeter/client.m
@@ -1,7 +1,7 @@
 % Copyright (c) ZeroC, Inc.
 
 function client(args)
-    % The Slice module VisitorCenter maps to a MATLAB package with the same name.
+    % The Slice module VisitorCenter maps to a MATLAB namespace with the same name.
     import VisitorCenter.*
 
     if nargin == 0

--- a/matlab/IceGrid/greeter/client.m
+++ b/matlab/IceGrid/greeter/client.m
@@ -1,7 +1,7 @@
 % Copyright (c) ZeroC, Inc.
 
 function client(args)
-    % The Slice module VisitorCenter maps to a MATLAB package with the same name.
+    % The Slice module VisitorCenter maps to a MATLAB namespace with the same name.
     import VisitorCenter.*
 
     if nargin == 0

--- a/matlab/IceGrid/locatorDiscovery/client.m
+++ b/matlab/IceGrid/locatorDiscovery/client.m
@@ -1,7 +1,7 @@
 % Copyright (c) ZeroC, Inc.
 
 function client(args)
-    % The Slice module VisitorCenter maps to a MATLAB package with the same name.
+    % The Slice module VisitorCenter maps to a MATLAB namespace with the same name.
     import VisitorCenter.*
 
     if nargin == 0

--- a/matlab/IceStorm/weather/sensor.m
+++ b/matlab/IceStorm/weather/sensor.m
@@ -1,7 +1,7 @@
 % Copyright (c) ZeroC, Inc.
 
 function sensor(args)
-    % The Slice module ClearSky in WeatherStation.ice maps a MATLAB package with the same name.
+    % The Slice module ClearSky in WeatherStation.ice maps a MATLAB namespace with the same name.
     import ClearSky.*
 
     if nargin == 0


### PR DESCRIPTION
MATLAB uses the term namespace since R2024a:

> The MATLAB language feature known as a package is now called a namespace. Namespaces are used to organize code, and in MATLAB, they are defined by folders that begin with a + symbol. As of R2024a, the terminology is updated in both the documentation and software. The behavior remains the same.

See for example https://www.mathworks.com/help/matlab/ref/import.html.

Note that the syntax import Namesspace.* is actually discouraged. We should only import select classes, like GreeterPrx.

