### PR TITLE
Delete Redundant Checkstyle Action from GitHub CI

### DIFF
--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -8,33 +8,6 @@ on:
     branches: ["main"]
 
 jobs:
-  checkstyle:
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Setup Java
-        uses: actions/setup-java@v4
-        with:
-          distribution: "oracle"
-          java-version: "17"
-
-      - name: Run checkstyle formatter
-        timeout-minutes: 20
-        working-directory: java
-        shell: pwsh
-        run: |
-          $ErrorActionPreference = "Stop"
-          Get-ChildItem -Recurse -Depth 2 -Filter gradlew | ForEach-Object {
-            Push-Location $_.DirectoryName
-            Write-Host "Building in $($_.DirectoryName)..."
-            & ./gradlew check
-            if ($LASTEXITCODE -ne 0) {
-              throw "Build failed in $($_.DirectoryName)"
-            }
-            Pop-Location
-          }
 
   rewrite:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
We're currently running Checkstyle over the repo twice, once in the main `java build`, and another in a stand-alone `checkstyle `action. This PR deletes the standalone checkstyle action. There's no need to run it twice.


----

**Outdated:**

We made this change in the main Ice repository, but I forgot to do the same for the demos.
See https://github.com/zeroc-ice/ice/pull/4359

We have a separate action for running `checkstyle`, so we don't want the main Java build running it as well.