### PR TITLE
Use maven central snapshots

### DIFF
--- a/java/Glacier2/greeter/settings.gradle.kts
+++ b/java/Glacier2/greeter/settings.gradle.kts
@@ -3,7 +3,7 @@
 pluginManagement {
     repositories {
         mavenLocal()
-        maven("https://download.zeroc.com/nexus/repository/maven-nightly/")
+        maven("https://central.sonatype.com/repository/maven-snapshots/")
         gradlePluginPortal() // Keep this to allow fetching other plugins
     }
 }
@@ -11,7 +11,7 @@ pluginManagement {
 dependencyResolutionManagement {
     repositories {
         // This demo uses the latest Ice nightly build published in ZeroC's maven-nightly repository.
-        maven("https://download.zeroc.com/nexus/repository/maven-nightly/")
+        maven("https://central.sonatype.com/repository/maven-snapshots/")
         mavenCentral()
     }
 }

--- a/java/Ice/android-greeter/settings.gradle.kts
+++ b/java/Ice/android-greeter/settings.gradle.kts
@@ -7,7 +7,7 @@ pluginManagement {
                 includeGroupByRegex("androidx.*")
             }
         }
-        maven("https://download.zeroc.com/nexus/repository/maven-nightly/")
+        maven("https://central.sonatype.com/repository/maven-snapshots/")
         mavenCentral()
         gradlePluginPortal()
     }
@@ -16,7 +16,7 @@ dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
         // This demo uses the latest Ice nightly build published in ZeroC's maven-nightly repository.
-        maven("https://download.zeroc.com/nexus/repository/maven-nightly/")
+        maven("https://central.sonatype.com/repository/maven-snapshots/")
         google()
         mavenCentral()
     }

--- a/java/Ice/cancellation/settings.gradle.kts
+++ b/java/Ice/cancellation/settings.gradle.kts
@@ -3,7 +3,7 @@
 pluginManagement {
     repositories {
         mavenLocal()
-        maven("https://download.zeroc.com/nexus/repository/maven-nightly/")
+        maven("https://central.sonatype.com/repository/maven-snapshots/")
         gradlePluginPortal() // Keep this to allow fetching other plugins
     }
 }
@@ -11,7 +11,7 @@ pluginManagement {
 dependencyResolutionManagement {
     repositories {
         // This demo uses the latest Ice nightly build published in ZeroC's maven-nightly repository.
-        maven("https://download.zeroc.com/nexus/repository/maven-nightly/")
+        maven("https://central.sonatype.com/repository/maven-snapshots/")
         mavenCentral()
     }
 }

--- a/java/Ice/config/settings.gradle.kts
+++ b/java/Ice/config/settings.gradle.kts
@@ -3,7 +3,7 @@
 pluginManagement {
     repositories {
         mavenLocal()
-        maven("https://download.zeroc.com/nexus/repository/maven-nightly/")
+        maven("https://central.sonatype.com/repository/maven-snapshots/")
         gradlePluginPortal() // Keep this to allow fetching other plugins
     }
 }
@@ -11,7 +11,7 @@ pluginManagement {
 dependencyResolutionManagement {
     repositories {
         // This demo uses the latest Ice nightly build published in ZeroC's maven-nightly repository.
-        maven("https://download.zeroc.com/nexus/repository/maven-nightly/")
+        maven("https://central.sonatype.com/repository/maven-snapshots/")
         mavenCentral()
     }
 }

--- a/java/Ice/context/settings.gradle.kts
+++ b/java/Ice/context/settings.gradle.kts
@@ -3,7 +3,7 @@
 pluginManagement {
     repositories {
         mavenLocal()
-        maven("https://download.zeroc.com/nexus/repository/maven-nightly/")
+        maven("https://central.sonatype.com/repository/maven-snapshots/")
         gradlePluginPortal() // Keep this to allow fetching other plugins
     }
 }
@@ -11,7 +11,7 @@ pluginManagement {
 dependencyResolutionManagement {
     repositories {
         // This demo uses the latest Ice nightly build published in ZeroC's maven-nightly repository.
-        maven("https://download.zeroc.com/nexus/repository/maven-nightly/")
+        maven("https://central.sonatype.com/repository/maven-snapshots/")
         mavenCentral()
     }
 }

--- a/java/Ice/customError/settings.gradle.kts
+++ b/java/Ice/customError/settings.gradle.kts
@@ -3,7 +3,7 @@
 pluginManagement {
     repositories {
         mavenLocal()
-        maven("https://download.zeroc.com/nexus/repository/maven-nightly/")
+        maven("https://central.sonatype.com/repository/maven-snapshots/")
         gradlePluginPortal() // Keep this to allow fetching other plugins
     }
 }
@@ -11,7 +11,7 @@ pluginManagement {
 dependencyResolutionManagement {
     repositories {
         // This demo uses the latest Ice nightly build published in ZeroC's maven-nightly repository.
-        maven("https://download.zeroc.com/nexus/repository/maven-nightly/")
+        maven("https://central.sonatype.com/repository/maven-snapshots/")
         mavenCentral()
     }
 }

--- a/java/Ice/forwarder/settings.gradle.kts
+++ b/java/Ice/forwarder/settings.gradle.kts
@@ -3,7 +3,7 @@
 pluginManagement {
     repositories {
         mavenLocal()
-        maven("https://download.zeroc.com/nexus/repository/maven-nightly/")
+        maven("https://central.sonatype.com/repository/maven-snapshots/")
         gradlePluginPortal() // Keep this to allow fetching other plugins
     }
 }
@@ -11,7 +11,7 @@ pluginManagement {
 dependencyResolutionManagement {
     repositories {
         // This demo uses the latest Ice nightly build published in ZeroC's maven-nightly repository.
-        maven("https://download.zeroc.com/nexus/repository/maven-nightly/")
+        maven("https://central.sonatype.com/repository/maven-snapshots/")
         mavenCentral()
     }
 }

--- a/java/Ice/greeter/settings.gradle.kts
+++ b/java/Ice/greeter/settings.gradle.kts
@@ -3,7 +3,7 @@
 pluginManagement {
     repositories {
         mavenLocal()
-        maven("https://download.zeroc.com/nexus/repository/maven-nightly/")
+        maven("https://central.sonatype.com/repository/maven-snapshots/")
         gradlePluginPortal() // Keep this to allow fetching other plugins
     }
 }
@@ -11,7 +11,7 @@ pluginManagement {
 dependencyResolutionManagement {
     repositories {
         // This demo uses the latest Ice nightly build published in ZeroC's maven-nightly repository.
-        maven("https://download.zeroc.com/nexus/repository/maven-nightly/")
+        maven("https://central.sonatype.com/repository/maven-snapshots/")
         mavenCentral()
     }
 }

--- a/java/Ice/middleware/settings.gradle.kts
+++ b/java/Ice/middleware/settings.gradle.kts
@@ -3,7 +3,7 @@
 pluginManagement {
     repositories {
         mavenLocal()
-        maven("https://download.zeroc.com/nexus/repository/maven-nightly/")
+        maven("https://central.sonatype.com/repository/maven-snapshots/")
         gradlePluginPortal() // Keep this to allow fetching other plugins
     }
 }
@@ -11,7 +11,7 @@ pluginManagement {
 dependencyResolutionManagement {
     repositories {
         // This demo uses the latest Ice nightly build published in ZeroC's maven-nightly repository.
-        maven("https://download.zeroc.com/nexus/repository/maven-nightly/")
+        maven("https://central.sonatype.com/repository/maven-snapshots/")
         mavenCentral()
     }
 }

--- a/java/Ice/secure/settings.gradle.kts
+++ b/java/Ice/secure/settings.gradle.kts
@@ -3,7 +3,7 @@
 pluginManagement {
     repositories {
         mavenLocal()
-        maven("https://download.zeroc.com/nexus/repository/maven-nightly/")
+        maven("https://central.sonatype.com/repository/maven-snapshots/")
         gradlePluginPortal() // Keep this to allow fetching other plugins
     }
 }
@@ -11,7 +11,7 @@ pluginManagement {
 dependencyResolutionManagement {
     repositories {
         // This demo uses the latest Ice nightly build published in ZeroC's maven-nightly repository.
-        maven("https://download.zeroc.com/nexus/repository/maven-nightly/")
+        maven("https://central.sonatype.com/repository/maven-snapshots/")
         mavenCentral()
     }
 }


### PR DESCRIPTION
This PR updates the demos to use maven-central SNAPSHOTS instead of ZeroC Nexus