### PR TITLE
Remove Disp from Swift greeter and filesystem

### DIFF
--- a/swift/Ice/filesystem/README.md
+++ b/swift/Ice/filesystem/README.md
@@ -1,6 +1,12 @@
 # Ice Filesystem
 
-This demo implements the filesystem application shown in the Ice manual.
+This demo shows the power of interface inheritance in Slice. In particular, it demonstrates how a derived servant class
+can inherit from a base servant class to reuse the Slice interface implementation provided by this base servant.
+
+> [!NOTE]
+> In Ice for C++, Java, JavaScript, and Python, reusing a base servant in a derived servant doesn't require extra
+> coding: it's completely automatic. In Swift, you need to define and implement the `dispatch` method as shown in
+> [MNode.swift][1], [MFile.swift][2], and [MDirectory.swift][3].
 
 You can build the client and server applications with:
 
@@ -19,3 +25,7 @@ Then, in a separate terminal, start the Client program with:
 ```shell
 swift run Client
 ```
+
+[1]: Sources/Server/MNode.swift
+[2]: Sources/Server/MFile.swift
+[3]: Sources/Server/MDirectory.swift

--- a/swift/Ice/filesystem/Sources/Server/MDirectory.swift
+++ b/swift/Ice/filesystem/Sources/Server/MDirectory.swift
@@ -16,4 +16,11 @@ final class MDirectory: MNode, Directory {
     func addChild(_ child: NodePrx) {
         contents.append(child)
     }
+
+    // Since we define a `dispatch` method in MNode, we need to override it here. Otherwise, we'd use the base class
+    // `dispatch`, not the one provided by generated Directory protocol extension.
+    override func dispatch(_ request: Ice.IncomingRequest) async throws -> Ice.OutgoingResponse {
+        // We implement dispatch by reusing the implementation provided by the generated Directory protocol extension.
+        try await Self.dispatch(self, request: request)
+    }
 }

--- a/swift/Ice/filesystem/Sources/Server/MFile.swift
+++ b/swift/Ice/filesystem/Sources/Server/MFile.swift
@@ -21,4 +21,11 @@ final class MFile: MNode, File {
     func writeDirect(text: [String]) {
         lines = text
     }
+
+    // Since we define a `dispatch` method in MNode, we need to override it here. Otherwise, we'd use the base class
+    // `dispatch`, not the one provided by the generated File protocol extension.
+    override func dispatch(_ request: Ice.IncomingRequest) async throws -> Ice.OutgoingResponse {
+        // We implement dispatch by reusing the implementation provided by the generated File protocol extension.
+        try await Self.dispatch(self, request: request)
+    }
 }

--- a/swift/Ice/filesystem/Sources/Server/MNode.swift
+++ b/swift/Ice/filesystem/Sources/Server/MNode.swift
@@ -3,6 +3,7 @@
 import Ice
 
 /// Provides an in-memory implementation of the Slice interface Node.
+// MNode conforms to the generated Node protocol, which inherits from the Ice.Dispatcher protocol.
 class MNode: Node {
     private let name: String
 
@@ -13,5 +14,13 @@ class MNode: Node {
     // Implements Node.name.
     func name(current _: Ice.Current) -> String {
         return name
+    }
+
+    // Since we want to reuse this servant class (MNode) in derived servant classes, we need to define an overridable
+    // `dispatch` method. The default `dispatch` method provided by the generated Node protocol extension is not
+    // overridable. See https://github.com/swiftlang/swift/issues/42725.
+    func dispatch(_ request: Ice.IncomingRequest) async throws -> Ice.OutgoingResponse {
+        // We implement dispatch by reusing the implementation provided by the generated Node protocol extension.
+        try await Self.dispatch(self, request: request)
     }
 }

--- a/swift/Ice/filesystem/Sources/Server/main.swift
+++ b/swift/Ice/filesystem/Sources/Server/main.swift
@@ -21,18 +21,18 @@ let adapter = try communicator.createObjectAdapterWithEndpoints(
 
 // Create the root directory servant (with name "/"), and add this servant to the adapter.
 let root = MDirectory(name: "/")
-try adapter.add(servant: DirectoryDisp(root), id: Ice.Identity(name: "RootDir"))
+try adapter.add(servant: root, id: Ice.Identity(name: "RootDir"))
 
 // Create a file called "README", add this servant to the adapter, and add the corresponding proxy to the root
 // directory.
 let readme = MFile(name: "README")
 readme.writeDirect(text: ["This file system contains a collection of poetry."])
-try root.addChild(uncheckedCast(prx: adapter.addWithUUID(FileDisp(readme)), type: FilePrx.self))
+try root.addChild(uncheckedCast(prx: adapter.addWithUUID(readme), type: FilePrx.self))
 
 // Create a directory called "Coleridge", add this servant to the adapter, and add the corresponding proxy to the
 // root directory.
 let coleridge = MDirectory(name: "Coleridge")
-try root.addChild(uncheckedCast(prx: adapter.addWithUUID(DirectoryDisp(coleridge)), type: DirectoryPrx.self))
+try root.addChild(uncheckedCast(prx: adapter.addWithUUID(coleridge), type: DirectoryPrx.self))
 
 // Create a file called "Kubla_Khan", add this servant to the adapter, and add the corresponding proxy to the
 // Coleridge directory.
@@ -44,7 +44,7 @@ kublaKhan.writeDirect(text: [
     "Through caverns measureless to man",
     "Down to a sunless sea."
 ])
-try coleridge.addChild(uncheckedCast(prx: adapter.addWithUUID(FileDisp(kublaKhan)), type: FilePrx.self))
+try coleridge.addChild(uncheckedCast(prx: adapter.addWithUUID(kublaKhan), type: FilePrx.self))
 
 // Start dispatching requests after registering all servants.
 try adapter.activate()

--- a/swift/Ice/greeter/Sources/Server/main.swift
+++ b/swift/Ice/greeter/Sources/Server/main.swift
@@ -20,7 +20,7 @@ let adapter = try communicator.createObjectAdapterWithEndpoints(
     name: "GreeterAdapter", endpoints: "tcp -p 4061")
 
 // Register the Chatbot servant with the adapter.
-try adapter.add(servant: GreeterDisp(Chatbot()), id: Ice.Identity(name: "greeter"))
+try adapter.add(servant: Chatbot(), id: Ice.Identity(name: "greeter"))
 
 // Start dispatching requests.
 try adapter.activate()

--- a/swift/Ice/greeter/Sources/ServerAMD/main.swift
+++ b/swift/Ice/greeter/Sources/ServerAMD/main.swift
@@ -20,7 +20,7 @@ let adapter = try communicator.createObjectAdapterWithEndpoints(
     name: "GreeterAdapter", endpoints: "tcp -p 4061")
 
 // Register the Chatbot servant with the adapter.
-try adapter.add(servant: GreeterDisp(Chatbot()), id: Ice.Identity(name: "greeter"))
+try adapter.add(servant: Chatbot(), id: Ice.Identity(name: "greeter"))
 
 // Start dispatching requests.
 try adapter.activate()


### PR DESCRIPTION
It affects mostly the filesystem demo. This demo now requires extra work since it showcases implementation reuse.