### PR TITLE
Update MATLAB demos to use lowercase namespace + no import

### DIFF
--- a/matlab/Glacier2/greeter/Greeter.ice
+++ b/matlab/Glacier2/greeter/Greeter.ice
@@ -2,6 +2,7 @@
 
 #pragma once
 
+["matlab:identifier:visitorcenter"]
 module VisitorCenter
 {
     /// Represents a simple greeter.

--- a/matlab/Glacier2/greeter/client.m
+++ b/matlab/Glacier2/greeter/client.m
@@ -1,9 +1,6 @@
 % Copyright (c) ZeroC, Inc.
 
 function client(args)
-    % The Slice module VisitorCenter maps to a MATLAB namespace with the same name.
-    import VisitorCenter.*
-
     if nargin == 0
         args = {};
     end
@@ -36,7 +33,7 @@ function client(args)
 
     % Create a proxy to the Greeter object in the server behind the Glacier2 router. Typically, the client cannot
     % connect directly to this server because it's on an unreachable network.
-    greeter = VisitorCenter.GreeterPrx(communicator, 'greeter:tcp -h localhost -p 4061');
+    greeter = visitorcenter.GreeterPrx(communicator, 'greeter:tcp -h localhost -p 4061');
 
     % Configure the proxy to route requests using the Glacier2 router.
     greeter = greeter.ice_router(router);

--- a/matlab/Ice/config/Greeter.ice
+++ b/matlab/Ice/config/Greeter.ice
@@ -2,6 +2,7 @@
 
 #pragma once
 
+["matlab:identifier:visitorcenter"]
 module VisitorCenter
 {
     /// Represents a simple greeter.

--- a/matlab/Ice/config/client.m
+++ b/matlab/Ice/config/client.m
@@ -1,9 +1,6 @@
 % Copyright (c) ZeroC, Inc.
 
 function client(args)
-    % The Slice module VisitorCenter maps to a MATLAB namespace with the same name.
-    import VisitorCenter.*
-
     if nargin == 0
         args = {};
     end
@@ -23,7 +20,7 @@ function client(args)
 
     % We create a Greeter proxy using the value of the Greeter.Proxy property in config.client.
     % It's null if the property is not set.
-    greeter = GreeterPrx.uncheckedCast(communicator.propertyToProxy('Greeter.Proxy'));
+    greeter = visitorcenter.GreeterPrx.uncheckedCast(communicator.propertyToProxy('Greeter.Proxy'));
 
     % Send a request to the remote object and get the response.
     greeting = greeter.greet(char(java.lang.System.getProperty('user.name')));

--- a/matlab/Ice/context/Greeter.ice
+++ b/matlab/Ice/context/Greeter.ice
@@ -2,6 +2,7 @@
 
 #pragma once
 
+["matlab:identifier:visitorcenter"]
 module VisitorCenter
 {
     /// Represents a simple greeter.

--- a/matlab/Ice/context/client.m
+++ b/matlab/Ice/context/client.m
@@ -1,11 +1,8 @@
 % Copyright (c) ZeroC, Inc.
 
 function client(args)
-   % The Slice module VisitorCenter maps to a MATLAB namespace with the same name.
-   import VisitorCenter.*
-
    if nargin == 0
-       args = {};
+        args = {};
    end
 
     % Load the Ice library if it is not already loaded.
@@ -29,7 +26,7 @@ function client(args)
     % "stringified proxy" with the address of the target object.
     % If you run the server on a different computer, replace localhost in the string below with the server's hostname
     % or IP address.
-    greeter = VisitorCenter.GreeterPrx(communicator, 'greeter:tcp -h localhost -p 4061');
+    greeter = visitorcenter.GreeterPrx(communicator, 'greeter:tcp -h localhost -p 4061');
 
     % Create a request context.
     context = containers.Map('KeyType', 'char', 'ValueType', 'char');

--- a/matlab/Ice/context/client.m
+++ b/matlab/Ice/context/client.m
@@ -1,9 +1,9 @@
 % Copyright (c) ZeroC, Inc.
 
 function client(args)
-   if nargin == 0
+    if nargin == 0
         args = {};
-   end
+    end
 
     % Load the Ice library if it is not already loaded.
     if ~libisloaded('ice')

--- a/matlab/Ice/filesystem/Filesystem.ice
+++ b/matlab/Ice/filesystem/Filesystem.ice
@@ -2,6 +2,7 @@
 
 #pragma once
 
+["matlab:identifier:filesystem"]
 module Filesystem
 {
     /// Represents a write failure.

--- a/matlab/Ice/filesystem/client.m
+++ b/matlab/Ice/filesystem/client.m
@@ -1,9 +1,6 @@
 % Copyright (c) ZeroC, Inc.
 
 function client(args)
-    % The Slice module Filesystem maps to a MATLAB namespace with the same name.
-    import Filesystem.*
-
     if nargin == 0
         args = {};
     end
@@ -20,7 +17,7 @@ function client(args)
     cleanup = onCleanup(@() communicator.destroy());
 
     % Create a proxy for the root directory.
-    rootDir = DirectoryPrx(communicator, 'RootDir:tcp -h localhost -p 4061');
+    rootDir = filesystem.DirectoryPrx(communicator, 'RootDir:tcp -h localhost -p 4061');
 
     % Recursively list the contents of the root directory
     fprintf("Contents of root directory:\n");
@@ -42,7 +39,7 @@ function listRecursive(dir, depth)
         assert(~isempty(node), 'Node is empty!'); % The node proxies returned by list() are never null.
 
         % Check if this node is a directory by asking the remote object.
-        subdir = Filesystem.DirectoryPrx.checkedCast(node);
+        subdir = filesystem.DirectoryPrx.checkedCast(node);
 
         kind = '(directory)';
         if(isempty(subdir))
@@ -56,7 +53,7 @@ function listRecursive(dir, depth)
             listRecursive(subdir, depth);
         else
             % Read and print the contents of the file.
-            file = Filesystem.FilePrx.uncheckedCast(node);
+            file = filesystem.FilePrx.uncheckedCast(node);
             lines = file.read();
             for j = lines
                 fprintf('%s\t%s\n', indent, j{1});

--- a/matlab/Ice/greeter/Greeter.ice
+++ b/matlab/Ice/greeter/Greeter.ice
@@ -2,6 +2,9 @@
 
 #pragma once
 
+// We use matlab:identifier to get a lowercase namespace in MATLAB; without this metadata directive, the mapped
+// namespace is VisitorCenter.
+["matlab:identifier:visitorcenter"]
 module VisitorCenter
 {
     /// Represents a simple greeter.

--- a/matlab/Ice/greeter/Greeter.ice
+++ b/matlab/Ice/greeter/Greeter.ice
@@ -3,7 +3,7 @@
 #pragma once
 
 // We use matlab:identifier to get a lowercase namespace in MATLAB; without this metadata directive, the mapped
-// namespace is VisitorCenter.
+// namespace would be VisitorCenter.
 ["matlab:identifier:visitorcenter"]
 module VisitorCenter
 {

--- a/matlab/Ice/greeter/client.m
+++ b/matlab/Ice/greeter/client.m
@@ -1,9 +1,6 @@
 % Copyright (c) ZeroC, Inc.
 
 function client(args)
-    % The Slice module VisitorCenter maps to a MATLAB namespace with the same name.
-    import VisitorCenter.*
-
     if nargin == 0
         args = {};
     end
@@ -23,7 +20,7 @@ function client(args)
     % "stringified proxy" with the address of the target object.
     % If you run the server on a different computer, replace localhost in the string below with the server's hostname
     % or IP address.
-    greeter = VisitorCenter.GreeterPrx(communicator, 'greeter:tcp -h localhost -p 4061');
+    greeter = visitorcenter.GreeterPrx(communicator, 'greeter:tcp -h localhost -p 4061');
 
     % Send a request to the remote object and wait synchronously for the response.
     greeting = greeter.greet(char(java.lang.System.getProperty('user.name')));

--- a/matlab/Ice/invocationTimeout/Greeter.ice
+++ b/matlab/Ice/invocationTimeout/Greeter.ice
@@ -2,6 +2,7 @@
 
 #pragma once
 
+["matlab:identifier:visitorcenter"]
 module VisitorCenter
 {
     /// Represents a simple greeter.

--- a/matlab/Ice/invocationTimeout/client.m
+++ b/matlab/Ice/invocationTimeout/client.m
@@ -1,9 +1,6 @@
 % Copyright (c) ZeroC, Inc.
 
 function client(args)
-    % The Slice module VisitorCenter maps to a MATLAB namespace with the same name.
-    import VisitorCenter.*
-
     if nargin == 0
         args = {};
     end
@@ -23,11 +20,11 @@ function client(args)
     % "stringified proxy" with the address of the target object.
     % If you run the server on a different computer, replace localhost in the string below with the server's hostname
     % or IP address.
-    greeter = VisitorCenter.GreeterPrx(communicator, 'greeter:tcp -h localhost -p 4061');
+    greeter = visitorcenter.GreeterPrx(communicator, 'greeter:tcp -h localhost -p 4061');
 
     % Create a proxy to the slow greeter with an invocation timeout of 4 seconds (the default invocation timeout is
     % infinite).
-    slowGreeter = VisitorCenter.GreeterPrx(communicator, 'slowGreeter:tcp -h localhost -p 4061');
+    slowGreeter = visitorcenter.GreeterPrx(communicator, 'slowGreeter:tcp -h localhost -p 4061');
     slowGreeter = slowGreeter.ice_invocationTimeout(4000);
 
     % Send a request to the regular greeter and get the response.

--- a/matlab/Ice/optional/client1/WeatherStation.ice
+++ b/matlab/Ice/optional/client1/WeatherStation.ice
@@ -4,6 +4,7 @@
 
 // Version 1 of the WeatherStation Slice definitions.
 
+["matlab:identifier:clearsky"]
 module ClearSky
 {
     /// Represents the atmospheric conditions measured by a sensor.

--- a/matlab/Ice/optional/client1/client.m
+++ b/matlab/Ice/optional/client1/client.m
@@ -1,9 +1,6 @@
 % Copyright (c) ZeroC, Inc.
 
 function client(args)
-    % The Slice module ClearSky in WeatherStation.ice maps a MATLAB namespace with the same name.
-    import ClearSky.*
-
     if nargin == 0
         args = {};
     end
@@ -20,13 +17,13 @@ function client(args)
     cleanup = onCleanup(@() communicator.destroy());
 
     % Create a proxy to the weather station.
-    weatherStation = WeatherStationPrx(communicator, 'weatherStation:tcp -h localhost -p 4061');
+    weatherStation = clearsky.WeatherStationPrx(communicator, 'weatherStation:tcp -h localhost -p 4061');
 
     % Create an AtmosphericConditions object with random values.
     temperature = randi([190, 230]) / 10; % Temperature in degrees Celsius (19.0 to 23.0).
     humidity = randi([450, 550]) / 10; % Humidity in percentage (45.0 to 55.0).
 
-    reading = AtmosphericConditions(temperature, humidity);
+    reading = clearsky.AtmosphericConditions(temperature, humidity);
 
     % Report this reading to the weather station.
     weatherStation.report('sensor-1', reading);

--- a/matlab/Ice/optional/client2/WeatherStation.ice
+++ b/matlab/Ice/optional/client2/WeatherStation.ice
@@ -4,6 +4,7 @@
 
 // Version 2 of the WeatherStation Slice definitions: we added a new optional pressure to AtmosphericConditions.
 
+["matlab:identifier:clearsky"]
 module ClearSky
 {
     /// Represents the atmospheric conditions measured by a sensor.

--- a/matlab/Ice/optional/client2/client.m
+++ b/matlab/Ice/optional/client2/client.m
@@ -1,9 +1,6 @@
 % Copyright (c) ZeroC, Inc.
 
 function client(args)
-    % The Slice module ClearSky in WeatherStation.ice maps a MATLAB namespace with the same name.
-    import ClearSky.*
-
     if nargin == 0
         args = {};
     end
@@ -20,14 +17,14 @@ function client(args)
     cleanup = onCleanup(@() communicator.destroy());
 
     % Create a proxy to the weather station.
-    weatherStation = WeatherStationPrx(communicator, 'weatherStation:tcp -h localhost -p 4061');
+    weatherStation = clearsky.WeatherStationPrx(communicator, 'weatherStation:tcp -h localhost -p 4061');
 
     % Create an AtmosphericConditions object with random values.
     temperature = randi([190, 230]) / 10; % Temperature in degrees Celsius (19.0 to 23.0).
     humidity = randi([450, 550]) / 10; % Humidity in percentage (45.0 to 55.0).
     pressure = randi([10000, 10500]) / 10; % Pressure in millibars (1,000 to 1,050).
 
-    reading = AtmosphericConditions(temperature, humidity, pressure);
+    reading = clearsky.AtmosphericConditions(temperature, humidity, pressure);
 
     % Report this reading to the weather station.
     weatherStation.report('sensor-2', reading);

--- a/matlab/IceDiscovery/greeter/Greeter.ice
+++ b/matlab/IceDiscovery/greeter/Greeter.ice
@@ -2,6 +2,7 @@
 
 #pragma once
 
+["matlab:identifier:visitorcenter"]
 module VisitorCenter
 {
     /// Represents a simple greeter.

--- a/matlab/IceDiscovery/greeter/client.m
+++ b/matlab/IceDiscovery/greeter/client.m
@@ -1,9 +1,6 @@
 % Copyright (c) ZeroC, Inc.
 
 function client(args)
-    % The Slice module VisitorCenter maps to a MATLAB namespace with the same name.
-    import VisitorCenter.*
-
     if nargin == 0
         args = {};
     end
@@ -28,7 +25,7 @@ function client(args)
     % Create a proxy to the Greeter object hosted by the server(s). 'greeter' is a stringified proxy with no addressing
     % information, also known as a well-known proxy. It's resolved by the default locator installed by the IceDiscovery
     % plugin.
-    greeter = GreeterPrx(communicator, 'greeter');
+    greeter = visitorcenter.GreeterPrx(communicator, 'greeter');
 
     % Send a request to the remote object and wait for the response.
     greeting = greeter.greet(char(java.lang.System.getProperty('user.name')));

--- a/matlab/IceGrid/greeter/Greeter.ice
+++ b/matlab/IceGrid/greeter/Greeter.ice
@@ -2,6 +2,7 @@
 
 #pragma once
 
+["matlab:identifier:visitorcenter"]
 module VisitorCenter
 {
     /// Represents a simple greeter.

--- a/matlab/IceGrid/greeter/client.m
+++ b/matlab/IceGrid/greeter/client.m
@@ -1,9 +1,6 @@
 % Copyright (c) ZeroC, Inc.
 
 function client(args)
-    % The Slice module VisitorCenter maps to a MATLAB namespace with the same name.
-    import VisitorCenter.*
-
     if nargin == 0
         args = {};
     end
@@ -27,7 +24,7 @@ function client(args)
     % information, also known as a well-known proxy. It's specified by the <object> element in the IceGrid XML file.
     % The IceGrid registry resolves this well-known proxy and returns the actual address (endpoint) of the server to
     % this client.
-    greeter = VisitorCenter.GreeterPrx(communicator, 'greeter');
+    greeter = visitorcenter.GreeterPrx(communicator, 'greeter');
 
     % Send a request to the remote object and get the response.
     greeting = greeter.greet(char(java.lang.System.getProperty('user.name')));

--- a/matlab/IceGrid/locatorDiscovery/Greeter.ice
+++ b/matlab/IceGrid/locatorDiscovery/Greeter.ice
@@ -2,6 +2,7 @@
 
 #pragma once
 
+["matlab:identifier:visitorcenter"]
 module VisitorCenter
 {
     /// Represents a simple greeter.

--- a/matlab/IceGrid/locatorDiscovery/client.m
+++ b/matlab/IceGrid/locatorDiscovery/client.m
@@ -1,9 +1,6 @@
 % Copyright (c) ZeroC, Inc.
 
 function client(args)
-    % The Slice module VisitorCenter maps to a MATLAB namespace with the same name.
-    import VisitorCenter.*
-
     if nargin == 0
         args = {};
     end
@@ -30,7 +27,7 @@ function client(args)
     % information, also known as a well-known proxy. It's specified by the <object> element in the IceGrid XML file.
     % The IceGrid registry resolves this well-known proxy and returns the actual address (endpoint) of the server to
     % this client.
-    greeter = VisitorCenter.GreeterPrx(communicator, 'greeter');
+    greeter = visitorcenter.GreeterPrx(communicator, 'greeter');
 
     % Send a request to the remote object and get the response.
     greeting = greeter.greet(char(java.lang.System.getProperty('user.name')));

--- a/matlab/IceStorm/weather/WeatherStation.ice
+++ b/matlab/IceStorm/weather/WeatherStation.ice
@@ -2,6 +2,7 @@
 
 #pragma once
 
+["matlab:identifier:clearsky"]
 module ClearSky
 {
     /// Represents the atmospheric conditions measured by a sensor.

--- a/matlab/IceStorm/weather/sensor.m
+++ b/matlab/IceStorm/weather/sensor.m
@@ -1,9 +1,6 @@
 % Copyright (c) ZeroC, Inc.
 
 function sensor(args)
-    % The Slice module ClearSky in WeatherStation.ice maps a MATLAB namespace with the same name.
-    import ClearSky.*
-
     if nargin == 0
         args = {};
     end
@@ -41,7 +38,7 @@ function sensor(args)
 
     % Create a WeatherStation proxy using the publisher proxy of the topic. The proxy returned by getPublisher is
     % never null.
-    weatherStation = WeatherStationPrx.uncheckedCast(topic.getPublisher());
+    weatherStation = clearsky.WeatherStationPrx.uncheckedCast(topic.getPublisher());
 
     % The proxy returned by IceStorm is a two-way proxy. We can convert it into a one-way proxy if we don't need
     % acknowledgments from IceStorm.
@@ -59,7 +56,7 @@ function sensor(args)
         humidity = randi([450, 550]) / 10; % Humidity in percentage (45.0 to 55.0).
 
         % Create an AtmosphericConditions object with the generated values.
-        reading = AtmosphericConditions(temperature, humidity);
+        reading = clearsky.AtmosphericConditions(temperature, humidity);
 
         % Send the reading to the weather station(s) via IceStorm.
         timeStamp = datetime('now', 'Format', 'HH:mm:ss');


### PR DESCRIPTION
No MATLAB demo shows unmarshaling class or exception instance, and as a result, no demo needs a SliceLoader to deal with the new namespace.