### PR TITLE
Update position of shutdownCommunicatorOnCtrlC call in Java demos

### DIFF
--- a/java/Glacier2/greeter/server/src/main/java/com/example/glacier2/greeter/server/Server.java
+++ b/java/Glacier2/greeter/server/src/main/java/com/example/glacier2/greeter/server/Server.java
@@ -11,10 +11,6 @@ class Server {
         // Create an Ice communicator. We'll use this communicator to create an object adapter.
         try (Communicator communicator = new Communicator(args)) {
 
-            // Register a shutdown hook that calls communicator.shutdown() when the user shuts down the server with
-            // Ctrl+C or similar. The shutdown hook thread also waits until the main thread completes its cleanup.
-            shutdownCommunicatorOnCtrlC(communicator, Thread.currentThread());
-
             // Create an object adapter that listens for incoming requests and dispatches them to servants.
             ObjectAdapter adapter = communicator.createObjectAdapterWithEndpoints("GreeterAdapter", "tcp -p 4061");
 
@@ -24,6 +20,10 @@ class Server {
             // Start dispatching requests.
             adapter.activate();
             System.out.println("Listening on port 4061...");
+
+            // Register a shutdown hook that calls communicator.shutdown() when the user shuts down the server with
+            // Ctrl+C or similar. The shutdown hook thread also waits until the main thread completes its cleanup.
+            shutdownCommunicatorOnCtrlC(communicator, Thread.currentThread());
 
             // Wait until the communicator is shut down. Here, this occurs when the user presses Ctrl+C.
             communicator.waitForShutdown();

--- a/java/Ice/config/server/src/main/java/com/example/ice/config/server/Server.java
+++ b/java/Ice/config/server/src/main/java/com/example/ice/config/server/Server.java
@@ -24,10 +24,6 @@ class Server {
         initData.properties = properties;
         try (Communicator communicator = new Communicator(initData)) {
 
-            // Register a shutdown hook that calls communicator.shutdown() when the user shuts down the server with
-            // Ctrl+C or similar. The shutdown hook thread also waits until the main thread completes its cleanup.
-            shutdownCommunicatorOnCtrlC(communicator, Thread.currentThread());
-
             // Create an object adapter that listens for incoming requests and dispatches them to servants.
             ObjectAdapter adapter = communicator.createObjectAdapter("GreeterAdapter");
 
@@ -37,6 +33,10 @@ class Server {
             // Start dispatching requests.
             adapter.activate();
             System.out.println("Listening on port 4061...");
+
+            // Register a shutdown hook that calls communicator.shutdown() when the user shuts down the server with
+            // Ctrl+C or similar. The shutdown hook thread also waits until the main thread completes its cleanup.
+            shutdownCommunicatorOnCtrlC(communicator, Thread.currentThread());
 
             // Wait until the communicator is shut down. Here, this occurs when the user presses Ctrl+C.
             communicator.waitForShutdown();

--- a/java/Ice/context/server/src/main/java/com/example/ice/context/server/Server.java
+++ b/java/Ice/context/server/src/main/java/com/example/ice/context/server/Server.java
@@ -11,10 +11,6 @@ class Server {
         // Create an Ice communicator. We'll use this communicator to create an object adapter.
         try (Communicator communicator = new Communicator(args)) {
 
-            // Register a shutdown hook that calls communicator.shutdown() when the user shuts down the server with
-            // Ctrl+C or similar. The shutdown hook thread also waits until the main thread completes its cleanup.
-            shutdownCommunicatorOnCtrlC(communicator, Thread.currentThread());
-
             // Create an object adapter that listens for incoming requests and dispatches them to servants.
             ObjectAdapter adapter = communicator.createObjectAdapterWithEndpoints("GreeterAdapter", "tcp -p 4061");
 
@@ -24,6 +20,10 @@ class Server {
             // Start dispatching requests.
             adapter.activate();
             System.out.println("Listening on port 4061...");
+
+            // Register a shutdown hook that calls communicator.shutdown() when the user shuts down the server with
+            // Ctrl+C or similar. The shutdown hook thread also waits until the main thread completes its cleanup.
+            shutdownCommunicatorOnCtrlC(communicator, Thread.currentThread());
 
             // Wait until the communicator is shut down. Here, this occurs when the user presses Ctrl+C.
             communicator.waitForShutdown();

--- a/java/Ice/customError/server/src/main/java/com/example/ice/customerror/server/Server.java
+++ b/java/Ice/customError/server/src/main/java/com/example/ice/customerror/server/Server.java
@@ -11,10 +11,6 @@ class Server {
         // Create an Ice communicator. We'll use this communicator to create an object adapter.
         try (Communicator communicator = new Communicator(args)) {
 
-            // Register a shutdown hook that calls communicator.shutdown() when the user shuts down the server with
-            // Ctrl+C or similar. The shutdown hook thread also waits until the main thread completes its cleanup.
-            shutdownCommunicatorOnCtrlC(communicator, Thread.currentThread());
-
             // Create an object adapter that listens for incoming requests and dispatches them to servants.
             ObjectAdapter adapter = communicator.createObjectAdapterWithEndpoints("GreeterAdapter", "tcp -p 4061");
 
@@ -24,6 +20,10 @@ class Server {
             // Start dispatching requests.
             adapter.activate();
             System.out.println("Listening on port 4061...");
+
+            // Register a shutdown hook that calls communicator.shutdown() when the user shuts down the server with
+            // Ctrl+C or similar. The shutdown hook thread also waits until the main thread completes its cleanup.
+            shutdownCommunicatorOnCtrlC(communicator, Thread.currentThread());
 
             // Wait until the communicator is shut down. Here, this occurs when the user presses Ctrl+C.
             communicator.waitForShutdown();

--- a/java/Ice/inheritance/server/src/main/java/com/example/ice/inheritance/server/Server.java
+++ b/java/Ice/inheritance/server/src/main/java/com/example/ice/inheritance/server/Server.java
@@ -14,11 +14,6 @@ class Server {
         // Create an Ice communicator. We'll use this communicator to create an object adapter.
         try (Communicator communicator = new Communicator(args)) {
 
-            // Register a shutdown hook that calls communicator.shutdown()
-            // when the user shuts down the server with Ctrl+C or similar.
-            // The shutdown hook thread also waits until the main thread completes its cleanup.
-            shutdownCommunicatorOnCtrlC(communicator, Thread.currentThread());
-
             // Create an object adapter that listens for incoming requests and dispatches them to servants.
             ObjectAdapter adapter = communicator.createObjectAdapterWithEndpoints("Filesystem", "tcp -p 4061");
 
@@ -52,6 +47,11 @@ class Server {
             // Start dispatching requests after registering all servants.
             adapter.activate();
             System.out.println("Listening on port 4061...");
+
+            // Register a shutdown hook that calls communicator.shutdown()
+            // when the user shuts down the server with Ctrl+C or similar.
+            // The shutdown hook thread also waits until the main thread completes its cleanup.
+            shutdownCommunicatorOnCtrlC(communicator, Thread.currentThread());
 
             // Wait until the communicator is shut down.
             // Here, this occurs when the user presses Ctrl+C.

--- a/java/Ice/middleware/server/src/main/java/com/example/ice/middleware/server/Server.java
+++ b/java/Ice/middleware/server/src/main/java/com/example/ice/middleware/server/Server.java
@@ -11,10 +11,6 @@ class Server {
         // Create an Ice communicator. We'll use this communicator to create an object adapter.
         try (Communicator communicator = new Communicator(args)) {
 
-            // Register a shutdown hook that calls communicator.shutdown() when the user shuts down the server with
-            // Ctrl+C or similar. The shutdown hook thread also waits until the main thread completes its cleanup.
-            shutdownCommunicatorOnCtrlC(communicator, Thread.currentThread());
-
             // Create an object adapter that listens for incoming requests and dispatches them to servants.
             ObjectAdapter adapter = communicator.createObjectAdapterWithEndpoints("GreeterAdapter", "tcp -p 4061");
 
@@ -27,6 +23,10 @@ class Server {
             // Start dispatching requests.
             adapter.activate();
             System.out.println("Listening on port 4061...");
+
+            // Register a shutdown hook that calls communicator.shutdown() when the user shuts down the server with
+            // Ctrl+C or similar. The shutdown hook thread also waits until the main thread completes its cleanup.
+            shutdownCommunicatorOnCtrlC(communicator, Thread.currentThread());
 
             // Wait until the communicator is shut down. Here, this occurs when the user presses Ctrl+C.
             communicator.waitForShutdown();

--- a/java/Ice/secure/server/src/main/java/com/example/ice/secure/server/Server.java
+++ b/java/Ice/secure/server/src/main/java/com/example/ice/secure/server/Server.java
@@ -24,10 +24,6 @@ final class Server {
         // Create an Ice communicator. We'll use this communicator to create an object adapter.
         try (Communicator communicator = new Communicator(args)) {
 
-            // Register a shutdown hook that calls communicator.shutdown() when the user shuts down the server with
-            // Ctrl+C or similar. The shutdown hook thread also waits until the main thread completes its cleanup.
-            shutdownCommunicatorOnCtrlC(communicator, Thread.currentThread());
-
             // Create the SSLContext and use it to configure the object adapter. When the adapter accepts a new
             // incoming ssl connection, it uses the `sslEngineFactory` to create an SSLEngine for that connection.
             // Here, we generate these SSLEngine instances using our carefully crafted SSLContext.
@@ -50,6 +46,10 @@ final class Server {
             // Start dispatching requests.
             adapter.activate();
             System.out.println("Listening on port 4061...");
+
+            // Register a shutdown hook that calls communicator.shutdown() when the user shuts down the server with
+            // Ctrl+C or similar. The shutdown hook thread also waits until the main thread completes its cleanup.
+            shutdownCommunicatorOnCtrlC(communicator, Thread.currentThread());
 
             // Wait until the communicator is shut down. Here, this occurs when the user presses Ctrl+C.
             communicator.waitForShutdown();


### PR DESCRIPTION
This PR moves the call to shutdownCommunicatorOnCtrlC in some Java demos. It was already correct in most demos.