### PR TITLE
Remove setIncludes from build.gradle.kts 

### DIFF
--- a/java/Ice/greeter/client/build.gradle.kts
+++ b/java/Ice/greeter/client/build.gradle.kts
@@ -21,9 +21,6 @@ sourceSets {
         // Add the Greeter.ice file from the parent slice directory to the main source set.
         slice {
             srcDirs("../slice")
-            // By default a Slice source set includes all Slice files in the srcDirs directories.
-            // Here we override the default behavior by specifying the list of Slice files to include.
-            setIncludes(listOf("Greeter.ice"))
         }
     }
 }

--- a/java/Ice/greeter/server/build.gradle.kts
+++ b/java/Ice/greeter/server/build.gradle.kts
@@ -21,9 +21,6 @@ sourceSets {
         // Add the Greeter.ice file from the parent slice directory to the main source set.
         slice {
             srcDirs("../slice")
-            // By default a Slice source set includes all Slice files in the srcDirs directories.
-            // Here we override the default behavior by specifying the list of Slice files to include.
-            setIncludes(listOf("Greeter.ice"))
         }
     }
 }

--- a/java/Ice/greeter/serveramd/build.gradle.kts
+++ b/java/Ice/greeter/serveramd/build.gradle.kts
@@ -21,9 +21,6 @@ sourceSets {
         // Add the Greeter.ice file from the parent slice directory to the main source set.
         slice {
             srcDirs("../slice")
-            // By default a Slice source set includes all Slice files in the srcDirs directories.
-            // Here we override the default behavior by specifying the list of Slice files to include.
-            setIncludes(listOf("Greeter.ice"))
         }
     }
 }

--- a/java/IceStorm/weather/sensor/build.gradle.kts
+++ b/java/IceStorm/weather/sensor/build.gradle.kts
@@ -22,9 +22,6 @@ sourceSets {
         // Add the WeatherStation.ice file from the parent slice directory to the main source set.
         slice {
             srcDirs("../slice")
-            // By default a Slice source set includes all Slice files in the srcDirs directories.
-            // Here we override the default behavior by specifying the list of Slice files to include.
-            setIncludes(listOf("WeatherStation.ice"))
         }
     }
 }

--- a/java/IceStorm/weather/station/build.gradle.kts
+++ b/java/IceStorm/weather/station/build.gradle.kts
@@ -22,9 +22,6 @@ sourceSets {
         // Add the WeatherStation.ice file from the parent slice directory to the main source set.
         slice {
             srcDirs("../slice")
-            // By default a Slice source set includes all Slice files in the srcDirs directories.
-            // Here we override the default behavior by specifying the list of Slice files to include.
-            setIncludes(listOf("WeatherStation.ice"))
         }
     }
 }


### PR DESCRIPTION
This PR removes extra setIncludes in Java demos.