### PR TITLE
Add Ice prerequisites to a few demos

### DIFF
--- a/cpp/Ice/greeter/README.md
+++ b/cpp/Ice/greeter/README.md
@@ -1,4 +1,4 @@
-# Greeter
+# Ice Greeter
 
 The Greeter demo illustrates how to build a simple application with Ice.
 
@@ -11,6 +11,12 @@ It features a client which demonstrates the 3 APIs you can use to make remote in
 This demo also provides two implementations for the server: a synchronous dispatch implementation (`server`), and an
 asynchronous dispatch implementation (`serveramd`). The client works with both.
 
+## Ice prerequisites
+
+- Install the C++ dev kit. See [Ice for C++ installation]. There is nothing to do on Windows.
+
+## Building the demo
+
 To build the demo, run:
 
 ```shell
@@ -19,6 +25,8 @@ cmake --build build --config Release
 ```
 
 The build produces 3 executables: client, server, and serveramd.
+
+## Running the demo
 
 To run the demo, first start the server:
 
@@ -59,3 +67,5 @@ In a separate window, start the client:
 ```shell
 build\Release\client
 ```
+
+[Ice for C++ installation]: https://github.com/zeroc-ice/ice/blob/main/NIGHTLY.md#ice-for-c

--- a/cpp/Ice/greeter/README.md
+++ b/cpp/Ice/greeter/README.md
@@ -13,7 +13,9 @@ asynchronous dispatch implementation (`serveramd`). The client works with both.
 
 ## Ice prerequisites
 
-- Install the C++ dev kit. See [Ice for C++ installation]. There is nothing to do on Windows.
+- Install the C++ dev kit.
+  - Linux and macOS: see [Ice for C++ installation].
+  - Windows: the cmake build downloads and installs the C++ dev kit automatically.
 
 ## Building the demo
 

--- a/cpp/IceStorm/weather/README.md
+++ b/cpp/IceStorm/weather/README.md
@@ -15,7 +15,9 @@ flowchart LR
 
 ## Ice prerequisites
 
-- Install the C++ dev kit. See [Ice for C++ installation]. There is nothing to do on Windows.
+- Install the C++ dev kit.
+  - Linux and macOS: see [Ice for C++ installation].
+  - Windows: the cmake build downloads and installs the C++ dev kit automatically.
 - Install the IceBox and IceStorm services. See [Ice service installation].
 
 ## Building the demo

--- a/cpp/IceStorm/weather/README.md
+++ b/cpp/IceStorm/weather/README.md
@@ -13,22 +13,29 @@ flowchart LR
     icestorm --report--> s3[Station #3]
 ```
 
-Follow these steps to build and run the demo:
+## Ice prerequisites
 
-1. Build the sensor and station applications:
+- Install the C++ dev kit. See [Ice for C++ installation]. There is nothing to do on Windows.
+- Install the IceBox and IceStorm services. See [Ice service installation].
 
-   ```shell
-   cmake -B build
-   cmake --build build --config Release
-   ```
+## Building the demo
 
-2. Start the IceStorm service in its own terminal:
+You can build the weather sensor and weather station applications with:
+
+```shell
+cmake -B build
+cmake --build build --config Release
+```
+
+## Running the demo
+
+1. Start the IceStorm service in its own terminal:
 
    ```shell
    icebox --IceBox.Service.IceStorm="IceStormService,38a0:createIceStorm --Ice.Config=config.icestorm"
    ```
 
-3. Run one or more sensors and weather stations, each in its own terminal. You can start them in any order.
+2. Run one or more sensors and weather stations, each in its own terminal. You can start them in any order.
 
    To start a weather station:
 
@@ -57,3 +64,6 @@ Follow these steps to build and run the demo:
     ```shell
     build\Release\sensor
     ```
+
+[Ice for C++ installation]: https://github.com/zeroc-ice/ice/blob/main/NIGHTLY.md#ice-for-c
+[Ice service installation]: https://github.com/zeroc-ice/ice/blob/main/NIGHTLY.md#ice-services

--- a/csharp/Ice/Greeter/README.md
+++ b/csharp/Ice/Greeter/README.md
@@ -5,11 +5,15 @@ This demo illustrates how to send a request and wait for the response.
 It provides two implementations for the server: a synchronous dispatch implementation (in Server), and an asynchronous
 dispatch implementation (in ServerAMD). The same client works with both.
 
+## Building the demo
+
 You can build the client and server applications with:
 
 ```shell
 dotnet build
 ```
+
+## Running the demo
 
 First start the Server program:
 

--- a/csharp/IceStorm/Weather/README.md
+++ b/csharp/IceStorm/Weather/README.md
@@ -13,13 +13,21 @@ flowchart LR
     icestorm --report--> s3[Station #3]
 ```
 
+## Ice prerequisites
+
+- Install the IceBox and IceStorm services. See [Ice service installation].
+
+## Building the demo
+
 You can build the weather sensor and weather station applications with:
 
 ```shell
 dotnet build
 ```
 
-Next, run the IceStorm service in its own terminal:
+## Running the demo
+
+First, run the IceStorm service in its own terminal:
 
 ```shell
 icebox --IceBox.Service.IceStorm="IceStormService,38a0:createIceStorm --Ice.Config=config.icestorm"
@@ -36,3 +44,5 @@ dotnet run
 cd Station
 dotnet run
 ```
+
+[Ice service installation]: https://github.com/zeroc-ice/ice/blob/main/NIGHTLY.md#ice-services


### PR DESCRIPTION
This PR adds an "Ice prerequisites" section to 4 demo READMEs. 

The goal is to make it easy for users to find which Ice components they need to install on their own, and not overwhelm them with other details, like "make sure you have the right Xcode installed".

See #575.