### PR TITLE
Update Ice/Config in C# to use initialize(InitializationData)

### DIFF
--- a/csharp/Ice/Config/Client/Program.cs
+++ b/csharp/Ice/Config/Client/Program.cs
@@ -5,16 +5,17 @@ using System.Diagnostics;
 // Slice module VisitorCenter in Greeter.ice maps to C# namespace VisitorCenter.
 using VisitorCenter;
 
-// Create Ice properties from the contents of the config.client file in the current working directory.
-var properties = new Ice.Properties();
-properties.load("config.client");
+// Load the contents of the config.client file into a Properties object.
+var configFileProperties = new Ice.Properties();
+configFileProperties.load("config.client");
+
+// Create a Properties object from the command line arguments and the config file properties; Ice.* properties and other
+// reserved properties set in args override the config file properties.
+var properties = new Ice.Properties(ref args, defaults: configFileProperties);
 
 // Create an Ice communicator. We'll use this communicator to create proxies and manage outgoing connections.
-// The communicator gets its properties from initData.properties; Ice.* properties and other reserved properties set in
-// args override these properties.
-await using Ice.Communicator communicator = Ice.Util.initialize(
-    ref args,
-    new Ice.InitializationData { properties = properties });
+// The communicator gets its properties from initData.properties.
+await using Ice.Communicator communicator = Ice.Util.initialize(new Ice.InitializationData { properties = properties });
 
 // We create a Greeter proxy using the value of the Greeter.Proxy property in config.client.
 // It's null if the property is not set.

--- a/csharp/Ice/Config/Client/Program.cs
+++ b/csharp/Ice/Config/Client/Program.cs
@@ -10,7 +10,7 @@ var configFileProperties = new Ice.Properties();
 configFileProperties.load("config.client");
 
 // Create a Properties object from the command line arguments and the config file properties; Ice.* properties and other
-// reserved properties set in args override the config file properties.
+// reserved properties set in args augment or override the config file properties.
 var properties = new Ice.Properties(ref args, defaults: configFileProperties);
 
 // Create an Ice communicator. We'll use this communicator to create proxies and manage outgoing connections.

--- a/csharp/Ice/Config/Server/Program.cs
+++ b/csharp/Ice/Config/Server/Program.cs
@@ -1,15 +1,16 @@
 // Copyright (c) ZeroC, Inc.
 
-// Create Ice properties from the contents of the config.server file in the current working directory.
-var properties = new Ice.Properties();
-properties.load("config.server");
+// Load the contents of the config.server file into a Properties object.
+var configFileProperties = new Ice.Properties();
+configFileProperties.load("config.server");
+
+// Create a Properties object from the command line arguments and the config file properties; Ice.* properties and other
+// reserved properties set in args augment or override the config file properties.
+var properties = new Ice.Properties(ref args, defaults: configFileProperties);
 
 // Create an Ice communicator. We'll use this communicator to create an object adapter.
-// The communicator gets its properties from initData.properties; Ice.* properties and other reserved properties set in
-// args override these properties.
-await using Ice.Communicator communicator = Ice.Util.initialize(
-    ref args,
-    new Ice.InitializationData { properties = properties });
+// The communicator gets its properties from initData.properties.
+await using Ice.Communicator communicator = Ice.Util.initialize(new Ice.InitializationData { properties = properties });
 
 // Create an object adapter that listens for incoming requests and dispatches them to servants.
 // This adapter is configured through the GreeterAdapter.* properties in config.server.


### PR DESCRIPTION
This PR updates the C# Config demo to use:
```csharp
Ice.Util.initialize(new Ice.InitializationData { properties = properties });
```

instead of the "ref args" initialize overload. See also https://github.com/zeroc-ice/ice/issues/4428.

