### PR TITLE
Added `.gitignore`s to Each of the Java Demos

### DIFF
--- a/java/Glacier2/greeter/.gitignore
+++ b/java/Glacier2/greeter/.gitignore
@@ -1,0 +1,5 @@
+bin
+build
+.gradle
+
+.DS_Store

--- a/java/Ice/cancellation/.gitignore
+++ b/java/Ice/cancellation/.gitignore
@@ -1,0 +1,5 @@
+bin
+build
+.gradle
+
+.DS_Store

--- a/java/Ice/config/.gitignore
+++ b/java/Ice/config/.gitignore
@@ -1,0 +1,5 @@
+bin
+build
+.gradle
+
+.DS_Store

--- a/java/Ice/context/.gitignore
+++ b/java/Ice/context/.gitignore
@@ -1,0 +1,5 @@
+bin
+build
+.gradle
+
+.DS_Store

--- a/java/Ice/customError/.gitignore
+++ b/java/Ice/customError/.gitignore
@@ -1,0 +1,5 @@
+bin
+build
+.gradle
+
+.DS_Store

--- a/java/Ice/forwarder/.gitignore
+++ b/java/Ice/forwarder/.gitignore
@@ -1,0 +1,5 @@
+bin
+build
+.gradle
+
+.DS_Store

--- a/java/Ice/greeter/.gitignore
+++ b/java/Ice/greeter/.gitignore
@@ -1,0 +1,5 @@
+bin
+build
+.gradle
+
+.DS_Store

--- a/java/Ice/middleware/.gitignore
+++ b/java/Ice/middleware/.gitignore
@@ -1,0 +1,5 @@
+bin
+build
+.gradle
+
+.DS_Store

--- a/java/Ice/secure/.gitignore
+++ b/java/Ice/secure/.gitignore
@@ -1,0 +1,5 @@
+bin
+build
+.gradle
+
+.DS_Store

--- a/java/build-logic/.gitignore
+++ b/java/build-logic/.gitignore
@@ -1,0 +1,5 @@
+bin
+build
+.gradle
+
+.DS_Store


### PR DESCRIPTION
This PR adds a `.gitignore` to each of the Java demos, now that the top-level `.gitignore` has been removed.

I also added one to the `build-logic` folder, where gradlew compiles and imports our build plugin to run the formatter.