### PR TITLE
Fix timeStamp display in C++ demos

### DIFF
--- a/cpp/Glacier2/callback/SimpleWakeUpService.cpp
+++ b/cpp/Glacier2/callback/SimpleWakeUpService.cpp
@@ -33,7 +33,7 @@ Server::SimpleWakeUpService::wakeMeUp(optional<AlarmClockPrx> alarmClock, int64_
     chrono::system_clock::time_point timePoint = Time::toTimePoint(timeStamp);
 
     cout << "Dispatching wakeMeUp request { alarmClock = '" << alarmClock << "', timeStamp = '"
-        << Time::formatTime(timePoint) << "' }" << endl;
+         << Time::formatTime(timePoint) << "' }" << endl;
 
     // Schedule a wake-up call in a background task.
     _tasks.emplace_back(std::async(

--- a/cpp/Glacier2/callback/SimpleWakeUpService.cpp
+++ b/cpp/Glacier2/callback/SimpleWakeUpService.cpp
@@ -29,10 +29,11 @@ Server::SimpleWakeUpService::wakeMeUp(optional<AlarmClockPrx> alarmClock, int64_
         throw std::invalid_argument{"alarmClock is null"};
     }
 
-    cout << "Dispatching wakeMeUp request { alarmClock = '" << alarmClock << "', timeStamp = " << timeStamp
-         << " ticks }" << endl;
-
+    // Convert the time stamp to a time point.
     chrono::system_clock::time_point timePoint = Time::toTimePoint(timeStamp);
+
+    cout << "Dispatching wakeMeUp request { alarmClock = '" << alarmClock << "', timeStamp = '"
+        << Time::formatTime(timePoint) << "' }" << endl;
 
     // Schedule a wake-up call in a background task.
     _tasks.emplace_back(std::async(

--- a/cpp/Ice/bidir/BidirWakeUpService.cpp
+++ b/cpp/Ice/bidir/BidirWakeUpService.cpp
@@ -23,9 +23,10 @@ Server::BidirWakeUpService::~BidirWakeUpService()
 void
 Server::BidirWakeUpService::wakeMeUp(int64_t timeStamp, const Ice::Current& current)
 {
-    cout << "Dispatching wakeMeUp request { timeStamp = " << timeStamp << " ticks }" << endl;
-
+    // Convert the time stamp to a time point.
     chrono::system_clock::time_point timePoint = Time::toTimePoint(timeStamp);
+
+    cout << "Dispatching wakeMeUp request { timeStamp = '" << Time::formatTime(timePoint) << "' }" << endl;
 
     Ice::ConnectionPtr connection = current.con; // The connection from the client to the server.
     if (!connection)

--- a/cpp/Ice/callback/SimpleWakeUpService.cpp
+++ b/cpp/Ice/callback/SimpleWakeUpService.cpp
@@ -33,7 +33,7 @@ Server::SimpleWakeUpService::wakeMeUp(optional<AlarmClockPrx> alarmClock, int64_
     chrono::system_clock::time_point timePoint = Time::toTimePoint(timeStamp);
 
     cout << "Dispatching wakeMeUp request { alarmClock = '" << alarmClock << "', timeStamp = '"
-        << Time::formatTime(timePoint) << "' }" << endl;
+         << Time::formatTime(timePoint) << "' }" << endl;
 
     // Schedule a wake-up call in a background task.
     _tasks.emplace_back(std::async(

--- a/cpp/Ice/callback/SimpleWakeUpService.cpp
+++ b/cpp/Ice/callback/SimpleWakeUpService.cpp
@@ -29,10 +29,11 @@ Server::SimpleWakeUpService::wakeMeUp(optional<AlarmClockPrx> alarmClock, int64_
         throw std::invalid_argument{"alarmClock is null"};
     }
 
-    cout << "Dispatching wakeMeUp request { alarmClock = '" << alarmClock << "', timeStamp = " << timeStamp
-         << " ticks }" << endl;
-
+    // Convert the time stamp to a time point.
     chrono::system_clock::time_point timePoint = Time::toTimePoint(timeStamp);
+
+    cout << "Dispatching wakeMeUp request { alarmClock = '" << alarmClock << "', timeStamp = '"
+        << Time::formatTime(timePoint) << "' }" << endl;
 
     // Schedule a wake-up call in a background task.
     _tasks.emplace_back(std::async(


### PR DESCRIPTION
We should always display the timeStamp in a format the user can understand.