### PR TITLE
Restrict when dev container workflow runs

### DIFF
--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -2,11 +2,13 @@ name: Dev Containers
 
 on:
   workflow_dispatch:
-  push:
-    branches: ["main"]
   pull_request:
-    # The branches below must be a subset of the branches above
     branches: ["main"]
+    paths:
+      - ".devcontainer/**"
+      - ".github/workflows/devcontainer.yml"
+  schedule:
+    - cron: "0 0 * * 0" # Run weekly on Sunday at midnight UTC
 
 jobs:
   build:


### PR DESCRIPTION
This PR restricts when the dev container workflow runs to:

- on PRs when a relevant is modified
- once a week to make sure dependencies are working correctly