### PR TITLE
Move signal.signal before await shutdownCompleted

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -5,6 +5,7 @@
         "Blobject",
         "icegrid",
         "pyright",
+        "signum",
         "visitorcenter",
         "zeroc"
     ],

--- a/python/Glacier2/callback/server/main.py
+++ b/python/Glacier2/callback/server/main.py
@@ -18,9 +18,6 @@ async def main():
     # create an object adapter. We enable asyncio support by passing the current event loop to the communicator
     # constructor.
     async with Ice.Communicator(sys.argv, eventLoop=loop) as communicator:
-        # Shutdown the communicator when the user presses Ctrl+C.
-        signal.signal(signal.SIGINT, lambda signum, frame: communicator.shutdown())
-
         # Create an object adapter that listens for incoming requests and dispatches them to servants.
         adapter = communicator.createObjectAdapterWithEndpoints("WakeUpAdapter", "tcp -p 4061")
 
@@ -30,6 +27,9 @@ async def main():
         # Start dispatching requests.
         adapter.activate()
         print("Listening on port 4061...")
+
+        # Shutdown the communicator when the user presses Ctrl+C.
+        signal.signal(signal.SIGINT, lambda _signum, _frame: communicator.shutdown())
 
         # Wait until the communicator is shut down. Here, this occurs when the user presses Ctrl+C.
         await communicator.shutdownCompleted()

--- a/python/Glacier2/greeter/server/main.py
+++ b/python/Glacier2/greeter/server/main.py
@@ -14,9 +14,6 @@ async def main():
     # Create an Ice communicator. We'll use this communicator to create an object adapter. We enable asyncio
     # support by passing the current event loop to the communicator constructor.
     async with Ice.Communicator(sys.argv, eventLoop=loop) as communicator:
-        # Shutdown the communicator when the user presses Ctrl+C.
-        signal.signal(signal.SIGINT, lambda signum, frame: communicator.shutdown())
-
         # Create an object adapter that listens for incoming requests and dispatches them to servants.
         adapter = communicator.createObjectAdapterWithEndpoints("GreeterAdapter", "tcp -p 4061")
 
@@ -26,6 +23,9 @@ async def main():
         # Start dispatching requests.
         adapter.activate()
         print("Listening on port 4061...")
+
+        # Shutdown the communicator when the user presses Ctrl+C.
+        signal.signal(signal.SIGINT, lambda _signum, _frame: communicator.shutdown())
 
         # Wait until the communicator is shut down. Here, this occurs when the user presses Ctrl+C.
         await communicator.shutdownCompleted()

--- a/python/Glacier2/session/server/main.py
+++ b/python/Glacier2/session/server/main.py
@@ -16,9 +16,6 @@ async def main():
     # Create an Ice communicator. We'll use this communicator to create an object adapter. We enable asyncio
     # support by passing the current event loop to the communicator constructor.
     async with Ice.Communicator(sys.argv, eventLoop=loop) as communicator:
-        # Shutdown the communicator when the user presses Ctrl+C.
-        signal.signal(signal.SIGINT, lambda signum, frame: communicator.shutdown())
-
         # Create an object adapter that listens for incoming requests and dispatches them to servants.
         adapter = communicator.createObjectAdapterWithEndpoints("PokeAdapter", "tcp -p 4061")
 
@@ -34,6 +31,9 @@ async def main():
         # Start dispatching requests.
         adapter.activate()
         print("Listening on port 4061...")
+
+        # Shutdown the communicator when the user presses Ctrl+C.
+        signal.signal(signal.SIGINT, lambda _signum, _frame: communicator.shutdown())
 
         # Wait until the communicator is shut down. Here, this occurs when the user presses Ctrl+C.
         await communicator.shutdownCompleted()

--- a/python/Ice/bidir/server/main.py
+++ b/python/Ice/bidir/server/main.py
@@ -16,9 +16,6 @@ async def main():
     # Create an Ice communicator. We'll use this communicator to create an object adapter. We enable asyncio
     # support by passing the current event loop to the communicator constructor.
     async with Ice.Communicator(sys.argv, eventLoop=loop) as communicator:
-        # Shutdown the communicator when the user presses Ctrl+C.
-        signal.signal(signal.SIGINT, lambda signum, frame: communicator.shutdown())
-
         # Create an object adapter that listens for incoming requests and dispatches them to servants.
         adapter = communicator.createObjectAdapterWithEndpoints("WakeUpAdapter", "tcp -p 4061")
 
@@ -28,6 +25,9 @@ async def main():
         # Start dispatching requests.
         adapter.activate()
         print("Listening on port 4061...")
+
+        # Shutdown the communicator when the user presses Ctrl+C.
+        signal.signal(signal.SIGINT, lambda _signum, _frame: communicator.shutdown())
 
         # Wait until the communicator is shut down. Here, this occurs when the user presses Ctrl+C.
         await communicator.shutdownCompleted()

--- a/python/Ice/callback/server/main.py
+++ b/python/Ice/callback/server/main.py
@@ -16,9 +16,6 @@ async def main():
     # create an object adapter. We enable asyncio support by passing the current event loop to the communicator
     # constructor.
     async with Ice.Communicator(sys.argv, eventLoop=loop) as communicator:
-        # Shutdown the communicator when the user presses Ctrl+C.
-        signal.signal(signal.SIGINT, lambda signum, frame: communicator.shutdown())
-
         # Create an object adapter that listens for incoming requests and dispatches them to servants.
         adapter = communicator.createObjectAdapterWithEndpoints("WakeUpAdapter", "tcp -p 4061")
 
@@ -28,6 +25,9 @@ async def main():
         # Start dispatching requests.
         adapter.activate()
         print("Listening on port 4061...")
+
+        # Shutdown the communicator when the user presses Ctrl+C.
+        signal.signal(signal.SIGINT, lambda _signum, _frame: communicator.shutdown())
 
         # Wait until the communicator is shut down. Here, this occurs when the user presses Ctrl+C.
         await communicator.shutdownCompleted()

--- a/python/Ice/config/server/main.py
+++ b/python/Ice/config/server/main.py
@@ -27,9 +27,6 @@ async def main():
     # Create an Ice communicator. We'll use this communicator to create an object adapter.
     # The communicator gets its properties from the properties object.
     async with Ice.Communicator(initData=initData) as communicator:
-        # Shutdown the communicator when the user presses Ctrl+C.
-        signal.signal(signal.SIGINT, lambda signum, frame: communicator.shutdown())
-
         # Create an object adapter that listens for incoming requests and dispatches them to servants.
         adapter = communicator.createObjectAdapter("GreeterAdapter")
 
@@ -38,6 +35,9 @@ async def main():
 
         # Start dispatching requests.
         adapter.activate()
+
+        # Shutdown the communicator when the user presses Ctrl+C.
+        signal.signal(signal.SIGINT, lambda _signum, _frame: communicator.shutdown())
 
         # Wait until the communicator is shut down. Here, this occurs when the user presses Ctrl+C.
         await communicator.shutdownCompleted()

--- a/python/Ice/context/server/main.py
+++ b/python/Ice/context/server/main.py
@@ -14,9 +14,6 @@ async def main():
     # Create an Ice communicator. We'll use this communicator to create an object adapter. We enable asyncio
     # support by passing the current event loop to the communicator constructor.
     async with Ice.Communicator(sys.argv, eventLoop=loop) as communicator:
-        # Shutdown the communicator when the user presses Ctrl+C.
-        signal.signal(signal.SIGINT, lambda signum, frame: communicator.shutdown())
-
         # Create an object adapter that listens for incoming requests and dispatches them to servants.
         adapter = communicator.createObjectAdapterWithEndpoints("GreeterAdapter", "tcp -p 4061")
 
@@ -26,6 +23,9 @@ async def main():
         # Start dispatching requests.
         adapter.activate()
         print("Listening on port 4061...")
+
+        # Shutdown the communicator when the user presses Ctrl+C.
+        signal.signal(signal.SIGINT, lambda _signum, _frame: communicator.shutdown())
 
         # Wait until the communicator is shut down. Here, this occurs when the user presses Ctrl+C.
         await communicator.shutdownCompleted()

--- a/python/Ice/customError/server/main.py
+++ b/python/Ice/customError/server/main.py
@@ -14,9 +14,6 @@ async def main():
     # Create an Ice communicator. We'll use this communicator to create an object adapter. We enable asyncio
     # support by passing the current event loop to the communicator constructor.
     async with Ice.Communicator(sys.argv, eventLoop=loop) as communicator:
-        # Shutdown the communicator when the user presses Ctrl+C.
-        signal.signal(signal.SIGINT, lambda signum, frame: communicator.shutdown())
-
         # Create an object adapter that listens for incoming requests and dispatches them to servants.
         adapter = communicator.createObjectAdapterWithEndpoints("GreeterAdapter", "tcp -p 4061")
 
@@ -26,6 +23,9 @@ async def main():
         # Start dispatching requests.
         adapter.activate()
         print("Listening on port 4061...")
+
+        # Shutdown the communicator when the user presses Ctrl+C.
+        signal.signal(signal.SIGINT, lambda _signum, _frame: communicator.shutdown())
 
         # Wait until the communicator is shut down. Here, this occurs when the user presses Ctrl+C.
         await communicator.shutdownCompleted()

--- a/python/Ice/greeter/server/main.py
+++ b/python/Ice/greeter/server/main.py
@@ -14,9 +14,6 @@ async def main():
     # Create an Ice communicator. We'll use this communicator to create an object adapter. We enable asyncio
     # support by passing the current event loop to the communicator constructor.
     async with Ice.Communicator(sys.argv, eventLoop=loop) as communicator:
-        # Shutdown the communicator when the user presses Ctrl+C.
-        signal.signal(signal.SIGINT, lambda signum, frame: communicator.shutdown())
-
         # Create an object adapter that listens for incoming requests and dispatches them to servants.
         adapter = communicator.createObjectAdapterWithEndpoints("GreeterAdapter", "tcp -p 4061")
 
@@ -26,6 +23,9 @@ async def main():
         # Start dispatching requests.
         adapter.activate()
         print("Listening on port 4061...")
+
+        # Shutdown the communicator when the user presses Ctrl+C.
+        signal.signal(signal.SIGINT, lambda _signum, _frame: communicator.shutdown())
 
         # Wait until the communicator is shut down. Here, this occurs when the user presses Ctrl+C.
         await communicator.shutdownCompleted()

--- a/python/Ice/greeter/server_amd/main.py
+++ b/python/Ice/greeter/server_amd/main.py
@@ -15,9 +15,6 @@ async def main():
     # Create an Ice communicator. We'll use this communicator to create an object adapter. We enable asyncio
     # support by passing the current event loop to the communicator constructor.
     async with Ice.Communicator(sys.argv, eventLoop=loop) as communicator:
-        # Shutdown the communicator when the user presses Ctrl+C.
-        signal.signal(signal.SIGINT, lambda signum, frame: communicator.shutdown())
-
         # Create an object adapter that listens for incoming requests and dispatches them to servants.
         adapter = communicator.createObjectAdapterWithEndpoints("GreeterAdapter", "tcp -p 4061")
 
@@ -27,6 +24,9 @@ async def main():
         # Start dispatching requests.
         adapter.activate()
         print("Listening on port 4061...")
+
+        # Shutdown the communicator when the user presses Ctrl+C.
+        signal.signal(signal.SIGINT, lambda _signum, _frame: communicator.shutdown())
 
         # Wait until the communicator is shut down. Here, this occurs when the user presses Ctrl+C.
         await communicator.shutdownCompleted()

--- a/python/Ice/inheritance/server/main.py
+++ b/python/Ice/inheritance/server/main.py
@@ -16,9 +16,6 @@ async def main():
     # Create an Ice communicator. We'll use this communicator to create an object adapter. We enable asyncio
     # support by passing the current event loop to the communicator constructor.
     async with Ice.Communicator(sys.argv, eventLoop=loop) as communicator:
-        # Shutdown the communicator when the user presses Ctrl+C.
-        signal.signal(signal.SIGINT, lambda signum, frame: communicator.shutdown())
-
         # Create an object adapter that listens for incoming requests and dispatches them to servants.
         adapter = communicator.createObjectAdapterWithEndpoints("Filesystem", "tcp -p 4061")
 
@@ -54,6 +51,9 @@ async def main():
         # Start dispatching requests.
         adapter.activate()
         print("Listening on port 4061...")
+
+        # Shutdown the communicator when the user presses Ctrl+C.
+        signal.signal(signal.SIGINT, lambda _signum, _frame: communicator.shutdown())
 
         # Wait until the communicator is shut down. Here, this occurs when the user presses Ctrl+C.
         await communicator.shutdownCompleted()

--- a/python/Ice/invocation_timeout/server/main.py
+++ b/python/Ice/invocation_timeout/server/main.py
@@ -16,9 +16,6 @@ async def main():
     # Create an Ice communicator. We'll use this communicator to create an object adapter. We enable asyncio
     # support by passing the current event loop to the communicator constructor.
     async with Ice.Communicator(sys.argv, eventLoop=loop) as communicator:
-        # Shutdown the communicator when the user presses Ctrl+C.
-        signal.signal(signal.SIGINT, lambda signum, frame: communicator.shutdown())
-
         # Create an object adapter that listens for incoming requests and dispatches them to servants.
         adapter = communicator.createObjectAdapterWithEndpoints("GreeterAdapter", "tcp -p 4061")
 
@@ -29,6 +26,9 @@ async def main():
         # Start dispatching requests.
         adapter.activate()
         print("Listening on port 4061...")
+
+        # Shutdown the communicator when the user presses Ctrl+C.
+        signal.signal(signal.SIGINT, lambda _signum, _frame: communicator.shutdown())
 
         # Wait until the communicator is shut down. Here, this occurs when the user presses Ctrl+C.
         await communicator.shutdownCompleted()

--- a/python/Ice/optional/server1/main.py
+++ b/python/Ice/optional/server1/main.py
@@ -14,9 +14,6 @@ async def main():
     # Create an Ice communicator. We'll use this communicator to create an object adapter. We enable asyncio
     # support by passing the current event loop to the communicator constructor.
     async with Ice.Communicator(sys.argv, eventLoop=loop) as communicator:
-        # Shutdown the communicator when the user presses Ctrl+C.
-        signal.signal(signal.SIGINT, lambda signum, frame: communicator.shutdown())
-
         # Create an object adapter that listens for incoming requests and dispatches them to servants.
         adapter = communicator.createObjectAdapterWithEndpoints("GreeterAdapter", "tcp -p 4061")
 
@@ -26,6 +23,9 @@ async def main():
         # Start dispatching requests.
         adapter.activate()
         print("Listening on port 4061...")
+
+        # Shutdown the communicator when the user presses Ctrl+C.
+        signal.signal(signal.SIGINT, lambda _signum, _frame: communicator.shutdown())
 
         # Wait until the communicator is shut down. Here, this occurs when the user presses Ctrl+C.
         await communicator.shutdownCompleted()

--- a/python/Ice/optional/server2/main.py
+++ b/python/Ice/optional/server2/main.py
@@ -14,9 +14,6 @@ async def main():
     # Create an Ice communicator. We'll use this communicator to create an object adapter. We enable asyncio
     # support by passing the current event loop to the communicator constructor.
     async with Ice.Communicator(sys.argv, eventLoop=loop) as communicator:
-        # Shutdown the communicator when the user presses Ctrl+C.
-        signal.signal(signal.SIGINT, lambda signum, frame: communicator.shutdown())
-
         # Create an object adapter that listens for incoming requests and dispatches them to servants.
         adapter = communicator.createObjectAdapterWithEndpoints("GreeterAdapter", "tcp -p 4061")
 
@@ -26,6 +23,9 @@ async def main():
         # Start dispatching requests.
         adapter.activate()
         print("Listening on port 4061...")
+
+        # Shutdown the communicator when the user presses Ctrl+C.
+        signal.signal(signal.SIGINT, lambda _signum, _frame: communicator.shutdown())
 
         # Wait until the communicator is shut down. Here, this occurs when the user presses Ctrl+C.
         await communicator.shutdownCompleted()

--- a/python/IceDiscovery/greeter/server/main.py
+++ b/python/IceDiscovery/greeter/server/main.py
@@ -31,9 +31,6 @@ async def main():
 
     # Create an Ice communicator. We'll use this communicator to create an object adapter.
     async with Ice.Communicator(initData=initData) as communicator:
-        # Shutdown the communicator when the user presses Ctrl+C.
-        signal.signal(signal.SIGINT, lambda signum, frame: communicator.shutdown())
-
         # Create an object adapter that listens for incoming requests and dispatches them to servants.
         adapter = communicator.createObjectAdapter("GreeterAdapter")
 
@@ -43,6 +40,9 @@ async def main():
         # Start dispatching requests. This method also registers the object adapter with the IceDiscovery plug-in.
         adapter.activate()
         print("Listening...")
+
+        # Shutdown the communicator when the user presses Ctrl+C.
+        signal.signal(signal.SIGINT, lambda _signum, _frame: communicator.shutdown())
 
         # Wait until the communicator is shut down. Here, this occurs when the user presses Ctrl+C.
         await communicator.shutdownCompleted()

--- a/python/IceDiscovery/replication/server/main.py
+++ b/python/IceDiscovery/replication/server/main.py
@@ -36,9 +36,6 @@ async def main():
 
     # Create an Ice communicator. We'll use this communicator to create an object adapter.
     async with Ice.Communicator(initData=initData) as communicator:
-        # Shutdown the communicator when the user presses Ctrl+C.
-        signal.signal(signal.SIGINT, lambda signum, frame: communicator.shutdown())
-
         # Create an object adapter that listens for incoming requests and dispatches them to servants.
         adapter = communicator.createObjectAdapter("GreeterAdapter")
 
@@ -49,6 +46,9 @@ async def main():
         # Start dispatching requests. This method also registers the object adapter with the IceDiscovery plug-in.
         adapter.activate()
         print("Listening...")
+
+        # Shutdown the communicator when the user presses Ctrl+C.
+        signal.signal(signal.SIGINT, lambda _signum, _frame: communicator.shutdown())
 
         # Wait until the communicator is shut down. Here, this occurs when the user presses Ctrl+C.
         await communicator.shutdownCompleted()

--- a/python/IceGrid/greeter/server/main.py
+++ b/python/IceGrid/greeter/server/main.py
@@ -16,9 +16,6 @@ async def main():
     # this communicator with sys.argv args. We enable asyncio support by passing the current event loop to the
     # communicator constructor.
     async with Ice.Communicator(sys.argv, eventLoop=loop) as communicator:
-        # Shutdown the communicator when the user presses Ctrl+C.
-        signal.signal(signal.SIGINT, lambda signum, frame: communicator.shutdown())
-
         # Create an object adapter. It's configured by the GreeterAdapter.* properties in the IceGrid-generated config
         # file.
         adapter = communicator.createObjectAdapter("GreeterAdapter")
@@ -34,6 +31,9 @@ async def main():
         # Start dispatching requests.
         adapter.activate()
         print(f"{greeterName} is listening...")
+
+        # Shutdown the communicator when the user presses Ctrl+C.
+        signal.signal(signal.SIGINT, lambda _signum, _frame: communicator.shutdown())
 
         # Wait until the communicator is shut down.
         await communicator.shutdownCompleted()

--- a/python/IceStorm/weather/station/main.py
+++ b/python/IceStorm/weather/station/main.py
@@ -20,9 +20,6 @@ async def main():
     # create an object adapter. We enable asyncio support by passing the current event loop to the communicator
     # constructor.
     async with Ice.Communicator(sys.argv, eventLoop=loop) as communicator:
-        # Shutdown the communicator when the user presses Ctrl+C.
-        signal.signal(signal.SIGINT, lambda signum, frame: communicator.shutdown())
-
         # Create an object adapter that listens for incoming requests and dispatches them to servants. This object
         # adapter listens on an OS-assigned TCP port, on all interfaces.
         adapter = communicator.createObjectAdapterWithEndpoints("StationAdapter", "tcp")
@@ -51,6 +48,9 @@ async def main():
         # Register our weather station with the topic.
         # subscribeAndGetPublisherAsync returns a publisher proxy that we don't need here.
         await topic.subscribeAndGetPublisherAsync(theQoS={}, subscriber=weatherStation)
+
+        # Shutdown the communicator when the user presses Ctrl+C.
+        signal.signal(signal.SIGINT, lambda _signum, _frame: communicator.shutdown())
 
         # Wait until the communicator is shut down. Here, this occurs when the user presses Ctrl+C.
         await communicator.shutdownCompleted()


### PR DESCRIPTION
Just like in the C# demos: it's clearly to perform the signal setup just before we wait until Ctrl+C.

In some languages (such as C++ and Swift), we need to do it at the beginning of the program. But not in Python/C#.