### PR TITLE
Bring the `ice-demos` Gradle in-line with the ice Repo Gradle

### DIFF
--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -30,7 +30,7 @@ jobs:
           Get-ChildItem -Recurse -Depth 2 -Filter gradlew | ForEach-Object {
             Push-Location $_.DirectoryName
             Write-Host "Building in $($_.DirectoryName)..."
-            & ./gradlew rewriteDryRun
+            & ./gradlew rewriteDryRun --no-parallel --no-configuration-cache
             if ($LASTEXITCODE -ne 0) {
               throw "Build failed in $($_.DirectoryName)"
             }

--- a/java/config/checkstyle/checkstyle.xml
+++ b/java/config/checkstyle/checkstyle.xml
@@ -97,6 +97,8 @@
       <property name="allowByTailComment" value="true"/>
       <property name="allowNonPrintableEscapes" value="true"/>
     </module>
+
+    <module name="UnusedImports"/>
     <module name="AvoidStarImport"/>
     <module name="OneTopLevelClass"/>
     <module name="NoLineWrap">


### PR DESCRIPTION
In the last week I've made some changes to the ice repo's gradle setup.
This PR copies the meaningful changes to the ice-demo repo to keep them in sync.

See https://github.com/zeroc-ice/ice/pull/4616 and https://github.com/zeroc-ice/ice/pull/4597