### PR TITLE
Cosmetic updates to DataStorm constructor calls

### DIFF
--- a/cpp/DataStorm/clock/Reader.cpp
+++ b/cpp/DataStorm/clock/Reader.cpp
@@ -52,7 +52,7 @@ main(int argc, char* argv[])
         ctrlCHandler.setCallback([&node](int) { node.shutdown(); });
 
         // Instantiates the "time" topic.
-        DataStorm::Topic<string, chrono::system_clock::time_point> topic(node, "time");
+        DataStorm::Topic<string, chrono::system_clock::time_point> topic{node, "time"};
 
         // Instantiate a reader to read the time from all the topic cities.
         auto reader = DataStorm::makeAnyKeyReader(topic);

--- a/cpp/DataStorm/clock/Reader.cpp
+++ b/cpp/DataStorm/clock/Reader.cpp
@@ -46,7 +46,7 @@ main(int argc, char* argv[])
         Ice::CtrlCHandler ctrlCHandler;
 
         // Instantiates node.
-        DataStorm::Node node(argc, argv);
+        DataStorm::Node node{argc, argv};
 
         // Shutdown the node on Ctrl-C.
         ctrlCHandler.setCallback([&node](int) { node.shutdown(); });

--- a/cpp/DataStorm/clock/Writer.cpp
+++ b/cpp/DataStorm/clock/Writer.cpp
@@ -58,7 +58,7 @@ main(int argc, char* argv[])
         getline(cin, city);
 
         // Instantiates the "time" topic.
-        DataStorm::Topic<string, chrono::system_clock::time_point> topic(node, "time");
+        DataStorm::Topic<string, chrono::system_clock::time_point> topic{node, "time"};
 
         // Instantiate a writer to write the time from the given city.
         auto writer = DataStorm::makeSingleKeyWriter(topic, city);

--- a/cpp/DataStorm/clock/Writer.cpp
+++ b/cpp/DataStorm/clock/Writer.cpp
@@ -47,7 +47,7 @@ main(int argc, char* argv[])
         Ice::CtrlCHandler ctrlCHandler;
 
         // Instantiates node.
-        DataStorm::Node node(argc, argv);
+        DataStorm::Node node{argc, argv};
 
         // Shutdown the node on Ctrl-C.
         ctrlCHandler.setCallback([&node](int) { node.shutdown(); });

--- a/cpp/DataStorm/keyFilter/Reader.cpp
+++ b/cpp/DataStorm/keyFilter/Reader.cpp
@@ -15,7 +15,7 @@ main(int argc, char* argv[])
     try
     {
         // Instantiates DataStorm node.
-        DataStorm::Node node(argc, argv);
+        DataStorm::Node node{argc, argv};
 
         // Instantiates the "hello" topic. The topic uses strings for keys and values.
         DataStorm::Topic<string, string> topic(node, "hello");

--- a/cpp/DataStorm/keyFilter/Reader.cpp
+++ b/cpp/DataStorm/keyFilter/Reader.cpp
@@ -18,7 +18,7 @@ main(int argc, char* argv[])
         DataStorm::Node node{argc, argv};
 
         // Instantiates the "hello" topic. The topic uses strings for keys and values.
-        DataStorm::Topic<string, string> topic(node, "hello");
+        DataStorm::Topic<string, string> topic{node, "hello"};
 
         // Configure readers to never clear the history. We want to receive all the
         // samples written by the writers.

--- a/cpp/DataStorm/keyFilter/Writer.cpp
+++ b/cpp/DataStorm/keyFilter/Writer.cpp
@@ -17,7 +17,7 @@ main(int argc, char* argv[])
         DataStorm::Node node{argc, argv};
 
         // Instantiates the "hello" topic. The topic uses strings for keys and values.
-        DataStorm::Topic<string, string> topic(node, "hello");
+        DataStorm::Topic<string, string> topic{node, "hello"};
 
         // Instantiate writers.
         auto writera = DataStorm::makeSingleKeyWriter(topic, "fooa");

--- a/cpp/DataStorm/keyFilter/Writer.cpp
+++ b/cpp/DataStorm/keyFilter/Writer.cpp
@@ -14,7 +14,7 @@ main(int argc, char* argv[])
     try
     {
         // Instantiates DataStorm node.
-        DataStorm::Node node(argc, argv);
+        DataStorm::Node node{argc, argv};
 
         // Instantiates the "hello" topic. The topic uses strings for keys and values.
         DataStorm::Topic<string, string> topic(node, "hello");

--- a/cpp/DataStorm/minimal/Reader.cpp
+++ b/cpp/DataStorm/minimal/Reader.cpp
@@ -12,7 +12,7 @@ main(int argc, char* argv[])
     try
     {
         // Instantiates DataStorm node.
-        DataStorm::Node node(argc, argv);
+        DataStorm::Node node{argc, argv};
 
         // Instantiates the "hello" topic. The topic uses strings for keys and values.
         DataStorm::Topic<string, string> topic(node, "hello");

--- a/cpp/DataStorm/minimal/Reader.cpp
+++ b/cpp/DataStorm/minimal/Reader.cpp
@@ -15,7 +15,7 @@ main(int argc, char* argv[])
         DataStorm::Node node{argc, argv};
 
         // Instantiates the "hello" topic. The topic uses strings for keys and values.
-        DataStorm::Topic<string, string> topic(node, "hello");
+        DataStorm::Topic<string, string> topic{node, "hello"};
 
         // Instantiate a reader with the key "foo".
         auto reader = DataStorm::makeSingleKeyReader(topic, "foo");

--- a/cpp/DataStorm/minimal/Writer.cpp
+++ b/cpp/DataStorm/minimal/Writer.cpp
@@ -12,7 +12,7 @@ main(int argc, char* argv[])
     try
     {
         // Instantiates DataStorm node.
-        DataStorm::Node node(argc, argv);
+        DataStorm::Node node{argc, argv};
 
         // Instantiates the "hello" topic. The topic uses strings for keys and values.
         DataStorm::Topic<string, string> topic(node, "hello");

--- a/cpp/DataStorm/minimal/Writer.cpp
+++ b/cpp/DataStorm/minimal/Writer.cpp
@@ -15,7 +15,7 @@ main(int argc, char* argv[])
         DataStorm::Node node{argc, argv};
 
         // Instantiates the "hello" topic. The topic uses strings for keys and values.
-        DataStorm::Topic<string, string> topic(node, "hello");
+        DataStorm::Topic<string, string> topic{node, "hello"};
 
         // Instantiate a writer with the key "foo" and wait for a reader to connect.
         auto writer = DataStorm::makeSingleKeyWriter(topic, "foo");

--- a/cpp/DataStorm/node/Reader.cpp
+++ b/cpp/DataStorm/node/Reader.cpp
@@ -39,7 +39,7 @@ main(int argc, char* argv[])
         ctrlCHandler.setCallback([&node](int) { node.shutdown(); });
 
         // Instantiates the "time" topic.
-        DataStorm::Topic<int, string> topic(node, "time");
+        DataStorm::Topic<int, string> topic{node, "time"};
 
         // Instantiate a reader to read the time from all the topic writers.
         auto reader = DataStorm::makeAnyKeyReader(topic);

--- a/cpp/DataStorm/node/Reader.cpp
+++ b/cpp/DataStorm/node/Reader.cpp
@@ -30,10 +30,10 @@ main(int argc, char* argv[])
         Ice::CommunicatorPtr communicator = Ice::initialize(initData);
 
         // Make sure the communicator is destroyed at the end of this scope.
-        Ice::CommunicatorHolder ich{communicator};
+        Ice::CommunicatorHolder communicatorHolder{communicator};
 
         // Instantiates node.
-        DataStorm::Node node(ich.communicator());
+        DataStorm::Node node{communicator};
 
         // Shutdown the node on Ctrl-C.
         ctrlCHandler.setCallback([&node](int) { node.shutdown(); });

--- a/cpp/DataStorm/node/Writer.cpp
+++ b/cpp/DataStorm/node/Writer.cpp
@@ -42,7 +42,7 @@ main(int argc, char* argv[])
         ctrlCHandler.setCallback([&node](int) { node.shutdown(); });
 
         // Instantiates the "time" topic.
-        DataStorm::Topic<int, string> topic(node, "time");
+        DataStorm::Topic<int, string> topic{node, "time"};
 
         // Setup a random generator to generate an identifier for the writer.
         random_device rd;

--- a/cpp/DataStorm/node/Writer.cpp
+++ b/cpp/DataStorm/node/Writer.cpp
@@ -33,10 +33,10 @@ main(int argc, char* argv[])
         Ice::CommunicatorPtr communicator = Ice::initialize(initData);
 
         // Make sure the communicator is destroyed at the end of this scope.
-        Ice::CommunicatorHolder ich{communicator};
+        Ice::CommunicatorHolder communicatorHolder{communicator};
 
         // Instantiates node.
-        DataStorm::Node node(ich.communicator());
+        DataStorm::Node node{communicator};
 
         // Shutdown the node on Ctrl-C.
         ctrlCHandler.setCallback([&node](int) { node.shutdown(); });

--- a/cpp/DataStorm/sampleFilter/Reader.cpp
+++ b/cpp/DataStorm/sampleFilter/Reader.cpp
@@ -18,7 +18,7 @@ main(int argc, char* argv[])
         DataStorm::Node node{argc, argv};
 
         // Instantiates the "hello" topic. The topic uses strings for keys and values.
-        DataStorm::Topic<string, string> topic(node, "hello");
+        DataStorm::Topic<string, string> topic{node, "hello"};
 
         // Configure readers to never clear the history. We want to receive all the samples written by the writers.
         topic.setReaderDefaultConfig({std::nullopt, std::nullopt, DataStorm::ClearHistoryPolicy::Never});

--- a/cpp/DataStorm/sampleFilter/Reader.cpp
+++ b/cpp/DataStorm/sampleFilter/Reader.cpp
@@ -15,7 +15,7 @@ main(int argc, char* argv[])
     try
     {
         // Instantiates DataStorm node.
-        DataStorm::Node node(argc, argv);
+        DataStorm::Node node{argc, argv};
 
         // Instantiates the "hello" topic. The topic uses strings for keys and values.
         DataStorm::Topic<string, string> topic(node, "hello");

--- a/cpp/DataStorm/sampleFilter/Writer.cpp
+++ b/cpp/DataStorm/sampleFilter/Writer.cpp
@@ -18,7 +18,7 @@ main(int argc, char* argv[])
         DataStorm::Node node{argc, argv};
 
         // Instantiates the "hello" topic. The topic uses strings for keys and values.
-        DataStorm::Topic<string, string> topic(node, "hello");
+        DataStorm::Topic<string, string> topic{node, "hello"};
 
         // Configure writers to not clear the history. We want the readers to receive all the writer samples.
         topic.setWriterDefaultConfig({std::nullopt, std::nullopt, DataStorm::ClearHistoryPolicy::Never});

--- a/cpp/DataStorm/sampleFilter/Writer.cpp
+++ b/cpp/DataStorm/sampleFilter/Writer.cpp
@@ -15,7 +15,7 @@ main(int argc, char* argv[])
     try
     {
         // Instantiates DataStorm node.
-        DataStorm::Node node(argc, argv);
+        DataStorm::Node node{argc, argv};
 
         // Instantiates the "hello" topic. The topic uses strings for keys and values.
         DataStorm::Topic<string, string> topic(node, "hello");

--- a/cpp/DataStorm/stock/Reader.cpp
+++ b/cpp/DataStorm/stock/Reader.cpp
@@ -19,7 +19,7 @@ main(int argc, char* argv[])
         Ice::CtrlCHandler ctrlCHandler;
 
         // Instantiates node.
-        DataStorm::Node node(argc, argv);
+        DataStorm::Node node{argc, argv};
 
         // Shutdown the node on Ctrl-C.
         ctrlCHandler.setCallback([&node](int) { node.shutdown(); });

--- a/cpp/DataStorm/stock/Reader.cpp
+++ b/cpp/DataStorm/stock/Reader.cpp
@@ -25,7 +25,7 @@ main(int argc, char* argv[])
         ctrlCHandler.setCallback([&node](int) { node.shutdown(); });
 
         // Instantiates the "stocks" topic.
-        DataStorm::Topic<string, Demo::Stock> topic(node, "stocks");
+        DataStorm::Topic<string, Demo::Stock> topic{node, "stocks"};
 
         // Setup partial update updaters. The updater is responsible for updating the element value when a partial
         // update is received. Updaters must be set on the topic from both the reader and writer.

--- a/cpp/DataStorm/stock/Writer.cpp
+++ b/cpp/DataStorm/stock/Writer.cpp
@@ -51,7 +51,7 @@ main(int argc, char* argv[])
         Ice::CtrlCHandler ctrlCHandler;
 
         // Instantiates node.
-        DataStorm::Node node(argc, argv);
+        DataStorm::Node node{argc, argv};
 
         // Shutdown the node on Ctrl-C.
         ctrlCHandler.setCallback([&node](int) { node.shutdown(); });

--- a/cpp/DataStorm/stock/Writer.cpp
+++ b/cpp/DataStorm/stock/Writer.cpp
@@ -57,7 +57,7 @@ main(int argc, char* argv[])
         ctrlCHandler.setCallback([&node](int) { node.shutdown(); });
 
         // Instantiates the "stock" topic.
-        DataStorm::Topic<string, Stock> topic(node, "stocks");
+        DataStorm::Topic<string, Stock> topic{node, "stocks"};
 
         // Setup partial update updaters. The updater is responsible for updating the element value when a partial
         // update is received. Updaters must be set on both the topic reader and writer.


### PR DESCRIPTION
Uses `{...}` instead of `(...)` to call Node and Topic constructors.