### PR TITLE
Prevent Checkstyle from Caching 'up-to-date' So it Always Re-Runs

### DIFF
--- a/java/build-logic/src/main/kotlin/zeroc-linting.gradle.kts
+++ b/java/build-logic/src/main/kotlin/zeroc-linting.gradle.kts
@@ -29,6 +29,13 @@ checkstyle {
     }
 }
 
+tasks.withType<Checkstyle>().configureEach {
+    // Ensure that running checkstyle multiple times always yields the same output. Otherwise, after an initial run,
+    // the checkstyle task will be marked "UP TO DATE", and subsequent runs will skip over it.
+    outputs.upToDateWhen { false }
+    doNotTrackState("Always run Checkstyle")
+}
+
 rewrite {
     activeRecipe("com.zeroc.IceRewriteRecipes")
     activeStyle("com.zeroc.IceRewriteStyle")


### PR DESCRIPTION
See https://github.com/zeroc-ice/ice/pull/4666.