### PR TITLE
Upgrade Nightly repository configuration

### DIFF
--- a/java/Glacier2/greeter/settings.gradle.kts
+++ b/java/Glacier2/greeter/settings.gradle.kts
@@ -3,16 +3,27 @@
 pluginManagement {
     repositories {
         mavenLocal()
-        maven("https://download.zeroc.com/nexus/repository/maven-nightly/")
-        gradlePluginPortal() // Keep this to allow fetching other plugins
+        gradlePluginPortal()
+        // This demo uses the nightly build of the Slice Tools plugin, published to the ZeroC Maven Nightly repository.
+        maven {
+            url = uri("https://download.zeroc.com/nexus/repository/maven-nightly/")
+            content {
+                includeGroupByRegex("com\\.zeroc.*")
+            }
+        }
     }
 }
 
 dependencyResolutionManagement {
     repositories {
-        // This demo uses the latest Ice nightly build published to the ZeroC maven-nightly repository.
-        maven("https://download.zeroc.com/nexus/repository/maven-nightly/")
         mavenCentral()
+        // This demo uses the nightly build of Ice, published to the ZeroC Maven Nightly repository.
+        maven {
+            url = uri("https://download.zeroc.com/nexus/repository/maven-nightly/")
+            content {
+                includeGroupByRegex("com\\.zeroc.*")
+            }
+        }
     }
 }
 

--- a/java/Ice/android-greeter/settings.gradle.kts
+++ b/java/Ice/android-greeter/settings.gradle.kts
@@ -7,18 +7,29 @@ pluginManagement {
                 includeGroupByRegex("androidx.*")
             }
         }
-        maven("https://download.zeroc.com/nexus/repository/maven-nightly/")
         mavenCentral()
         gradlePluginPortal()
+        // This demo uses the nightly build of the Slice Tools plugin, published to the ZeroC Maven Nightly repository.
+        maven {
+            url = uri("https://download.zeroc.com/nexus/repository/maven-nightly/")
+            content {
+                includeGroupByRegex("com\\.zeroc.*")
+            }
+        }
     }
 }
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
-        // This demo uses the latest Ice nightly build published to the maven central snapshots repository.
-        maven("https://download.zeroc.com/nexus/repository/maven-nightly/")
         google()
         mavenCentral()
+        // This demo uses the nightly build of Ice, published to the ZeroC Maven Nightly repository.
+        maven {
+            url = uri("https://download.zeroc.com/nexus/repository/maven-nightly/")
+            content {
+                includeGroupByRegex("com\\.zeroc.*")
+            }
+        }
     }
 }
 

--- a/java/Ice/bidir/settings.gradle.kts
+++ b/java/Ice/bidir/settings.gradle.kts
@@ -3,16 +3,27 @@
 pluginManagement {
     repositories {
         mavenLocal()
-        maven("https://download.zeroc.com/nexus/repository/maven-nightly/")
-        gradlePluginPortal() // Keep this to allow fetching other plugins
+        gradlePluginPortal()
+        // This demo uses the nightly build of the Slice Tools plugin, published to the ZeroC Maven Nightly repository.
+        maven {
+            url = uri("https://download.zeroc.com/nexus/repository/maven-nightly/")
+            content {
+                includeGroupByRegex("com\\.zeroc.*")
+            }
+        }
     }
 }
 
 dependencyResolutionManagement {
     repositories {
-        // This demo uses the latest Ice nightly build published to the maven central snapshots repository.
-        maven("https://download.zeroc.com/nexus/repository/maven-nightly/")
         mavenCentral()
+        // This demo uses the nightly build of Ice, published to the ZeroC Maven Nightly repository.
+        maven {
+            url = uri("https://download.zeroc.com/nexus/repository/maven-nightly/")
+            content {
+                includeGroupByRegex("com\\.zeroc.*")
+            }
+        }
     }
 }
 

--- a/java/Ice/callback/settings.gradle.kts
+++ b/java/Ice/callback/settings.gradle.kts
@@ -3,16 +3,27 @@
 pluginManagement {
     repositories {
         mavenLocal()
-        maven("https://download.zeroc.com/nexus/repository/maven-nightly/")
-        gradlePluginPortal() // Keep this to allow fetching other plugins
+        gradlePluginPortal()
+        // This demo uses the nightly build of the Slice Tools plugin, published to the ZeroC Maven Nightly repository.
+        maven {
+            url = uri("https://download.zeroc.com/nexus/repository/maven-nightly/")
+            content {
+                includeGroupByRegex("com\\.zeroc.*")
+            }
+        }
     }
 }
 
 dependencyResolutionManagement {
     repositories {
-        // This demo uses the latest Ice nightly build published to the ZeroC maven-nightly repository.
-        maven("https://download.zeroc.com/nexus/repository/maven-nightly/")
         mavenCentral()
+        // This demo uses the nightly build of Ice, published to the ZeroC Maven Nightly repository.
+        maven {
+            url = uri("https://download.zeroc.com/nexus/repository/maven-nightly/")
+            content {
+                includeGroupByRegex("com\\.zeroc.*")
+            }
+        }
     }
 }
 

--- a/java/Ice/cancellation/settings.gradle.kts
+++ b/java/Ice/cancellation/settings.gradle.kts
@@ -3,16 +3,27 @@
 pluginManagement {
     repositories {
         mavenLocal()
-        maven("https://download.zeroc.com/nexus/repository/maven-nightly/")
-        gradlePluginPortal() // Keep this to allow fetching other plugins
+        gradlePluginPortal()
+        // This demo uses the nightly build of the Slice Tools plugin, published to the ZeroC Maven Nightly repository.
+        maven {
+            url = uri("https://download.zeroc.com/nexus/repository/maven-nightly/")
+            content {
+                includeGroupByRegex("com\\.zeroc.*")
+            }
+        }
     }
 }
 
 dependencyResolutionManagement {
     repositories {
-        // This demo uses the latest Ice nightly build published to the ZeroC maven-nightly repository.
-        maven("https://download.zeroc.com/nexus/repository/maven-nightly/")
         mavenCentral()
+        // This demo uses the nightly build of Ice, published to the ZeroC Maven Nightly repository.
+        maven {
+            url = uri("https://download.zeroc.com/nexus/repository/maven-nightly/")
+            content {
+                includeGroupByRegex("com\\.zeroc.*")
+            }
+        }
     }
 }
 

--- a/java/Ice/config/settings.gradle.kts
+++ b/java/Ice/config/settings.gradle.kts
@@ -3,16 +3,27 @@
 pluginManagement {
     repositories {
         mavenLocal()
-        maven("https://download.zeroc.com/nexus/repository/maven-nightly/")
-        gradlePluginPortal() // Keep this to allow fetching other plugins
+        gradlePluginPortal()
+        // This demo uses the nightly build of the Slice Tools plugin, published to the ZeroC Maven Nightly repository.
+        maven {
+            url = uri("https://download.zeroc.com/nexus/repository/maven-nightly/")
+            content {
+                includeGroupByRegex("com\\.zeroc.*")
+            }
+        }
     }
 }
 
 dependencyResolutionManagement {
     repositories {
-        // This demo uses the latest Ice nightly build published to the ZeroC maven-nightly repository.
-        maven("https://download.zeroc.com/nexus/repository/maven-nightly/")
         mavenCentral()
+        // This demo uses the nightly build of Ice, published to the ZeroC Maven Nightly repository.
+        maven {
+            url = uri("https://download.zeroc.com/nexus/repository/maven-nightly/")
+            content {
+                includeGroupByRegex("com\\.zeroc.*")
+            }
+        }
     }
 }
 

--- a/java/Ice/context/settings.gradle.kts
+++ b/java/Ice/context/settings.gradle.kts
@@ -3,16 +3,27 @@
 pluginManagement {
     repositories {
         mavenLocal()
-        maven("https://download.zeroc.com/nexus/repository/maven-nightly/")
-        gradlePluginPortal() // Keep this to allow fetching other plugins
+        gradlePluginPortal()
+        // This demo uses the nightly build of the Slice Tools plugin, published to the ZeroC Maven Nightly repository.
+        maven {
+            url = uri("https://download.zeroc.com/nexus/repository/maven-nightly/")
+            content {
+                includeGroupByRegex("com\\.zeroc.*")
+            }
+        }
     }
 }
 
 dependencyResolutionManagement {
     repositories {
-        // This demo uses the latest Ice nightly build published to the ZeroC maven-nightly repository.
-        maven("https://download.zeroc.com/nexus/repository/maven-nightly/")
         mavenCentral()
+        // This demo uses the nightly build of Ice, published to the ZeroC Maven Nightly repository.
+        maven {
+            url = uri("https://download.zeroc.com/nexus/repository/maven-nightly/")
+            content {
+                includeGroupByRegex("com\\.zeroc.*")
+            }
+        }
     }
 }
 

--- a/java/Ice/customError/settings.gradle.kts
+++ b/java/Ice/customError/settings.gradle.kts
@@ -3,16 +3,27 @@
 pluginManagement {
     repositories {
         mavenLocal()
-        maven("https://download.zeroc.com/nexus/repository/maven-nightly/")
-        gradlePluginPortal() // Keep this to allow fetching other plugins
+        gradlePluginPortal()
+        // This demo uses the nightly build of the Slice Tools plugin, published to the ZeroC Maven Nightly repository.
+        maven {
+            url = uri("https://download.zeroc.com/nexus/repository/maven-nightly/")
+            content {
+                includeGroupByRegex("com\\.zeroc.*")
+            }
+        }
     }
 }
 
 dependencyResolutionManagement {
     repositories {
-        // This demo uses the latest Ice nightly build published to the ZeroC maven-nightly repository.
-        maven("https://download.zeroc.com/nexus/repository/maven-nightly/")
         mavenCentral()
+        // This demo uses the nightly build of Ice, published to the ZeroC Maven Nightly repository.
+        maven {
+            url = uri("https://download.zeroc.com/nexus/repository/maven-nightly/")
+            content {
+                includeGroupByRegex("com\\.zeroc.*")
+            }
+        }
     }
 }
 

--- a/java/Ice/forwarder/settings.gradle.kts
+++ b/java/Ice/forwarder/settings.gradle.kts
@@ -3,16 +3,27 @@
 pluginManagement {
     repositories {
         mavenLocal()
-        maven("https://download.zeroc.com/nexus/repository/maven-nightly/")
-        gradlePluginPortal() // Keep this to allow fetching other plugins
+        gradlePluginPortal()
+        // This demo uses the nightly build of the Slice Tools plugin, published to the ZeroC Maven Nightly repository.
+        maven {
+            url = uri("https://download.zeroc.com/nexus/repository/maven-nightly/")
+            content {
+                includeGroupByRegex("com\\.zeroc.*")
+            }
+        }
     }
 }
 
 dependencyResolutionManagement {
     repositories {
-        // This demo uses the latest Ice nightly build published to the ZeroC maven-nightly repository.
-        maven("https://download.zeroc.com/nexus/repository/maven-nightly/")
         mavenCentral()
+        // This demo uses the nightly build of Ice, published to the ZeroC Maven Nightly repository.
+        maven {
+            url = uri("https://download.zeroc.com/nexus/repository/maven-nightly/")
+            content {
+                includeGroupByRegex("com\\.zeroc.*")
+            }
+        }
     }
 }
 

--- a/java/Ice/greeter/settings.gradle.kts
+++ b/java/Ice/greeter/settings.gradle.kts
@@ -3,16 +3,27 @@
 pluginManagement {
     repositories {
         mavenLocal()
-        maven("https://download.zeroc.com/nexus/repository/maven-nightly/")
-        gradlePluginPortal() // Keep this to allow fetching other plugins
+        gradlePluginPortal()
+        // This demo uses the nightly build of the Slice Tools plugin, published to the ZeroC Maven Nightly repository.
+        maven {
+            url = uri("https://download.zeroc.com/nexus/repository/maven-nightly/")
+            content {
+                includeGroupByRegex("com\\.zeroc.*")
+            }
+        }
     }
 }
 
 dependencyResolutionManagement {
     repositories {
-        // This demo uses the latest Ice nightly build published to the ZeroC maven-nightly repository.
-        maven("https://download.zeroc.com/nexus/repository/maven-nightly/")
         mavenCentral()
+        // This demo uses the nightly build of Ice, published to the ZeroC Maven Nightly repository.
+        maven {
+            url = uri("https://download.zeroc.com/nexus/repository/maven-nightly/")
+            content {
+                includeGroupByRegex("com\\.zeroc.*")
+            }
+        }
     }
 }
 

--- a/java/Ice/inheritance/settings.gradle.kts
+++ b/java/Ice/inheritance/settings.gradle.kts
@@ -3,16 +3,27 @@
 pluginManagement {
     repositories {
         mavenLocal()
-        maven("https://download.zeroc.com/nexus/repository/maven-nightly/")
-        gradlePluginPortal() // Keep this to allow fetching other plugins
+        gradlePluginPortal()
+        // This demo uses the nightly build of the Slice Tools plugin, published to the ZeroC Maven Nightly repository.
+        maven {
+            url = uri("https://download.zeroc.com/nexus/repository/maven-nightly/")
+            content {
+                includeGroupByRegex("com\\.zeroc.*")
+            }
+        }
     }
 }
 
 dependencyResolutionManagement {
     repositories {
-        // This demo uses the latest Ice nightly build published to the ZeroC maven-nightly repository.
-        maven("https://download.zeroc.com/nexus/repository/maven-nightly/")
         mavenCentral()
+        // This demo uses the nightly build of Ice, published to the ZeroC Maven Nightly repository.
+        maven {
+            url = uri("https://download.zeroc.com/nexus/repository/maven-nightly/")
+            content {
+                includeGroupByRegex("com\\.zeroc.*")
+            }
+        }
     }
 }
 

--- a/java/Ice/middleware/settings.gradle.kts
+++ b/java/Ice/middleware/settings.gradle.kts
@@ -3,16 +3,27 @@
 pluginManagement {
     repositories {
         mavenLocal()
-        maven("https://download.zeroc.com/nexus/repository/maven-nightly/")
-        gradlePluginPortal() // Keep this to allow fetching other plugins
+        gradlePluginPortal()
+        // This demo uses the nightly build of the Slice Tools plugin, published to the ZeroC Maven Nightly repository.
+        maven {
+            url = uri("https://download.zeroc.com/nexus/repository/maven-nightly/")
+            content {
+                includeGroupByRegex("com\\.zeroc.*")
+            }
+        }
     }
 }
 
 dependencyResolutionManagement {
     repositories {
-        // This demo uses the latest Ice nightly build published to the ZeroC maven-nightly repository.
-        maven("https://download.zeroc.com/nexus/repository/maven-nightly/")
         mavenCentral()
+        // This demo uses the nightly build of Ice, published to the ZeroC Maven Nightly repository.
+        maven {
+            url = uri("https://download.zeroc.com/nexus/repository/maven-nightly/")
+            content {
+                includeGroupByRegex("com\\.zeroc.*")
+            }
+        }
     }
 }
 

--- a/java/Ice/secure/settings.gradle.kts
+++ b/java/Ice/secure/settings.gradle.kts
@@ -3,16 +3,27 @@
 pluginManagement {
     repositories {
         mavenLocal()
-        maven("https://download.zeroc.com/nexus/repository/maven-nightly/")
-        gradlePluginPortal() // Keep this to allow fetching other plugins
+        gradlePluginPortal()
+        // This demo uses the nightly build of the Slice Tools plugin, published to the ZeroC Maven Nightly repository.
+        maven {
+            url = uri("https://download.zeroc.com/nexus/repository/maven-nightly/")
+            content {
+                includeGroupByRegex("com\\.zeroc.*")
+            }
+        }
     }
 }
 
 dependencyResolutionManagement {
     repositories {
-        // This demo uses the latest Ice nightly build published to the ZeroC maven-nightly repository.
-        maven("https://download.zeroc.com/nexus/repository/maven-nightly/")
         mavenCentral()
+        // This demo uses the nightly build of Ice, published to the ZeroC Maven Nightly repository.
+        maven {
+            url = uri("https://download.zeroc.com/nexus/repository/maven-nightly/")
+            content {
+                includeGroupByRegex("com\\.zeroc.*")
+            }
+        }
     }
 }
 


### PR DESCRIPTION
This PR updates Gradle maven repository configuration, ZeroC Maven Nightly should be only used for ZeroC artifacts.