### PR TITLE
Update demos to use 3.9 Nightly repositories

### DIFF
--- a/cpp/cmake/common.cmake
+++ b/cpp/cmake/common.cmake
@@ -26,7 +26,7 @@ if(WIN32)
 
     # Download the Ice NuGet package using the nuget command line tool.
     message(STATUS "Downloading Ice NuGet package: ${Ice_NUGET_NAME}")
-    set(ICE_NUGET_SOURCE "https://download.zeroc.com/nexus/repository/nuget-nightly/" CACHE STRING "Ice NuGet package source")
+    set(ICE_NUGET_SOURCE "https://download.zeroc.com/nexus/repository/nuget-3.9-nightly/" CACHE STRING "Ice NuGet package source")
     execute_process(
       COMMAND ${NUGET_EXE} install -Source ${ICE_NUGET_SOURCE} -OutputDirectory ${CMAKE_CURRENT_LIST_DIR}/packages ${Ice_NUGET_NAME} -Prerelease -ExcludeVersion
       RESULT_VARIABLE nuget_result

--- a/csharp/Directory.Build.props
+++ b/csharp/Directory.Build.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build"
     xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
-        <IceVersion Condition="'$(IceVersion)' == ''">3.8.0-nightly.*</IceVersion>
+        <IceVersion Condition="'$(IceVersion)' == ''">3.9.0-nightly.*</IceVersion>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <AnalysisMode>All</AnalysisMode>
     </PropertyGroup>

--- a/csharp/nuget.config
+++ b/csharp/nuget.config
@@ -5,7 +5,7 @@
   <packageSources>
     <clear />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-    <add key="zeroc.com" value="https://download.zeroc.com/nexus/repository/nuget-nightly/" />
+    <add key="zeroc.com" value="https://download.zeroc.com/nexus/repository/nuget-3.9-nightly/" />
   </packageSources>
 
   <!-- Define mappings by adding package patterns beneath the target source. -->

--- a/java/Glacier2/callback/client/build.gradle.kts
+++ b/java/Glacier2/callback/client/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id("application")
 
     // Apply the Slice-tools plugin to enable Slice compilation.
-    id("com.zeroc.slice-tools") version "3.8.+"
+    id("com.zeroc.slice-tools") version "3.9.+"
 
     // Pull in our local 'convention plugin' to enable linting.
     id("zeroc-linting")
@@ -13,8 +13,8 @@ plugins {
 
 dependencies {
     // Add Ice and Glacier2 as implementation dependencies.
-    implementation("com.zeroc:ice:3.8.+")
-    implementation("com.zeroc:glacier2:3.8.+")
+    implementation("com.zeroc:ice:3.9.+")
+    implementation("com.zeroc:glacier2:3.9.+")
     implementation(project(":util"))
 }
 

--- a/java/Glacier2/callback/server/build.gradle.kts
+++ b/java/Glacier2/callback/server/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id("application")
 
     // Apply the Slice-tools plugin to enable Slice compilation.
-    id("com.zeroc.slice-tools") version "3.8.+"
+    id("com.zeroc.slice-tools") version "3.9.+"
 
     // Pull in our local 'convention plugin' to enable linting.
     id("zeroc-linting")
@@ -13,8 +13,8 @@ plugins {
 
 dependencies {
     // Add Ice and Glacier2 as implementation dependencies.
-    implementation("com.zeroc:ice:3.8.+")
-    implementation("com.zeroc:glacier2:3.8.+")
+    implementation("com.zeroc:ice:3.9.+")
+    implementation("com.zeroc:glacier2:3.9.+")
     implementation(project(":util"))
 }
 

--- a/java/Glacier2/callback/settings.gradle.kts
+++ b/java/Glacier2/callback/settings.gradle.kts
@@ -4,9 +4,9 @@ pluginManagement {
     repositories {
         mavenLocal()
         gradlePluginPortal()
-        // Use the nightly build of the Slice Tools plugin from the ZeroC maven-nightly repository.
+        // Use the nightly build of the Slice Tools plugin from the ZeroC maven-3.9-nightly repository.
         maven {
-            url = uri("https://download.zeroc.com/nexus/repository/maven-nightly/")
+            url = uri("https://download.zeroc.com/nexus/repository/maven-3.9-nightly/")
             content {
                 includeGroupByRegex("com\\.zeroc.*")
             }
@@ -17,9 +17,9 @@ pluginManagement {
 dependencyResolutionManagement {
     repositories {
         mavenCentral()
-        // Use the nightly build of Ice from the ZeroC maven-nightly repository.
+        // Use the nightly build of Ice from the ZeroC maven-3.9-nightly repository.
         maven {
-            url = uri("https://download.zeroc.com/nexus/repository/maven-nightly/")
+            url = uri("https://download.zeroc.com/nexus/repository/maven-3.9-nightly/")
             content {
                 includeGroupByRegex("com\\.zeroc.*")
             }

--- a/java/Glacier2/greeter/client/build.gradle.kts
+++ b/java/Glacier2/greeter/client/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id("application")
 
     // Apply the Slice-tools plugin to enable Slice compilation.
-    id("com.zeroc.slice-tools") version "3.8.+"
+    id("com.zeroc.slice-tools") version "3.9.+"
 
     // Pull in our local 'convention plugin' to enable linting.
     id("zeroc-linting")
@@ -13,8 +13,8 @@ plugins {
 
 dependencies {
     // Add Ice and Glacier2 as implementation dependencies.
-    implementation("com.zeroc:ice:3.8.+")
-    implementation("com.zeroc:glacier2:3.8.+")
+    implementation("com.zeroc:ice:3.9.+")
+    implementation("com.zeroc:glacier2:3.9.+")
 }
 
 sourceSets {

--- a/java/Glacier2/greeter/server/build.gradle.kts
+++ b/java/Glacier2/greeter/server/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id("application")
 
     // Apply the Slice-tools plugin to enable Slice compilation.
-    id("com.zeroc.slice-tools") version "3.8.+"
+    id("com.zeroc.slice-tools") version "3.9.+"
 
     // Pull in our local 'convention plugin' to enable linting.
     id("zeroc-linting")
@@ -13,8 +13,8 @@ plugins {
 
 dependencies {
     // Add Ice and Glacier2 as implementation dependencies.
-    implementation("com.zeroc:ice:3.8.+")
-    implementation("com.zeroc:glacier2:3.8.+")
+    implementation("com.zeroc:ice:3.9.+")
+    implementation("com.zeroc:glacier2:3.9.+")
 }
 
 sourceSets {

--- a/java/Glacier2/greeter/settings.gradle.kts
+++ b/java/Glacier2/greeter/settings.gradle.kts
@@ -4,9 +4,9 @@ pluginManagement {
     repositories {
         mavenLocal()
         gradlePluginPortal()
-        // Use the nightly build of the Slice Tools plugin from the ZeroC maven-nightly repository.
+        // Use the nightly build of the Slice Tools plugin from the ZeroC maven-3.9-nightly repository.
         maven {
-            url = uri("https://download.zeroc.com/nexus/repository/maven-nightly/")
+            url = uri("https://download.zeroc.com/nexus/repository/maven-3.9-nightly/")
             content {
                 includeGroupByRegex("com\\.zeroc.*")
             }
@@ -17,9 +17,9 @@ pluginManagement {
 dependencyResolutionManagement {
     repositories {
         mavenCentral()
-        // Use the nightly build of Ice from the ZeroC maven-nightly repository.
+        // Use the nightly build of Ice from the ZeroC maven-3.9-nightly repository.
         maven {
-            url = uri("https://download.zeroc.com/nexus/repository/maven-nightly/")
+            url = uri("https://download.zeroc.com/nexus/repository/maven-3.9-nightly/")
             content {
                 includeGroupByRegex("com\\.zeroc.*")
             }

--- a/java/Glacier2/session/client/build.gradle.kts
+++ b/java/Glacier2/session/client/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id("application")
 
     // Apply the Slice-tools plugin to enable Slice compilation.
-    id("com.zeroc.slice-tools") version "3.8.+"
+    id("com.zeroc.slice-tools") version "3.9.+"
 
     // Pull in our local 'convention plugin' to enable linting.
     id("zeroc-linting")
@@ -13,8 +13,8 @@ plugins {
 
 dependencies {
     // Add Ice and Glacier2 as implementation dependencies.
-    implementation("com.zeroc:ice:3.8.+")
-    implementation("com.zeroc:glacier2:3.8.+")
+    implementation("com.zeroc:ice:3.9.+")
+    implementation("com.zeroc:glacier2:3.9.+")
 }
 
 sourceSets {

--- a/java/Glacier2/session/server/build.gradle.kts
+++ b/java/Glacier2/session/server/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id("application")
 
     // Apply the Slice-tools plugin to enable Slice compilation.
-    id("com.zeroc.slice-tools") version "3.8.+"
+    id("com.zeroc.slice-tools") version "3.9.+"
 
     // Pull in our local 'convention plugin' to enable linting.
     id("zeroc-linting")
@@ -13,8 +13,8 @@ plugins {
 
 dependencies {
     // Add Ice and Glacier2 as implementation dependencies.
-    implementation("com.zeroc:ice:3.8.+")
-    implementation("com.zeroc:glacier2:3.8.+")
+    implementation("com.zeroc:ice:3.9.+")
+    implementation("com.zeroc:glacier2:3.9.+")
 }
 
 sourceSets {

--- a/java/Glacier2/session/settings.gradle.kts
+++ b/java/Glacier2/session/settings.gradle.kts
@@ -4,9 +4,9 @@ pluginManagement {
     repositories {
         mavenLocal()
         gradlePluginPortal()
-        // Use the nightly build of the Slice Tools plugin from the ZeroC maven-nightly repository.
+        // Use the nightly build of the Slice Tools plugin from the ZeroC maven-3.9-nightly repository.
         maven {
-            url = uri("https://download.zeroc.com/nexus/repository/maven-nightly/")
+            url = uri("https://download.zeroc.com/nexus/repository/maven-3.9-nightly/")
             content {
                 includeGroupByRegex("com\\.zeroc.*")
             }
@@ -17,9 +17,9 @@ pluginManagement {
 dependencyResolutionManagement {
     repositories {
         mavenCentral()
-        // Use the nightly build of Ice from the ZeroC maven-nightly repository.
+        // Use the nightly build of Ice from the ZeroC maven-3.9-nightly repository.
         maven {
-            url = uri("https://download.zeroc.com/nexus/repository/maven-nightly/")
+            url = uri("https://download.zeroc.com/nexus/repository/maven-3.9-nightly/")
             content {
                 includeGroupByRegex("com\\.zeroc.*")
             }

--- a/java/Ice/android-greeter/app/build.gradle.kts
+++ b/java/Ice/android-greeter/app/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
     // Apply the Slice-tools plugin to enable Slice compilation.
-    id("com.zeroc.slice-tools") version "3.8.+"
+    id("com.zeroc.slice-tools") version "3.9.+"
     // Pull in our local 'convention plugin' to enable linting.
     id("zeroc-linting")
 }
@@ -46,7 +46,7 @@ kotlin {
 
 dependencies {
     // Add the Ice library as an implementation dependency.
-    implementation("com.zeroc:ice:3.8.+")
+    implementation("com.zeroc:ice:3.9.+")
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)
     implementation(libs.material)

--- a/java/Ice/android-greeter/settings.gradle.kts
+++ b/java/Ice/android-greeter/settings.gradle.kts
@@ -9,9 +9,9 @@ pluginManagement {
         }
         mavenCentral()
         gradlePluginPortal()
-        // Use the nightly build of the Slice Tools plugin from the ZeroC maven-nightly repository.
+        // Use the nightly build of the Slice Tools plugin from the ZeroC maven-3.9-nightly repository.
         maven {
-            url = uri("https://download.zeroc.com/nexus/repository/maven-nightly/")
+            url = uri("https://download.zeroc.com/nexus/repository/maven-3.9-nightly/")
             content {
                 includeGroupByRegex("com\\.zeroc.*")
             }
@@ -23,9 +23,9 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
-        // Use the nightly build of Ice from the ZeroC maven-nightly repository.
+        // Use the nightly build of Ice from the ZeroC maven-3.9-nightly repository.
         maven {
-            url = uri("https://download.zeroc.com/nexus/repository/maven-nightly/")
+            url = uri("https://download.zeroc.com/nexus/repository/maven-3.9-nightly/")
             content {
                 includeGroupByRegex("com\\.zeroc.*")
             }

--- a/java/Ice/bidir/client/build.gradle.kts
+++ b/java/Ice/bidir/client/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id("application")
 
     // Apply the Slice-tools plugin to enable Slice compilation.
-    id("com.zeroc.slice-tools") version "3.8.+"
+    id("com.zeroc.slice-tools") version "3.9.+"
 
     // Pull in our local 'convention plugin' to enable linting.
     id("zeroc-linting")
@@ -13,7 +13,7 @@ plugins {
 
 dependencies {
     // Add the Ice library as an implementation dependency.
-    implementation("com.zeroc:ice:3.8.+")
+    implementation("com.zeroc:ice:3.9.+")
     implementation(project(":util"))
 }
 

--- a/java/Ice/bidir/server/build.gradle.kts
+++ b/java/Ice/bidir/server/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id("application")
 
     // Apply the Slice-tools plugin to enable Slice compilation.
-    id("com.zeroc.slice-tools") version "3.8.+"
+    id("com.zeroc.slice-tools") version "3.9.+"
 
     // Pull in our local 'convention plugin' to enable linting.
     id("zeroc-linting")
@@ -13,7 +13,7 @@ plugins {
 
 dependencies {
     // Add the Ice library as an implementation dependency.
-    implementation("com.zeroc:ice:3.8.+")
+    implementation("com.zeroc:ice:3.9.+")
     implementation(project(":util"))
 }
 

--- a/java/Ice/bidir/settings.gradle.kts
+++ b/java/Ice/bidir/settings.gradle.kts
@@ -4,9 +4,9 @@ pluginManagement {
     repositories {
         mavenLocal()
         gradlePluginPortal()
-        // Use the nightly build of the Slice Tools plugin from the ZeroC maven-nightly repository.
+        // Use the nightly build of the Slice Tools plugin from the ZeroC maven-3.9-nightly repository.
         maven {
-            url = uri("https://download.zeroc.com/nexus/repository/maven-nightly/")
+            url = uri("https://download.zeroc.com/nexus/repository/maven-3.9-nightly/")
             content {
                 includeGroupByRegex("com\\.zeroc.*")
             }
@@ -17,9 +17,9 @@ pluginManagement {
 dependencyResolutionManagement {
     repositories {
         mavenCentral()
-        // Use the nightly build of Ice from the ZeroC maven-nightly repository.
+        // Use the nightly build of Ice from the ZeroC maven-3.9-nightly repository.
         maven {
-            url = uri("https://download.zeroc.com/nexus/repository/maven-nightly/")
+            url = uri("https://download.zeroc.com/nexus/repository/maven-3.9-nightly/")
             content {
                 includeGroupByRegex("com\\.zeroc.*")
             }

--- a/java/Ice/callback/client/build.gradle.kts
+++ b/java/Ice/callback/client/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id("application")
 
     // Apply the Slice-tools plugin to enable Slice compilation.
-    id("com.zeroc.slice-tools") version "3.8.+"
+    id("com.zeroc.slice-tools") version "3.9.+"
 
     // Pull in our local 'convention plugin' to enable linting.
     id("zeroc-linting")
@@ -13,7 +13,7 @@ plugins {
 
 dependencies {
     // Add the Ice library as an implementation dependency.
-    implementation("com.zeroc:ice:3.8.+")
+    implementation("com.zeroc:ice:3.9.+")
     implementation(project(":util"))
 }
 

--- a/java/Ice/callback/server/build.gradle.kts
+++ b/java/Ice/callback/server/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id("application")
 
     // Apply the Slice-tools plugin to enable Slice compilation.
-    id("com.zeroc.slice-tools") version "3.8.+"
+    id("com.zeroc.slice-tools") version "3.9.+"
 
     // Pull in our local 'convention plugin' to enable linting.
     id("zeroc-linting")
@@ -13,7 +13,7 @@ plugins {
 
 dependencies {
     // Add the Ice library as an implementation dependency.
-    implementation("com.zeroc:ice:3.8.+")
+    implementation("com.zeroc:ice:3.9.+")
     implementation(project(":util"))
 }
 

--- a/java/Ice/callback/settings.gradle.kts
+++ b/java/Ice/callback/settings.gradle.kts
@@ -4,9 +4,9 @@ pluginManagement {
     repositories {
         mavenLocal()
         gradlePluginPortal()
-        // Use the nightly build of the Slice Tools plugin from the ZeroC maven-nightly repository.
+        // Use the nightly build of the Slice Tools plugin from the ZeroC maven-3.9-nightly repository.
         maven {
-            url = uri("https://download.zeroc.com/nexus/repository/maven-nightly/")
+            url = uri("https://download.zeroc.com/nexus/repository/maven-3.9-nightly/")
             content {
                 includeGroupByRegex("com\\.zeroc.*")
             }
@@ -17,9 +17,9 @@ pluginManagement {
 dependencyResolutionManagement {
     repositories {
         mavenCentral()
-        // Use the nightly build of Ice from the ZeroC maven-nightly repository.
+        // Use the nightly build of Ice from the ZeroC maven-3.9-nightly repository.
         maven {
-            url = uri("https://download.zeroc.com/nexus/repository/maven-nightly/")
+            url = uri("https://download.zeroc.com/nexus/repository/maven-3.9-nightly/")
             content {
                 includeGroupByRegex("com\\.zeroc.*")
             }

--- a/java/Ice/cancellation/client/build.gradle.kts
+++ b/java/Ice/cancellation/client/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id("application")
 
     // Apply the Slice-tools plugin to enable Slice compilation.
-    id("com.zeroc.slice-tools") version "3.8.+"
+    id("com.zeroc.slice-tools") version "3.9.+"
 
     // Pull in our local 'convention plugin' to enable linting.
     id("zeroc-linting")
@@ -13,7 +13,7 @@ plugins {
 
 dependencies {
     // Add the Ice library as an implementation dependency.
-    implementation("com.zeroc:ice:3.8.+")
+    implementation("com.zeroc:ice:3.9.+")
 }
 
 sourceSets {

--- a/java/Ice/cancellation/server/build.gradle.kts
+++ b/java/Ice/cancellation/server/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id("application")
 
     // Apply the Slice-tools plugin to enable Slice compilation.
-    id("com.zeroc.slice-tools") version "3.8.+"
+    id("com.zeroc.slice-tools") version "3.9.+"
 
     // Pull in our local 'convention plugin' to enable linting.
     id("zeroc-linting")
@@ -13,7 +13,7 @@ plugins {
 
 dependencies {
     // Add the Ice library as an implementation dependency.
-    implementation("com.zeroc:ice:3.8.+")
+    implementation("com.zeroc:ice:3.9.+")
 }
 
 sourceSets {

--- a/java/Ice/cancellation/settings.gradle.kts
+++ b/java/Ice/cancellation/settings.gradle.kts
@@ -4,9 +4,9 @@ pluginManagement {
     repositories {
         mavenLocal()
         gradlePluginPortal()
-        // Use the nightly build of the Slice Tools plugin from the ZeroC maven-nightly repository.
+        // Use the nightly build of the Slice Tools plugin from the ZeroC maven-3.9-nightly repository.
         maven {
-            url = uri("https://download.zeroc.com/nexus/repository/maven-nightly/")
+            url = uri("https://download.zeroc.com/nexus/repository/maven-3.9-nightly/")
             content {
                 includeGroupByRegex("com\\.zeroc.*")
             }
@@ -17,9 +17,9 @@ pluginManagement {
 dependencyResolutionManagement {
     repositories {
         mavenCentral()
-        // Use the nightly build of Ice from the ZeroC maven-nightly repository.
+        // Use the nightly build of Ice from the ZeroC maven-3.9-nightly repository.
         maven {
-            url = uri("https://download.zeroc.com/nexus/repository/maven-nightly/")
+            url = uri("https://download.zeroc.com/nexus/repository/maven-3.9-nightly/")
             content {
                 includeGroupByRegex("com\\.zeroc.*")
             }

--- a/java/Ice/config/client/build.gradle.kts
+++ b/java/Ice/config/client/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id("application")
 
     // Apply the Slice-tools plugin to enable Slice compilation.
-    id("com.zeroc.slice-tools") version "3.8.+"
+    id("com.zeroc.slice-tools") version "3.9.+"
 
     // Pull in our local 'convention plugin' to enable linting.
     id("zeroc-linting")
@@ -13,7 +13,7 @@ plugins {
 
 dependencies {
     // Add the Ice library as an implementation dependency.
-    implementation("com.zeroc:ice:3.8.+")
+    implementation("com.zeroc:ice:3.9.+")
 }
 
 sourceSets {

--- a/java/Ice/config/server/build.gradle.kts
+++ b/java/Ice/config/server/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id("application")
 
     // Apply the Slice-tools plugin to enable Slice compilation.
-    id("com.zeroc.slice-tools") version "3.8.+"
+    id("com.zeroc.slice-tools") version "3.9.+"
 
     // Pull in our local 'convention plugin' to enable linting.
     id("zeroc-linting")
@@ -13,7 +13,7 @@ plugins {
 
 dependencies {
     // Add the Ice library as an implementation dependency.
-    implementation("com.zeroc:ice:3.8.+")
+    implementation("com.zeroc:ice:3.9.+")
 }
 
 sourceSets {

--- a/java/Ice/config/settings.gradle.kts
+++ b/java/Ice/config/settings.gradle.kts
@@ -4,9 +4,9 @@ pluginManagement {
     repositories {
         mavenLocal()
         gradlePluginPortal()
-        // Use the nightly build of the Slice Tools plugin from the ZeroC maven-nightly repository.
+        // Use the nightly build of the Slice Tools plugin from the ZeroC maven-3.9-nightly repository.
         maven {
-            url = uri("https://download.zeroc.com/nexus/repository/maven-nightly/")
+            url = uri("https://download.zeroc.com/nexus/repository/maven-3.9-nightly/")
             content {
                 includeGroupByRegex("com\\.zeroc.*")
             }
@@ -17,9 +17,9 @@ pluginManagement {
 dependencyResolutionManagement {
     repositories {
         mavenCentral()
-        // Use the nightly build of Ice from the ZeroC maven-nightly repository.
+        // Use the nightly build of Ice from the ZeroC maven-3.9-nightly repository.
         maven {
-            url = uri("https://download.zeroc.com/nexus/repository/maven-nightly/")
+            url = uri("https://download.zeroc.com/nexus/repository/maven-3.9-nightly/")
             content {
                 includeGroupByRegex("com\\.zeroc.*")
             }

--- a/java/Ice/context/client/build.gradle.kts
+++ b/java/Ice/context/client/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id("application")
 
     // Apply the Slice-tools plugin to enable Slice compilation.
-    id("com.zeroc.slice-tools") version "3.8.+"
+    id("com.zeroc.slice-tools") version "3.9.+"
 
     // Pull in our local 'convention plugin' to enable linting.
     id("zeroc-linting")
@@ -13,7 +13,7 @@ plugins {
 
 dependencies {
     // Add the Ice library as an implementation dependency.
-    implementation("com.zeroc:ice:3.8.+")
+    implementation("com.zeroc:ice:3.9.+")
 }
 
 sourceSets {

--- a/java/Ice/context/server/build.gradle.kts
+++ b/java/Ice/context/server/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id("application")
 
     // Apply the Slice-tools plugin to enable Slice compilation.
-    id("com.zeroc.slice-tools") version "3.8.+"
+    id("com.zeroc.slice-tools") version "3.9.+"
 
     // Pull in our local 'convention plugin' to enable linting.
     id("zeroc-linting")
@@ -13,7 +13,7 @@ plugins {
 
 dependencies {
     // Add the Ice library as an implementation dependency.
-    implementation("com.zeroc:ice:3.8.+")
+    implementation("com.zeroc:ice:3.9.+")
 }
 
 sourceSets {

--- a/java/Ice/context/settings.gradle.kts
+++ b/java/Ice/context/settings.gradle.kts
@@ -4,9 +4,9 @@ pluginManagement {
     repositories {
         mavenLocal()
         gradlePluginPortal()
-        // Use the nightly build of the Slice Tools plugin from the ZeroC maven-nightly repository.
+        // Use the nightly build of the Slice Tools plugin from the ZeroC maven-3.9-nightly repository.
         maven {
-            url = uri("https://download.zeroc.com/nexus/repository/maven-nightly/")
+            url = uri("https://download.zeroc.com/nexus/repository/maven-3.9-nightly/")
             content {
                 includeGroupByRegex("com\\.zeroc.*")
             }
@@ -17,9 +17,9 @@ pluginManagement {
 dependencyResolutionManagement {
     repositories {
         mavenCentral()
-        // Use the nightly build of Ice from the ZeroC maven-nightly repository.
+        // Use the nightly build of Ice from the ZeroC maven-3.9-nightly repository.
         maven {
-            url = uri("https://download.zeroc.com/nexus/repository/maven-nightly/")
+            url = uri("https://download.zeroc.com/nexus/repository/maven-3.9-nightly/")
             content {
                 includeGroupByRegex("com\\.zeroc.*")
             }

--- a/java/Ice/customError/client/build.gradle.kts
+++ b/java/Ice/customError/client/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id("application")
 
     // Apply the Slice-tools plugin to enable Slice compilation.
-    id("com.zeroc.slice-tools") version "3.8.+"
+    id("com.zeroc.slice-tools") version "3.9.+"
 
     // Pull in our local 'convention plugin' to enable linting.
     id("zeroc-linting")
@@ -13,7 +13,7 @@ plugins {
 
 dependencies {
     // Add the Ice library as an implementation dependency.
-    implementation("com.zeroc:ice:3.8.+")
+    implementation("com.zeroc:ice:3.9.+")
 }
 
 sourceSets {

--- a/java/Ice/customError/server/build.gradle.kts
+++ b/java/Ice/customError/server/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id("application")
 
     // Apply the Slice-tools plugin to enable Slice compilation.
-    id("com.zeroc.slice-tools") version "3.8.+"
+    id("com.zeroc.slice-tools") version "3.9.+"
 
     // Pull in our local 'convention plugin' to enable linting.
     id("zeroc-linting")
@@ -13,7 +13,7 @@ plugins {
 
 dependencies {
     // Add the Ice library as an implementation dependency.
-    implementation("com.zeroc:ice:3.8.+")
+    implementation("com.zeroc:ice:3.9.+")
 }
 
 sourceSets {

--- a/java/Ice/customError/settings.gradle.kts
+++ b/java/Ice/customError/settings.gradle.kts
@@ -4,9 +4,9 @@ pluginManagement {
     repositories {
         mavenLocal()
         gradlePluginPortal()
-        // Use the nightly build of the Slice Tools plugin from the ZeroC maven-nightly repository.
+        // Use the nightly build of the Slice Tools plugin from the ZeroC maven-3.9-nightly repository.
         maven {
-            url = uri("https://download.zeroc.com/nexus/repository/maven-nightly/")
+            url = uri("https://download.zeroc.com/nexus/repository/maven-3.9-nightly/")
             content {
                 includeGroupByRegex("com\\.zeroc.*")
             }
@@ -17,9 +17,9 @@ pluginManagement {
 dependencyResolutionManagement {
     repositories {
         mavenCentral()
-        // Use the nightly build of Ice from the ZeroC maven-nightly repository.
+        // Use the nightly build of Ice from the ZeroC maven-3.9-nightly repository.
         maven {
-            url = uri("https://download.zeroc.com/nexus/repository/maven-nightly/")
+            url = uri("https://download.zeroc.com/nexus/repository/maven-3.9-nightly/")
             content {
                 includeGroupByRegex("com\\.zeroc.*")
             }

--- a/java/Ice/forwarder/client/build.gradle.kts
+++ b/java/Ice/forwarder/client/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id("application")
 
     // Apply the Slice-tools plugin to enable Slice compilation.
-    id("com.zeroc.slice-tools") version "3.8.+"
+    id("com.zeroc.slice-tools") version "3.9.+"
 
     // Pull in our local 'convention plugin' to enable linting.
     id("zeroc-linting")
@@ -13,7 +13,7 @@ plugins {
 
 dependencies {
     // Add the Ice library as an implementation dependency.
-    implementation("com.zeroc:ice:3.8.+")
+    implementation("com.zeroc:ice:3.9.+")
 }
 
 sourceSets {

--- a/java/Ice/forwarder/forwardingserver/build.gradle.kts
+++ b/java/Ice/forwarder/forwardingserver/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 
 dependencies {
     // Add the Ice library as an implementation dependency.
-    implementation("com.zeroc:ice:3.8.+")
+    implementation("com.zeroc:ice:3.9.+")
 }
 
 application {

--- a/java/Ice/forwarder/server/build.gradle.kts
+++ b/java/Ice/forwarder/server/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id("application")
 
     // Apply the Slice-tools plugin to enable Slice compilation.
-    id("com.zeroc.slice-tools") version "3.8.+"
+    id("com.zeroc.slice-tools") version "3.9.+"
 
     // Pull in our local 'convention plugin' to enable linting.
     id("zeroc-linting")
@@ -13,7 +13,7 @@ plugins {
 
 dependencies {
     // Add the Ice library as an implementation dependency.
-    implementation("com.zeroc:ice:3.8.+")
+    implementation("com.zeroc:ice:3.9.+")
 }
 
 sourceSets {

--- a/java/Ice/forwarder/settings.gradle.kts
+++ b/java/Ice/forwarder/settings.gradle.kts
@@ -4,9 +4,9 @@ pluginManagement {
     repositories {
         mavenLocal()
         gradlePluginPortal()
-        // Use the nightly build of the Slice Tools plugin from the ZeroC maven-nightly repository.
+        // Use the nightly build of the Slice Tools plugin from the ZeroC maven-3.9-nightly repository.
         maven {
-            url = uri("https://download.zeroc.com/nexus/repository/maven-nightly/")
+            url = uri("https://download.zeroc.com/nexus/repository/maven-3.9-nightly/")
             content {
                 includeGroupByRegex("com\\.zeroc.*")
             }
@@ -17,9 +17,9 @@ pluginManagement {
 dependencyResolutionManagement {
     repositories {
         mavenCentral()
-        // Use the nightly build of Ice from the ZeroC maven-nightly repository.
+        // Use the nightly build of Ice from the ZeroC maven-3.9-nightly repository.
         maven {
-            url = uri("https://download.zeroc.com/nexus/repository/maven-nightly/")
+            url = uri("https://download.zeroc.com/nexus/repository/maven-3.9-nightly/")
             content {
                 includeGroupByRegex("com\\.zeroc.*")
             }

--- a/java/Ice/greeter/client/build.gradle.kts
+++ b/java/Ice/greeter/client/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id("application")
 
     // Apply the Slice-tools plugin to enable Slice compilation.
-    id("com.zeroc.slice-tools") version "3.8.+"
+    id("com.zeroc.slice-tools") version "3.9.+"
 
     // Pull in our local 'convention plugin' to enable linting.
     id("zeroc-linting")
@@ -13,7 +13,7 @@ plugins {
 
 dependencies {
     // Add the Ice library as an implementation dependency.
-    implementation("com.zeroc:ice:3.8.+")
+    implementation("com.zeroc:ice:3.9.+")
 }
 
 sourceSets {

--- a/java/Ice/greeter/server/build.gradle.kts
+++ b/java/Ice/greeter/server/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id("application")
 
     // Apply the Slice-tools plugin to enable Slice compilation.
-    id("com.zeroc.slice-tools") version "3.8.+"
+    id("com.zeroc.slice-tools") version "3.9.+"
 
     // Pull in our local 'convention plugin' to enable linting.
     id("zeroc-linting")
@@ -13,7 +13,7 @@ plugins {
 
 dependencies {
     // Add the Ice library as an implementation dependency.
-    implementation("com.zeroc:ice:3.8.+")
+    implementation("com.zeroc:ice:3.9.+")
 }
 
 sourceSets {

--- a/java/Ice/greeter/serveramd/build.gradle.kts
+++ b/java/Ice/greeter/serveramd/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id("application")
 
     // Apply the Slice-tools plugin to enable Slice compilation.
-    id("com.zeroc.slice-tools") version "3.8.+"
+    id("com.zeroc.slice-tools") version "3.9.+"
 
     // Pull in our local 'convention plugin' to enable linting.
     id("zeroc-linting")
@@ -13,7 +13,7 @@ plugins {
 
 dependencies {
     // Add the Ice library as an implementation dependency.
-    implementation("com.zeroc:ice:3.8.+")
+    implementation("com.zeroc:ice:3.9.+")
 }
 
 sourceSets {

--- a/java/Ice/greeter/settings.gradle.kts
+++ b/java/Ice/greeter/settings.gradle.kts
@@ -4,9 +4,9 @@ pluginManagement {
     repositories {
         mavenLocal()
         gradlePluginPortal()
-        // Use the nightly build of the Slice Tools plugin from the ZeroC maven-nightly repository.
+        // Use the nightly build of the Slice Tools plugin from the ZeroC maven-3.9-nightly repository.
         maven {
-            url = uri("https://download.zeroc.com/nexus/repository/maven-nightly/")
+            url = uri("https://download.zeroc.com/nexus/repository/maven-3.9-nightly/")
             content {
                 includeGroupByRegex("com\\.zeroc.*")
             }
@@ -17,9 +17,9 @@ pluginManagement {
 dependencyResolutionManagement {
     repositories {
         mavenCentral()
-        // Use the nightly build of Ice from the ZeroC maven-nightly repository.
+        // Use the nightly build of Ice from the ZeroC maven-3.9-nightly repository.
         maven {
-            url = uri("https://download.zeroc.com/nexus/repository/maven-nightly/")
+            url = uri("https://download.zeroc.com/nexus/repository/maven-3.9-nightly/")
             content {
                 includeGroupByRegex("com\\.zeroc.*")
             }

--- a/java/Ice/inheritance/client/build.gradle.kts
+++ b/java/Ice/inheritance/client/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id("application")
 
     // Apply the Slice-tools plugin to enable Slice compilation.
-    id("com.zeroc.slice-tools") version "3.8.+"
+    id("com.zeroc.slice-tools") version "3.9.+"
 
     // Pull in our local 'convention plugin' to enable linting.
     id("zeroc-linting")
@@ -13,7 +13,7 @@ plugins {
 
 dependencies {
     // Add the Ice library as an implementation dependency.
-    implementation("com.zeroc:ice:3.8.+")
+    implementation("com.zeroc:ice:3.9.+")
 }
 
 sourceSets {

--- a/java/Ice/inheritance/server/build.gradle.kts
+++ b/java/Ice/inheritance/server/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id("application")
 
     // Apply the Slice-tools plugin to enable Slice compilation.
-    id("com.zeroc.slice-tools") version "3.8.+"
+    id("com.zeroc.slice-tools") version "3.9.+"
 
     // Pull in our local 'convention plugin' to enable linting.
     id("zeroc-linting")
@@ -13,7 +13,7 @@ plugins {
 
 dependencies {
     // Add the Ice library as an implementation dependency.
-    implementation("com.zeroc:ice:3.8.+")
+    implementation("com.zeroc:ice:3.9.+")
 }
 
 sourceSets {

--- a/java/Ice/inheritance/settings.gradle.kts
+++ b/java/Ice/inheritance/settings.gradle.kts
@@ -4,9 +4,9 @@ pluginManagement {
     repositories {
         mavenLocal()
         gradlePluginPortal()
-        // Use the nightly build of the Slice Tools plugin from the ZeroC maven-nightly repository.
+        // Use the nightly build of the Slice Tools plugin from the ZeroC maven-3.9-nightly repository.
         maven {
-            url = uri("https://download.zeroc.com/nexus/repository/maven-nightly/")
+            url = uri("https://download.zeroc.com/nexus/repository/maven-3.9-nightly/")
             content {
                 includeGroupByRegex("com\\.zeroc.*")
             }
@@ -17,9 +17,9 @@ pluginManagement {
 dependencyResolutionManagement {
     repositories {
         mavenCentral()
-        // Use the nightly build of Ice from the ZeroC maven-nightly repository.
+        // Use the nightly build of Ice from the ZeroC maven-3.9-nightly repository.
         maven {
-            url = uri("https://download.zeroc.com/nexus/repository/maven-nightly/")
+            url = uri("https://download.zeroc.com/nexus/repository/maven-3.9-nightly/")
             content {
                 includeGroupByRegex("com\\.zeroc.*")
             }

--- a/java/Ice/middleware/client/build.gradle.kts
+++ b/java/Ice/middleware/client/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id("application")
 
     // Apply the Slice-tools plugin to enable Slice compilation.
-    id("com.zeroc.slice-tools") version "3.8.+"
+    id("com.zeroc.slice-tools") version "3.9.+"
 
     // Pull in our local 'convention plugin' to enable linting.
     id("zeroc-linting")
@@ -13,7 +13,7 @@ plugins {
 
 dependencies {
     // Add the Ice library as an implementation dependency.
-    implementation("com.zeroc:ice:3.8.+")
+    implementation("com.zeroc:ice:3.9.+")
 }
 
 sourceSets {

--- a/java/Ice/middleware/server/build.gradle.kts
+++ b/java/Ice/middleware/server/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id("application")
 
     // Apply the Slice-tools plugin to enable Slice compilation.
-    id("com.zeroc.slice-tools") version "3.8.+"
+    id("com.zeroc.slice-tools") version "3.9.+"
 
     // Pull in our local 'convention plugin' to enable linting.
     id("zeroc-linting")
@@ -13,7 +13,7 @@ plugins {
 
 dependencies {
     // Add the Ice library as an implementation dependency.
-    implementation("com.zeroc:ice:3.8.+")
+    implementation("com.zeroc:ice:3.9.+")
 }
 
 sourceSets {

--- a/java/Ice/middleware/settings.gradle.kts
+++ b/java/Ice/middleware/settings.gradle.kts
@@ -4,9 +4,9 @@ pluginManagement {
     repositories {
         mavenLocal()
         gradlePluginPortal()
-        // Use the nightly build of the Slice Tools plugin from the ZeroC maven-nightly repository.
+        // Use the nightly build of the Slice Tools plugin from the ZeroC maven-3.9-nightly repository.
         maven {
-            url = uri("https://download.zeroc.com/nexus/repository/maven-nightly/")
+            url = uri("https://download.zeroc.com/nexus/repository/maven-3.9-nightly/")
             content {
                 includeGroupByRegex("com\\.zeroc.*")
             }
@@ -17,9 +17,9 @@ pluginManagement {
 dependencyResolutionManagement {
     repositories {
         mavenCentral()
-        // Use the nightly build of Ice from the ZeroC maven-nightly repository.
+        // Use the nightly build of Ice from the ZeroC maven-3.9-nightly repository.
         maven {
-            url = uri("https://download.zeroc.com/nexus/repository/maven-nightly/")
+            url = uri("https://download.zeroc.com/nexus/repository/maven-3.9-nightly/")
             content {
                 includeGroupByRegex("com\\.zeroc.*")
             }

--- a/java/Ice/optional/client1/build.gradle.kts
+++ b/java/Ice/optional/client1/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id("application")
 
     // Apply the Slice-tools plugin to enable Slice compilation.
-    id("com.zeroc.slice-tools") version "3.8.+"
+    id("com.zeroc.slice-tools") version "3.9.+"
 
     // Pull in our local 'convention plugin' to enable linting.
     id("zeroc-linting")
@@ -13,7 +13,7 @@ plugins {
 
 dependencies {
     // Add the Ice library as an implementation dependency.
-    implementation("com.zeroc:ice:3.8.+")
+    implementation("com.zeroc:ice:3.9.+")
 }
 
 sourceSets {

--- a/java/Ice/optional/client2/build.gradle.kts
+++ b/java/Ice/optional/client2/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id("application")
 
     // Apply the Slice-tools plugin to enable Slice compilation.
-    id("com.zeroc.slice-tools") version "3.8.+"
+    id("com.zeroc.slice-tools") version "3.9.+"
 
     // Pull in our local 'convention plugin' to enable linting.
     id("zeroc-linting")
@@ -13,7 +13,7 @@ plugins {
 
 dependencies {
     // Add the Ice library as an implementation dependency.
-    implementation("com.zeroc:ice:3.8.+")
+    implementation("com.zeroc:ice:3.9.+")
 }
 
 sourceSets {

--- a/java/Ice/optional/server1/build.gradle.kts
+++ b/java/Ice/optional/server1/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id("application")
 
     // Apply the Slice-tools plugin to enable Slice compilation.
-    id("com.zeroc.slice-tools") version "3.8.+"
+    id("com.zeroc.slice-tools") version "3.9.+"
 
     // Pull in our local 'convention plugin' to enable linting.
     id("zeroc-linting")
@@ -13,7 +13,7 @@ plugins {
 
 dependencies {
     // Add the Ice library as an implementation dependency.
-    implementation("com.zeroc:ice:3.8.+")
+    implementation("com.zeroc:ice:3.9.+")
 }
 
 sourceSets {

--- a/java/Ice/optional/server2/build.gradle.kts
+++ b/java/Ice/optional/server2/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id("application")
 
     // Apply the Slice-tools plugin to enable Slice compilation.
-    id("com.zeroc.slice-tools") version "3.8.+"
+    id("com.zeroc.slice-tools") version "3.9.+"
 
     // Pull in our local 'convention plugin' to enable linting.
     id("zeroc-linting")
@@ -13,7 +13,7 @@ plugins {
 
 dependencies {
     // Add the Ice library as an implementation dependency.
-    implementation("com.zeroc:ice:3.8.+")
+    implementation("com.zeroc:ice:3.9.+")
 }
 
 sourceSets {

--- a/java/Ice/optional/settings.gradle.kts
+++ b/java/Ice/optional/settings.gradle.kts
@@ -4,9 +4,9 @@ pluginManagement {
     repositories {
         mavenLocal()
         gradlePluginPortal()
-        // Use the nightly build of the Slice Tools plugin from the ZeroC maven-nightly repository.
+        // Use the nightly build of the Slice Tools plugin from the ZeroC maven-3.9-nightly repository.
         maven {
-            url = uri("https://download.zeroc.com/nexus/repository/maven-nightly/")
+            url = uri("https://download.zeroc.com/nexus/repository/maven-3.9-nightly/")
             content {
                 includeGroupByRegex("com\\.zeroc.*")
             }
@@ -17,9 +17,9 @@ pluginManagement {
 dependencyResolutionManagement {
     repositories {
         mavenCentral()
-        // Use the nightly build of Ice from the ZeroC maven-nightly repository.
+        // Use the nightly build of Ice from the ZeroC maven-3.9-nightly repository.
         maven {
-            url = uri("https://download.zeroc.com/nexus/repository/maven-nightly/")
+            url = uri("https://download.zeroc.com/nexus/repository/maven-3.9-nightly/")
             content {
                 includeGroupByRegex("com\\.zeroc.*")
             }

--- a/java/Ice/secure/client/build.gradle.kts
+++ b/java/Ice/secure/client/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id("application")
 
     // Apply the Slice-tools plugin to enable Slice compilation.
-    id("com.zeroc.slice-tools") version "3.8.+"
+    id("com.zeroc.slice-tools") version "3.9.+"
 
     // Pull in our local 'convention plugin' to enable linting.
     id("zeroc-linting")
@@ -13,7 +13,7 @@ plugins {
 
 dependencies {
     // Add the Ice library as an implementation dependency.
-    implementation("com.zeroc:ice:3.8.+")
+    implementation("com.zeroc:ice:3.9.+")
 }
 
 sourceSets {

--- a/java/Ice/secure/server/build.gradle.kts
+++ b/java/Ice/secure/server/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id("application")
 
     // Apply the Slice-tools plugin to enable Slice compilation.
-    id("com.zeroc.slice-tools") version "3.8.+"
+    id("com.zeroc.slice-tools") version "3.9.+"
 
     // Pull in our local 'convention plugin' to enable linting.
     id("zeroc-linting")
@@ -13,7 +13,7 @@ plugins {
 
 dependencies {
     // Add the Ice library as an implementation dependency.
-    implementation("com.zeroc:ice:3.8.+")
+    implementation("com.zeroc:ice:3.9.+")
 }
 
 sourceSets {

--- a/java/Ice/secure/settings.gradle.kts
+++ b/java/Ice/secure/settings.gradle.kts
@@ -4,9 +4,9 @@ pluginManagement {
     repositories {
         mavenLocal()
         gradlePluginPortal()
-        // Use the nightly build of the Slice Tools plugin from the ZeroC maven-nightly repository.
+        // Use the nightly build of the Slice Tools plugin from the ZeroC maven-3.9-nightly repository.
         maven {
-            url = uri("https://download.zeroc.com/nexus/repository/maven-nightly/")
+            url = uri("https://download.zeroc.com/nexus/repository/maven-3.9-nightly/")
             content {
                 includeGroupByRegex("com\\.zeroc.*")
             }
@@ -17,9 +17,9 @@ pluginManagement {
 dependencyResolutionManagement {
     repositories {
         mavenCentral()
-        // Use the nightly build of Ice from the ZeroC maven-nightly repository.
+        // Use the nightly build of Ice from the ZeroC maven-3.9-nightly repository.
         maven {
-            url = uri("https://download.zeroc.com/nexus/repository/maven-nightly/")
+            url = uri("https://download.zeroc.com/nexus/repository/maven-3.9-nightly/")
             content {
                 includeGroupByRegex("com\\.zeroc.*")
             }

--- a/java/IceBox/greeter/client/build.gradle.kts
+++ b/java/IceBox/greeter/client/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id("application")
 
     // Apply the Slice-tools plugin to enable Slice compilation.
-    id("com.zeroc.slice-tools") version "3.8.+"
+    id("com.zeroc.slice-tools") version "3.9.+"
 
     // Pull in our local 'convention plugin' to enable linting.
     id("zeroc-linting")
@@ -13,7 +13,7 @@ plugins {
 
 dependencies {
     // Add the Ice library as an implementation dependency.
-    implementation("com.zeroc:ice:3.8.+")
+    implementation("com.zeroc:ice:3.9.+")
 }
 
 sourceSets {

--- a/java/IceBox/greeter/iceboxserver/build.gradle.kts
+++ b/java/IceBox/greeter/iceboxserver/build.gradle.kts
@@ -7,8 +7,8 @@ plugins {
 
 dependencies {
     // Include the Ice and IceBox libraries on the runtime classpath.
-    runtimeOnly("com.zeroc:ice:3.8.+")
-    runtimeOnly("com.zeroc:icebox:3.8.+")
+    runtimeOnly("com.zeroc:ice:3.9.+")
+    runtimeOnly("com.zeroc:icebox:3.9.+")
 
     // Include the service project so its GreeterService class is available at runtime.
     runtimeOnly(project(":service"))

--- a/java/IceBox/greeter/service/build.gradle.kts
+++ b/java/IceBox/greeter/service/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id("java-library")
 
     // Apply the Slice-tools plugin to enable Slice compilation.
-    id("com.zeroc.slice-tools") version "3.8.+"
+    id("com.zeroc.slice-tools") version "3.9.+"
 
     // Pull in our local 'convention plugin' to enable linting.
     id("zeroc-linting")
@@ -13,8 +13,8 @@ plugins {
 
 dependencies {
     // Add the Ice and IceBox libraries as implementation dependencies.
-    implementation("com.zeroc:ice:3.8.+")
-    implementation("com.zeroc:icebox:3.8.+")
+    implementation("com.zeroc:ice:3.9.+")
+    implementation("com.zeroc:icebox:3.9.+")
 }
 
 sourceSets {

--- a/java/IceBox/greeter/settings.gradle.kts
+++ b/java/IceBox/greeter/settings.gradle.kts
@@ -4,9 +4,9 @@ pluginManagement {
     repositories {
         mavenLocal()
         gradlePluginPortal()
-        // Use the nightly build of the Slice Tools plugin from the ZeroC maven-nightly repository.
+        // Use the nightly build of the Slice Tools plugin from the ZeroC maven-3.9-nightly repository.
         maven {
-            url = uri("https://download.zeroc.com/nexus/repository/maven-nightly/")
+            url = uri("https://download.zeroc.com/nexus/repository/maven-3.9-nightly/")
             content {
                 includeGroupByRegex("com\\.zeroc.*")
             }
@@ -17,9 +17,9 @@ pluginManagement {
 dependencyResolutionManagement {
     repositories {
         mavenCentral()
-        // Use the nightly build of Ice from the ZeroC maven-nightly repository.
+        // Use the nightly build of Ice from the ZeroC maven-3.9-nightly repository.
         maven {
-            url = uri("https://download.zeroc.com/nexus/repository/maven-nightly/")
+            url = uri("https://download.zeroc.com/nexus/repository/maven-3.9-nightly/")
             content {
                 includeGroupByRegex("com\\.zeroc.*")
             }

--- a/java/IceDiscovery/greeter/client/build.gradle.kts
+++ b/java/IceDiscovery/greeter/client/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id("application")
 
     // Apply the Slice-tools plugin to enable Slice compilation.
-    id("com.zeroc.slice-tools") version "3.8.+"
+    id("com.zeroc.slice-tools") version "3.9.+"
 
     // Pull in our local 'convention plugin' to enable linting.
     id("zeroc-linting")
@@ -13,8 +13,8 @@ plugins {
 
 dependencies {
     // Add the Ice and IceDiscovery libraries as implementation dependencies.
-    implementation("com.zeroc:ice:3.8.+")
-    implementation("com.zeroc:icediscovery:3.8.+")
+    implementation("com.zeroc:ice:3.9.+")
+    implementation("com.zeroc:icediscovery:3.9.+")
 }
 
 sourceSets {

--- a/java/IceDiscovery/greeter/server/build.gradle.kts
+++ b/java/IceDiscovery/greeter/server/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id("application")
 
     // Apply the Slice-tools plugin to enable Slice compilation.
-    id("com.zeroc.slice-tools") version "3.8.+"
+    id("com.zeroc.slice-tools") version "3.9.+"
 
     // Pull in our local 'convention plugin' to enable linting.
     id("zeroc-linting")
@@ -13,8 +13,8 @@ plugins {
 
 dependencies {
     // Add the Ice and IceDiscovery libraries as implementation dependencies.
-    implementation("com.zeroc:ice:3.8.+")
-    implementation("com.zeroc:icediscovery:3.8.+")
+    implementation("com.zeroc:ice:3.9.+")
+    implementation("com.zeroc:icediscovery:3.9.+")
 }
 
 sourceSets {

--- a/java/IceDiscovery/greeter/settings.gradle.kts
+++ b/java/IceDiscovery/greeter/settings.gradle.kts
@@ -4,9 +4,9 @@ pluginManagement {
     repositories {
         mavenLocal()
         gradlePluginPortal()
-        // Use the nightly build of the Slice Tools plugin from the ZeroC maven-nightly repository.
+        // Use the nightly build of the Slice Tools plugin from the ZeroC maven-3.9-nightly repository.
         maven {
-            url = uri("https://download.zeroc.com/nexus/repository/maven-nightly/")
+            url = uri("https://download.zeroc.com/nexus/repository/maven-3.9-nightly/")
             content {
                 includeGroupByRegex("com\\.zeroc.*")
             }
@@ -17,9 +17,9 @@ pluginManagement {
 dependencyResolutionManagement {
     repositories {
         mavenCentral()
-        // Use the nightly build of Ice from the ZeroC maven-nightly repository.
+        // Use the nightly build of Ice from the ZeroC maven-3.9-nightly repository.
         maven {
-            url = uri("https://download.zeroc.com/nexus/repository/maven-nightly/")
+            url = uri("https://download.zeroc.com/nexus/repository/maven-3.9-nightly/")
             content {
                 includeGroupByRegex("com\\.zeroc.*")
             }

--- a/java/IceDiscovery/replication/client/build.gradle.kts
+++ b/java/IceDiscovery/replication/client/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id("application")
 
     // Apply the Slice-tools plugin to enable Slice compilation.
-    id("com.zeroc.slice-tools") version "3.8.+"
+    id("com.zeroc.slice-tools") version "3.9.+"
 
     // Pull in our local 'convention plugin' to enable linting.
     id("zeroc-linting")
@@ -13,8 +13,8 @@ plugins {
 
 dependencies {
     // Add the Ice and IceDiscovery libraries as implementation dependencies.
-    implementation("com.zeroc:ice:3.8.+")
-    implementation("com.zeroc:icediscovery:3.8.+")
+    implementation("com.zeroc:ice:3.9.+")
+    implementation("com.zeroc:icediscovery:3.9.+")
 }
 
 sourceSets {

--- a/java/IceDiscovery/replication/server/build.gradle.kts
+++ b/java/IceDiscovery/replication/server/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id("application")
 
     // Apply the Slice-tools plugin to enable Slice compilation.
-    id("com.zeroc.slice-tools") version "3.8.+"
+    id("com.zeroc.slice-tools") version "3.9.+"
 
     // Pull in our local 'convention plugin' to enable linting.
     id("zeroc-linting")
@@ -13,8 +13,8 @@ plugins {
 
 dependencies {
     // Add the Ice and IceDiscovery libraries as implementation dependencies.
-    implementation("com.zeroc:ice:3.8.+")
-    implementation("com.zeroc:icediscovery:3.8.+")
+    implementation("com.zeroc:ice:3.9.+")
+    implementation("com.zeroc:icediscovery:3.9.+")
 }
 
 sourceSets {

--- a/java/IceDiscovery/replication/settings.gradle.kts
+++ b/java/IceDiscovery/replication/settings.gradle.kts
@@ -4,9 +4,9 @@ pluginManagement {
     repositories {
         mavenLocal()
         gradlePluginPortal()
-        // Use the nightly build of the Slice Tools plugin from the ZeroC maven-nightly repository.
+        // Use the nightly build of the Slice Tools plugin from the ZeroC maven-3.9-nightly repository.
         maven {
-            url = uri("https://download.zeroc.com/nexus/repository/maven-nightly/")
+            url = uri("https://download.zeroc.com/nexus/repository/maven-3.9-nightly/")
             content {
                 includeGroupByRegex("com\\.zeroc.*")
             }
@@ -17,9 +17,9 @@ pluginManagement {
 dependencyResolutionManagement {
     repositories {
         mavenCentral()
-        // Use the nightly build of Ice from the ZeroC maven-nightly repository.
+        // Use the nightly build of Ice from the ZeroC maven-3.9-nightly repository.
         maven {
-            url = uri("https://download.zeroc.com/nexus/repository/maven-nightly/")
+            url = uri("https://download.zeroc.com/nexus/repository/maven-3.9-nightly/")
             content {
                 includeGroupByRegex("com\\.zeroc.*")
             }

--- a/java/IceGrid/greeter/client/build.gradle.kts
+++ b/java/IceGrid/greeter/client/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id("application")
 
     // Apply the Slice-tools plugin to enable Slice compilation.
-    id("com.zeroc.slice-tools") version "3.8.+"
+    id("com.zeroc.slice-tools") version "3.9.+"
 
     // Pull in our local 'convention plugin' to enable linting.
     id("zeroc-linting")
@@ -13,7 +13,7 @@ plugins {
 
 dependencies {
     // Add the Ice library as an implementation dependency.
-    implementation("com.zeroc:ice:3.8.+")
+    implementation("com.zeroc:ice:3.9.+")
 }
 
 sourceSets {

--- a/java/IceGrid/greeter/server/build.gradle.kts
+++ b/java/IceGrid/greeter/server/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id("application")
 
     // Apply the Slice-tools plugin to enable Slice compilation.
-    id("com.zeroc.slice-tools") version "3.8.+"
+    id("com.zeroc.slice-tools") version "3.9.+"
 
     // Pull in our local 'convention plugin' to enable linting.
     id("zeroc-linting")
@@ -13,7 +13,7 @@ plugins {
 
 dependencies {
     // Add the Ice library as an implementation dependency.
-    implementation("com.zeroc:ice:3.8.+")
+    implementation("com.zeroc:ice:3.9.+")
 }
 
 sourceSets {

--- a/java/IceGrid/greeter/settings.gradle.kts
+++ b/java/IceGrid/greeter/settings.gradle.kts
@@ -4,9 +4,9 @@ pluginManagement {
     repositories {
         mavenLocal()
         gradlePluginPortal()
-        // Use the nightly build of the Slice Tools plugin from the ZeroC maven-nightly repository.
+        // Use the nightly build of the Slice Tools plugin from the ZeroC maven-3.9-nightly repository.
         maven {
-            url = uri("https://download.zeroc.com/nexus/repository/maven-nightly/")
+            url = uri("https://download.zeroc.com/nexus/repository/maven-3.9-nightly/")
             content {
                 includeGroupByRegex("com\\.zeroc.*")
             }
@@ -17,9 +17,9 @@ pluginManagement {
 dependencyResolutionManagement {
     repositories {
         mavenCentral()
-        // Use the nightly build of Ice from the ZeroC maven-nightly repository.
+        // Use the nightly build of Ice from the ZeroC maven-3.9-nightly repository.
         maven {
-            url = uri("https://download.zeroc.com/nexus/repository/maven-nightly/")
+            url = uri("https://download.zeroc.com/nexus/repository/maven-3.9-nightly/")
             content {
                 includeGroupByRegex("com\\.zeroc.*")
             }

--- a/java/IceGrid/icebox/client/build.gradle.kts
+++ b/java/IceGrid/icebox/client/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id("application")
 
     // Apply the Slice-tools plugin to enable Slice compilation.
-    id("com.zeroc.slice-tools") version "3.8.+"
+    id("com.zeroc.slice-tools") version "3.9.+"
 
     // Pull in our local 'convention plugin' to enable linting.
     id("zeroc-linting")
@@ -13,7 +13,7 @@ plugins {
 
 dependencies {
     // Add the Ice library as an implementation dependency.
-    implementation("com.zeroc:ice:3.8.+")
+    implementation("com.zeroc:ice:3.9.+")
 }
 
 sourceSets {

--- a/java/IceGrid/icebox/iceboxserver/build.gradle.kts
+++ b/java/IceGrid/icebox/iceboxserver/build.gradle.kts
@@ -7,8 +7,8 @@ plugins {
 
 dependencies {
     // Include the Ice and IceBox libraries on the runtime classpath.
-    runtimeOnly("com.zeroc:ice:3.8.+")
-    runtimeOnly("com.zeroc:icebox:3.8.+")
+    runtimeOnly("com.zeroc:ice:3.9.+")
+    runtimeOnly("com.zeroc:icebox:3.9.+")
 
     // Include the service project so its GreeterService class is available at runtime.
     runtimeOnly(project(":service"))

--- a/java/IceGrid/icebox/service/build.gradle.kts
+++ b/java/IceGrid/icebox/service/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id("java-library")
 
     // Apply the Slice-tools plugin to enable Slice compilation.
-    id("com.zeroc.slice-tools") version "3.8.+"
+    id("com.zeroc.slice-tools") version "3.9.+"
 
     // Pull in our local 'convention plugin' to enable linting.
     id("zeroc-linting")
@@ -13,8 +13,8 @@ plugins {
 
 dependencies {
     // Add the Ice and IceBox libraries as implementation dependencies.
-    implementation("com.zeroc:ice:3.8.+")
-    implementation("com.zeroc:icebox:3.8.+")
+    implementation("com.zeroc:ice:3.9.+")
+    implementation("com.zeroc:icebox:3.9.+")
 }
 
 sourceSets {

--- a/java/IceGrid/icebox/settings.gradle.kts
+++ b/java/IceGrid/icebox/settings.gradle.kts
@@ -4,9 +4,9 @@ pluginManagement {
     repositories {
         mavenLocal()
         gradlePluginPortal()
-        // Use the nightly build of the Slice Tools plugin from the ZeroC maven-nightly repository.
+        // Use the nightly build of the Slice Tools plugin from the ZeroC maven-3.9-nightly repository.
         maven {
-            url = uri("https://download.zeroc.com/nexus/repository/maven-nightly/")
+            url = uri("https://download.zeroc.com/nexus/repository/maven-3.9-nightly/")
             content {
                 includeGroupByRegex("com\\.zeroc.*")
             }
@@ -17,9 +17,9 @@ pluginManagement {
 dependencyResolutionManagement {
     repositories {
         mavenCentral()
-        // Use the nightly build of Ice from the ZeroC maven-nightly repository.
+        // Use the nightly build of Ice from the ZeroC maven-3.9-nightly repository.
         maven {
-            url = uri("https://download.zeroc.com/nexus/repository/maven-nightly/")
+            url = uri("https://download.zeroc.com/nexus/repository/maven-3.9-nightly/")
             content {
                 includeGroupByRegex("com\\.zeroc.*")
             }

--- a/java/IceGrid/locatorDiscovery/client/build.gradle.kts
+++ b/java/IceGrid/locatorDiscovery/client/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id("application")
 
     // Apply the Slice-tools plugin to enable Slice compilation.
-    id("com.zeroc.slice-tools") version "3.8.+"
+    id("com.zeroc.slice-tools") version "3.9.+"
 
     // Pull in our local 'convention plugin' to enable linting.
     id("zeroc-linting")
@@ -13,8 +13,8 @@ plugins {
 
 dependencies {
     // Add the Ice and IceLocatorDiscovery libraries as an implementation dependencies.
-    implementation("com.zeroc:ice:3.8.+")
-    implementation("com.zeroc:icelocatordiscovery:3.8.+")
+    implementation("com.zeroc:ice:3.9.+")
+    implementation("com.zeroc:icelocatordiscovery:3.9.+")
 }
 
 sourceSets {

--- a/java/IceGrid/locatorDiscovery/server/build.gradle.kts
+++ b/java/IceGrid/locatorDiscovery/server/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id("application")
 
     // Apply the Slice-tools plugin to enable Slice compilation.
-    id("com.zeroc.slice-tools") version "3.8.+"
+    id("com.zeroc.slice-tools") version "3.9.+"
 
     // Pull in our local 'convention plugin' to enable linting.
     id("zeroc-linting")
@@ -13,7 +13,7 @@ plugins {
 
 dependencies {
     // Add the Ice library as an implementation dependency.
-    implementation("com.zeroc:ice:3.8.+")
+    implementation("com.zeroc:ice:3.9.+")
 }
 
 sourceSets {

--- a/java/IceGrid/locatorDiscovery/settings.gradle.kts
+++ b/java/IceGrid/locatorDiscovery/settings.gradle.kts
@@ -4,9 +4,9 @@ pluginManagement {
     repositories {
         mavenLocal()
         gradlePluginPortal()
-        // Use the nightly build of the Slice Tools plugin from the ZeroC maven-nightly repository.
+        // Use the nightly build of the Slice Tools plugin from the ZeroC maven-3.9-nightly repository.
         maven {
-            url = uri("https://download.zeroc.com/nexus/repository/maven-nightly/")
+            url = uri("https://download.zeroc.com/nexus/repository/maven-3.9-nightly/")
             content {
                 includeGroupByRegex("com\\.zeroc.*")
             }
@@ -17,9 +17,9 @@ pluginManagement {
 dependencyResolutionManagement {
     repositories {
         mavenCentral()
-        // Use the nightly build of Ice from the ZeroC maven-nightly repository.
+        // Use the nightly build of Ice from the ZeroC maven-3.9-nightly repository.
         maven {
-            url = uri("https://download.zeroc.com/nexus/repository/maven-nightly/")
+            url = uri("https://download.zeroc.com/nexus/repository/maven-3.9-nightly/")
             content {
                 includeGroupByRegex("com\\.zeroc.*")
             }

--- a/java/IceGrid/query/client/build.gradle.kts
+++ b/java/IceGrid/query/client/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id("application")
 
     // Apply the Slice-tools plugin to enable Slice compilation.
-    id("com.zeroc.slice-tools") version "3.8.+"
+    id("com.zeroc.slice-tools") version "3.9.+"
 
     // Pull in our local 'convention plugin' to enable linting.
     id("zeroc-linting")
@@ -13,8 +13,8 @@ plugins {
 
 dependencies {
     // Add the Ice and IceGrid libraries as an implementation dependencies.
-    implementation("com.zeroc:ice:3.8.+")
-    implementation("com.zeroc:icegrid:3.8.+")
+    implementation("com.zeroc:ice:3.9.+")
+    implementation("com.zeroc:icegrid:3.9.+")
 }
 
 sourceSets {

--- a/java/IceGrid/query/server/build.gradle.kts
+++ b/java/IceGrid/query/server/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id("application")
 
     // Apply the Slice-tools plugin to enable Slice compilation.
-    id("com.zeroc.slice-tools") version "3.8.+"
+    id("com.zeroc.slice-tools") version "3.9.+"
 
     // Pull in our local 'convention plugin' to enable linting.
     id("zeroc-linting")
@@ -13,7 +13,7 @@ plugins {
 
 dependencies {
     // Add the Ice library as an implementation dependency.
-    implementation("com.zeroc:ice:3.8.+")
+    implementation("com.zeroc:ice:3.9.+")
 }
 
 sourceSets {

--- a/java/IceGrid/query/settings.gradle.kts
+++ b/java/IceGrid/query/settings.gradle.kts
@@ -4,9 +4,9 @@ pluginManagement {
     repositories {
         mavenLocal()
         gradlePluginPortal()
-        // Use the nightly build of the Slice Tools plugin from the ZeroC maven-nightly repository.
+        // Use the nightly build of the Slice Tools plugin from the ZeroC maven-3.9-nightly repository.
         maven {
-            url = uri("https://download.zeroc.com/nexus/repository/maven-nightly/")
+            url = uri("https://download.zeroc.com/nexus/repository/maven-3.9-nightly/")
             content {
                 includeGroupByRegex("com\\.zeroc.*")
             }
@@ -17,9 +17,9 @@ pluginManagement {
 dependencyResolutionManagement {
     repositories {
         mavenCentral()
-        // Use the nightly build of Ice from the ZeroC maven-nightly repository.
+        // Use the nightly build of Ice from the ZeroC maven-3.9-nightly repository.
         maven {
-            url = uri("https://download.zeroc.com/nexus/repository/maven-nightly/")
+            url = uri("https://download.zeroc.com/nexus/repository/maven-3.9-nightly/")
             content {
                 includeGroupByRegex("com\\.zeroc.*")
             }

--- a/java/IceStorm/weather/sensor/build.gradle.kts
+++ b/java/IceStorm/weather/sensor/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id("application")
 
     // Apply the Slice-tools plugin to enable Slice compilation.
-    id("com.zeroc.slice-tools") version "3.8.+"
+    id("com.zeroc.slice-tools") version "3.9.+"
 
     // Pull in our local 'convention plugin' to enable linting.
     id("zeroc-linting")
@@ -13,8 +13,8 @@ plugins {
 
 dependencies {
     // Add the Ice and IceStorm libraries as an implementation dependency.
-    implementation("com.zeroc:ice:3.8.+")
-    implementation("com.zeroc:icestorm:3.8.+")
+    implementation("com.zeroc:ice:3.9.+")
+    implementation("com.zeroc:icestorm:3.9.+")
 }
 
 sourceSets {

--- a/java/IceStorm/weather/settings.gradle.kts
+++ b/java/IceStorm/weather/settings.gradle.kts
@@ -4,9 +4,9 @@ pluginManagement {
     repositories {
         mavenLocal()
         gradlePluginPortal()
-        // Use the nightly build of the Slice Tools plugin from the ZeroC maven-nightly repository.
+        // Use the nightly build of the Slice Tools plugin from the ZeroC maven-3.9-nightly repository.
         maven {
-            url = uri("https://download.zeroc.com/nexus/repository/maven-nightly/")
+            url = uri("https://download.zeroc.com/nexus/repository/maven-3.9-nightly/")
             content {
                 includeGroupByRegex("com\\.zeroc.*")
             }
@@ -17,9 +17,9 @@ pluginManagement {
 dependencyResolutionManagement {
     repositories {
         mavenCentral()
-        // Use the nightly build of Ice from the ZeroC maven-nightly repository.
+        // Use the nightly build of Ice from the ZeroC maven-3.9-nightly repository.
         maven {
-            url = uri("https://download.zeroc.com/nexus/repository/maven-nightly/")
+            url = uri("https://download.zeroc.com/nexus/repository/maven-3.9-nightly/")
             content {
                 includeGroupByRegex("com\\.zeroc.*")
             }

--- a/java/IceStorm/weather/station/build.gradle.kts
+++ b/java/IceStorm/weather/station/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id("application")
 
     // Apply the Slice-tools plugin to enable Slice compilation.
-    id("com.zeroc.slice-tools") version "3.8.+"
+    id("com.zeroc.slice-tools") version "3.9.+"
 
     // Pull in our local 'convention plugin' to enable linting.
     id("zeroc-linting")
@@ -13,8 +13,8 @@ plugins {
 
 dependencies {
     // Add the Ice and IceStorm libraries as an implementation dependencies.
-    implementation("com.zeroc:ice:3.8.+")
-    implementation("com.zeroc:icestorm:3.8.+")
+    implementation("com.zeroc:ice:3.9.+")
+    implementation("com.zeroc:icestorm:3.9.+")
 }
 
 sourceSets {

--- a/js/Glacier2/callback/.npmrc
+++ b/js/Glacier2/callback/.npmrc
@@ -1,2 +1,2 @@
 # Use ZeroC nightly registry for @zeroc packages
-@zeroc:registry=https://download.zeroc.com/nexus/repository/npm-nightly/
+@zeroc:registry=https://download.zeroc.com/nexus/repository/npm-3.9-nightly/

--- a/js/Glacier2/callback/package.json
+++ b/js/Glacier2/callback/package.json
@@ -10,7 +10,7 @@
         "build": "npx slice2js --typescript AlarmClock.ice && npx tsc"
     },
     "dependencies": {
-        "@zeroc/ice": "^3.8.0-nightly.0.0"
+        "@zeroc/ice": "^3.9.0-nightly.0.0"
     },
     "devDependencies": {
         "@eslint/js": "^9.32.0",

--- a/js/Ice/bidir/.npmrc
+++ b/js/Ice/bidir/.npmrc
@@ -1,2 +1,2 @@
 # Use ZeroC nightly registry for @zeroc packages
-@zeroc:registry=https://download.zeroc.com/nexus/repository/npm-nightly/
+@zeroc:registry=https://download.zeroc.com/nexus/repository/npm-3.9-nightly/

--- a/js/Ice/bidir/package.json
+++ b/js/Ice/bidir/package.json
@@ -10,7 +10,7 @@
         "build": "npx slice2js --typescript AlarmClock.ice && npx tsc"
     },
     "dependencies": {
-        "@zeroc/ice": "^3.8.0-nightly.0.0"
+        "@zeroc/ice": "^3.9.0-nightly.0.0"
     },
     "devDependencies": {
         "@eslint/js": "^9.32.0",

--- a/js/Ice/cancellation/.npmrc
+++ b/js/Ice/cancellation/.npmrc
@@ -1,2 +1,2 @@
 # Use ZeroC nightly registry for @zeroc packages
-@zeroc:registry=https://download.zeroc.com/nexus/repository/npm-nightly/
+@zeroc:registry=https://download.zeroc.com/nexus/repository/npm-3.9-nightly/

--- a/js/Ice/cancellation/package.json
+++ b/js/Ice/cancellation/package.json
@@ -10,7 +10,7 @@
         "build": "npx slice2js --typescript Greeter.ice && npx tsc"
     },
     "dependencies": {
-        "@zeroc/ice": "^3.8.0-nightly.0.0"
+        "@zeroc/ice": "^3.9.0-nightly.0.0"
     },
     "devDependencies": {
         "@eslint/js": "^9.32.0",

--- a/js/Ice/context/.npmrc
+++ b/js/Ice/context/.npmrc
@@ -1,2 +1,2 @@
 # Use ZeroC nightly registry for @zeroc packages
-@zeroc:registry=https://download.zeroc.com/nexus/repository/npm-nightly/
+@zeroc:registry=https://download.zeroc.com/nexus/repository/npm-3.9-nightly/

--- a/js/Ice/context/package.json
+++ b/js/Ice/context/package.json
@@ -10,7 +10,7 @@
         "build": "npx slice2js --typescript Greeter.ice && npx tsc"
     },
     "dependencies": {
-        "@zeroc/ice": "^3.8.0-nightly.0.0"
+        "@zeroc/ice": "^3.9.0-nightly.0.0"
     },
     "devDependencies": {
         "@eslint/js": "^9.32.0",

--- a/js/Ice/customError/.npmrc
+++ b/js/Ice/customError/.npmrc
@@ -1,2 +1,2 @@
 # Use ZeroC nightly registry for @zeroc packages
-@zeroc:registry=https://download.zeroc.com/nexus/repository/npm-nightly/
+@zeroc:registry=https://download.zeroc.com/nexus/repository/npm-3.9-nightly/

--- a/js/Ice/customError/package.json
+++ b/js/Ice/customError/package.json
@@ -10,7 +10,7 @@
         "build": "npx slice2js --typescript Greeter.ice && npx tsc"
     },
     "dependencies": {
-        "@zeroc/ice": "^3.8.0-nightly.0.0"
+        "@zeroc/ice": "^3.9.0-nightly.0.0"
     },
     "devDependencies": {
         "@eslint/js": "^9.32.0",

--- a/js/Ice/greeter/.npmrc
+++ b/js/Ice/greeter/.npmrc
@@ -1,2 +1,2 @@
 # Use ZeroC nightly registry for @zeroc packages
-@zeroc:registry=https://download.zeroc.com/nexus/repository/npm-nightly/
+@zeroc:registry=https://download.zeroc.com/nexus/repository/npm-3.9-nightly/

--- a/js/Ice/greeter/package.json
+++ b/js/Ice/greeter/package.json
@@ -10,7 +10,7 @@
         "build": "npx slice2js --typescript Greeter.ice && npx tsc"
     },
     "dependencies": {
-        "@zeroc/ice": "^3.8.0-nightly.0.0"
+        "@zeroc/ice": "^3.9.0-nightly.0.0"
     },
     "devDependencies": {
         "@eslint/js": "^9.32.0",

--- a/js/Ice/inheritance/.npmrc
+++ b/js/Ice/inheritance/.npmrc
@@ -1,2 +1,2 @@
 # Use ZeroC nightly registry for @zeroc packages
-@zeroc:registry=https://download.zeroc.com/nexus/repository/npm-nightly/
+@zeroc:registry=https://download.zeroc.com/nexus/repository/npm-3.9-nightly/

--- a/js/Ice/inheritance/package.json
+++ b/js/Ice/inheritance/package.json
@@ -10,7 +10,7 @@
         "build": "npx slice2js --typescript Filesystem.ice && npx tsc"
     },
     "dependencies": {
-        "@zeroc/ice": "^3.8.0-nightly.0.0"
+        "@zeroc/ice": "^3.9.0-nightly.0.0"
     },
     "devDependencies": {
         "@eslint/js": "^9.32.0",

--- a/js/Ice/optional/client1/.npmrc
+++ b/js/Ice/optional/client1/.npmrc
@@ -1,2 +1,2 @@
 # Use ZeroC nightly registry for @zeroc packages
-@zeroc:registry=https://download.zeroc.com/nexus/repository/npm-nightly/
+@zeroc:registry=https://download.zeroc.com/nexus/repository/npm-3.9-nightly/

--- a/js/Ice/optional/client1/package.json
+++ b/js/Ice/optional/client1/package.json
@@ -10,7 +10,7 @@
         "build": "npx slice2js --typescript WeatherStation1.ice && npx tsc"
     },
     "dependencies": {
-        "@zeroc/ice": "^3.8.0-nightly.0.0"
+        "@zeroc/ice": "^3.9.0-nightly.0.0"
     },
     "devDependencies": {
         "@eslint/js": "^9.32.0",

--- a/js/Ice/optional/client2/.npmrc
+++ b/js/Ice/optional/client2/.npmrc
@@ -1,2 +1,2 @@
 # Use ZeroC nightly registry for @zeroc packages
-@zeroc:registry=https://download.zeroc.com/nexus/repository/npm-nightly/
+@zeroc:registry=https://download.zeroc.com/nexus/repository/npm-3.9-nightly/

--- a/js/Ice/optional/client2/package.json
+++ b/js/Ice/optional/client2/package.json
@@ -10,7 +10,7 @@
         "build": "npx slice2js --typescript WeatherStation2.ice && npx tsc"
     },
     "dependencies": {
-        "@zeroc/ice": "^3.8.0-nightly.0.0"
+        "@zeroc/ice": "^3.9.0-nightly.0.0"
     },
     "devDependencies": {
         "@eslint/js": "^9.32.0",

--- a/js/Ice/react-greeter/.npmrc
+++ b/js/Ice/react-greeter/.npmrc
@@ -1,2 +1,2 @@
 # Use ZeroC nightly registry for @zeroc packages
-@zeroc:registry=https://download.zeroc.com/nexus/repository/npm-nightly/
+@zeroc:registry=https://download.zeroc.com/nexus/repository/npm-3.9-nightly/

--- a/js/Ice/react-greeter/package.json
+++ b/js/Ice/react-greeter/package.json
@@ -13,7 +13,7 @@
         "preview": "vite preview"
     },
     "dependencies": {
-        "@zeroc/ice": "^3.8.0-nightly.0.0",
+        "@zeroc/ice": "^3.9.0-nightly.0.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
     },

--- a/js/IceGrid/greeter/.npmrc
+++ b/js/IceGrid/greeter/.npmrc
@@ -1,2 +1,2 @@
 # Use ZeroC nightly registry for @zeroc packages
-@zeroc:registry=https://download.zeroc.com/nexus/repository/npm-nightly/
+@zeroc:registry=https://download.zeroc.com/nexus/repository/npm-3.9-nightly/

--- a/js/IceGrid/greeter/package.json
+++ b/js/IceGrid/greeter/package.json
@@ -10,7 +10,7 @@
         "build": "npx slice2js --typescript Greeter.ice && npx tsc"
     },
     "dependencies": {
-        "@zeroc/ice": "^3.8.0-nightly.0.0"
+        "@zeroc/ice": "^3.9.0-nightly.0.0"
     },
     "devDependencies": {
         "@eslint/js": "^9.32.0",

--- a/js/IceStorm/weather/.npmrc
+++ b/js/IceStorm/weather/.npmrc
@@ -1,2 +1,2 @@
 # Use ZeroC nightly registry for @zeroc packages
-@zeroc:registry=https://download.zeroc.com/nexus/repository/npm-nightly/
+@zeroc:registry=https://download.zeroc.com/nexus/repository/npm-3.9-nightly/

--- a/js/IceStorm/weather/package.json
+++ b/js/IceStorm/weather/package.json
@@ -10,7 +10,7 @@
         "build": "npx slice2js --typescript WeatherStation.ice && npx tsc"
     },
     "dependencies": {
-        "@zeroc/ice": "^3.8.0-nightly.0.0"
+        "@zeroc/ice": "^3.9.0-nightly.0.0"
     },
     "devDependencies": {
         "@eslint/js": "^9.32.0",

--- a/python/Glacier2/callback/client/pyproject.toml
+++ b/python/Glacier2/callback/client/pyproject.toml
@@ -15,7 +15,7 @@ common = { path = "../../../common" }
 [[tool.uv.index]]
 # Configure the ZeroC nightly index as an additional index, searched *before* the default PyPI index.
 name = "zeroc-nightly"
-url = "https://download.zeroc.com/nexus/repository/pypi-nightly/simple/"
+url = "https://download.zeroc.com/nexus/repository/pypi-3.9-nightly/simple/"
 
 [dependency-groups]
 lint = [

--- a/python/Glacier2/callback/server/pyproject.toml
+++ b/python/Glacier2/callback/server/pyproject.toml
@@ -15,7 +15,7 @@ common = { path = "../../../common" }
 [[tool.uv.index]]
 # Configure the ZeroC nightly index as an additional index, searched *before* the default PyPI index.
 name = "zeroc-nightly"
-url = "https://download.zeroc.com/nexus/repository/pypi-nightly/simple/"
+url = "https://download.zeroc.com/nexus/repository/pypi-3.9-nightly/simple/"
 
 [dependency-groups]
 lint = [

--- a/python/Glacier2/greeter/client/pyproject.toml
+++ b/python/Glacier2/greeter/client/pyproject.toml
@@ -12,7 +12,7 @@ prerelease = "allow"
 [[tool.uv.index]]
 # Configure the ZeroC nightly index as an additional index, searched *before* the default PyPI index.
 name = "zeroc-nightly"
-url = "https://download.zeroc.com/nexus/repository/pypi-nightly/simple/"
+url = "https://download.zeroc.com/nexus/repository/pypi-3.9-nightly/simple/"
 
 [dependency-groups]
 lint = [

--- a/python/Glacier2/greeter/server/pyproject.toml
+++ b/python/Glacier2/greeter/server/pyproject.toml
@@ -12,7 +12,7 @@ prerelease = "allow"
 [[tool.uv.index]]
 # Configure the ZeroC nightly index as an additional index, searched *before* the default PyPI index.
 name = "zeroc-nightly"
-url = "https://download.zeroc.com/nexus/repository/pypi-nightly/simple/"
+url = "https://download.zeroc.com/nexus/repository/pypi-3.9-nightly/simple/"
 
 [dependency-groups]
 lint = [

--- a/python/Glacier2/session/client/pyproject.toml
+++ b/python/Glacier2/session/client/pyproject.toml
@@ -12,7 +12,7 @@ prerelease = "allow"
 [[tool.uv.index]]
 # Configure the ZeroC nightly index as an additional index, searched *before* the default PyPI index.
 name = "zeroc-nightly"
-url = "https://download.zeroc.com/nexus/repository/pypi-nightly/simple/"
+url = "https://download.zeroc.com/nexus/repository/pypi-3.9-nightly/simple/"
 
 [dependency-groups]
 lint = [

--- a/python/Glacier2/session/server/pyproject.toml
+++ b/python/Glacier2/session/server/pyproject.toml
@@ -12,7 +12,7 @@ prerelease = "allow"
 [[tool.uv.index]]
 # Configure the ZeroC nightly index as an additional index, searched *before* the default PyPI index.
 name = "zeroc-nightly"
-url = "https://download.zeroc.com/nexus/repository/pypi-nightly/simple/"
+url = "https://download.zeroc.com/nexus/repository/pypi-3.9-nightly/simple/"
 
 [dependency-groups]
 lint = [

--- a/python/Ice/bidir/client/pyproject.toml
+++ b/python/Ice/bidir/client/pyproject.toml
@@ -15,7 +15,7 @@ common = { path = "../../../common" }
 [[tool.uv.index]]
 # Configure the ZeroC nightly index as an additional index, searched *before* the default PyPI index.
 name = "zeroc-nightly"
-url = "https://download.zeroc.com/nexus/repository/pypi-nightly/simple/"
+url = "https://download.zeroc.com/nexus/repository/pypi-3.9-nightly/simple/"
 
 [dependency-groups]
 lint = [

--- a/python/Ice/bidir/server/pyproject.toml
+++ b/python/Ice/bidir/server/pyproject.toml
@@ -15,7 +15,7 @@ common = { path = "../../../common" }
 [[tool.uv.index]]
 # Configure the ZeroC nightly index as an additional index, searched *before* the default PyPI index.
 name = "zeroc-nightly"
-url = "https://download.zeroc.com/nexus/repository/pypi-nightly/simple/"
+url = "https://download.zeroc.com/nexus/repository/pypi-3.9-nightly/simple/"
 
 [dependency-groups]
 lint = [

--- a/python/Ice/callback/client/pyproject.toml
+++ b/python/Ice/callback/client/pyproject.toml
@@ -15,7 +15,7 @@ common = { path = "../../../common" }
 [[tool.uv.index]]
 # Configure the ZeroC nightly index as an additional index, searched *before* the default PyPI index.
 name = "zeroc-nightly"
-url = "https://download.zeroc.com/nexus/repository/pypi-nightly/simple/"
+url = "https://download.zeroc.com/nexus/repository/pypi-3.9-nightly/simple/"
 
 [dependency-groups]
 lint = [

--- a/python/Ice/callback/server/pyproject.toml
+++ b/python/Ice/callback/server/pyproject.toml
@@ -15,7 +15,7 @@ common = { path = "../../../common" }
 [[tool.uv.index]]
 # Configure the ZeroC nightly index as an additional index, searched *before* the default PyPI index.
 name = "zeroc-nightly"
-url = "https://download.zeroc.com/nexus/repository/pypi-nightly/simple/"
+url = "https://download.zeroc.com/nexus/repository/pypi-3.9-nightly/simple/"
 
 [dependency-groups]
 lint = [

--- a/python/Ice/config/client/pyproject.toml
+++ b/python/Ice/config/client/pyproject.toml
@@ -12,7 +12,7 @@ prerelease = "allow"
 [[tool.uv.index]]
 # Configure the ZeroC nightly index as an additional index, searched *before* the default PyPI index.
 name = "zeroc-nightly"
-url = "https://download.zeroc.com/nexus/repository/pypi-nightly/simple/"
+url = "https://download.zeroc.com/nexus/repository/pypi-3.9-nightly/simple/"
 
 [dependency-groups]
 lint = [

--- a/python/Ice/config/server/pyproject.toml
+++ b/python/Ice/config/server/pyproject.toml
@@ -12,7 +12,7 @@ prerelease = "allow"
 [[tool.uv.index]]
 # Configure the ZeroC nightly index as an additional index, searched *before* the default PyPI index.
 name = "zeroc-nightly"
-url = "https://download.zeroc.com/nexus/repository/pypi-nightly/simple/"
+url = "https://download.zeroc.com/nexus/repository/pypi-3.9-nightly/simple/"
 
 [dependency-groups]
 lint = [

--- a/python/Ice/context/client/pyproject.toml
+++ b/python/Ice/context/client/pyproject.toml
@@ -12,7 +12,7 @@ prerelease = "allow"
 [[tool.uv.index]]
 # Configure the ZeroC nightly index as an additional index, searched *before* the default PyPI index.
 name = "zeroc-nightly"
-url = "https://download.zeroc.com/nexus/repository/pypi-nightly/simple/"
+url = "https://download.zeroc.com/nexus/repository/pypi-3.9-nightly/simple/"
 
 [dependency-groups]
 lint = [

--- a/python/Ice/context/server/pyproject.toml
+++ b/python/Ice/context/server/pyproject.toml
@@ -12,7 +12,7 @@ prerelease = "allow"
 [[tool.uv.index]]
 # Configure the ZeroC nightly index as an additional index, searched *before* the default PyPI index.
 name = "zeroc-nightly"
-url = "https://download.zeroc.com/nexus/repository/pypi-nightly/simple/"
+url = "https://download.zeroc.com/nexus/repository/pypi-3.9-nightly/simple/"
 
 [dependency-groups]
 lint = [

--- a/python/Ice/customError/client/pyproject.toml
+++ b/python/Ice/customError/client/pyproject.toml
@@ -12,7 +12,7 @@ prerelease = "allow"
 [[tool.uv.index]]
 # Configure the ZeroC nightly index as an additional index, searched *before* the default PyPI index.
 name = "zeroc-nightly"
-url = "https://download.zeroc.com/nexus/repository/pypi-nightly/simple/"
+url = "https://download.zeroc.com/nexus/repository/pypi-3.9-nightly/simple/"
 
 [dependency-groups]
 lint = [

--- a/python/Ice/customError/server/pyproject.toml
+++ b/python/Ice/customError/server/pyproject.toml
@@ -12,7 +12,7 @@ prerelease = "allow"
 [[tool.uv.index]]
 # Configure the ZeroC nightly index as an additional index, searched *before* the default PyPI index.
 name = "zeroc-nightly"
-url = "https://download.zeroc.com/nexus/repository/pypi-nightly/simple/"
+url = "https://download.zeroc.com/nexus/repository/pypi-3.9-nightly/simple/"
 
 [dependency-groups]
 lint = [

--- a/python/Ice/greeter/client/pyproject.toml
+++ b/python/Ice/greeter/client/pyproject.toml
@@ -12,7 +12,7 @@ prerelease = "allow"
 [[tool.uv.index]]
 # Configure the ZeroC nightly index as an additional index, searched *before* the default PyPI index.
 name = "zeroc-nightly"
-url = "https://download.zeroc.com/nexus/repository/pypi-nightly/simple/"
+url = "https://download.zeroc.com/nexus/repository/pypi-3.9-nightly/simple/"
 
 [dependency-groups]
 lint = [

--- a/python/Ice/greeter/server/pyproject.toml
+++ b/python/Ice/greeter/server/pyproject.toml
@@ -12,7 +12,7 @@ prerelease = "allow"
 [[tool.uv.index]]
 # Configure the ZeroC nightly index as an additional index, searched *before* the default PyPI index.
 name = "zeroc-nightly"
-url = "https://download.zeroc.com/nexus/repository/pypi-nightly/simple/"
+url = "https://download.zeroc.com/nexus/repository/pypi-3.9-nightly/simple/"
 
 [dependency-groups]
 lint = [

--- a/python/Ice/greeter/server_amd/pyproject.toml
+++ b/python/Ice/greeter/server_amd/pyproject.toml
@@ -12,7 +12,7 @@ prerelease = "allow"
 [[tool.uv.index]]
 # Configure the ZeroC nightly index as an additional index, searched *before* the default PyPI index.
 name = "zeroc-nightly"
-url = "https://download.zeroc.com/nexus/repository/pypi-nightly/simple/"
+url = "https://download.zeroc.com/nexus/repository/pypi-3.9-nightly/simple/"
 
 [dependency-groups]
 lint = [

--- a/python/Ice/inheritance/client/pyproject.toml
+++ b/python/Ice/inheritance/client/pyproject.toml
@@ -12,7 +12,7 @@ prerelease = "allow"
 [[tool.uv.index]]
 # Configure the ZeroC nightly index as an additional index, searched *before* the default PyPI index.
 name = "zeroc-nightly"
-url = "https://download.zeroc.com/nexus/repository/pypi-nightly/simple/"
+url = "https://download.zeroc.com/nexus/repository/pypi-3.9-nightly/simple/"
 
 [dependency-groups]
 lint = [

--- a/python/Ice/inheritance/server/pyproject.toml
+++ b/python/Ice/inheritance/server/pyproject.toml
@@ -12,7 +12,7 @@ prerelease = "allow"
 [[tool.uv.index]]
 # Configure the ZeroC nightly index as an additional index, searched *before* the default PyPI index.
 name = "zeroc-nightly"
-url = "https://download.zeroc.com/nexus/repository/pypi-nightly/simple/"
+url = "https://download.zeroc.com/nexus/repository/pypi-3.9-nightly/simple/"
 
 [dependency-groups]
 lint = [

--- a/python/Ice/invocation_timeout/client/pyproject.toml
+++ b/python/Ice/invocation_timeout/client/pyproject.toml
@@ -12,7 +12,7 @@ prerelease = "allow"
 [[tool.uv.index]]
 # Configure the ZeroC nightly index as an additional index, searched *before* the default PyPI index.
 name = "zeroc-nightly"
-url = "https://download.zeroc.com/nexus/repository/pypi-nightly/simple/"
+url = "https://download.zeroc.com/nexus/repository/pypi-3.9-nightly/simple/"
 
 [dependency-groups]
 lint = [

--- a/python/Ice/invocation_timeout/server/pyproject.toml
+++ b/python/Ice/invocation_timeout/server/pyproject.toml
@@ -12,7 +12,7 @@ prerelease = "allow"
 [[tool.uv.index]]
 # Configure the ZeroC nightly index as an additional index, searched *before* the default PyPI index.
 name = "zeroc-nightly"
-url = "https://download.zeroc.com/nexus/repository/pypi-nightly/simple/"
+url = "https://download.zeroc.com/nexus/repository/pypi-3.9-nightly/simple/"
 
 [dependency-groups]
 lint = [

--- a/python/Ice/optional/client1/pyproject.toml
+++ b/python/Ice/optional/client1/pyproject.toml
@@ -12,7 +12,7 @@ prerelease = "allow"
 [[tool.uv.index]]
 # Configure the ZeroC nightly index as an additional index, searched *before* the default PyPI index.
 name = "zeroc-nightly"
-url = "https://download.zeroc.com/nexus/repository/pypi-nightly/simple/"
+url = "https://download.zeroc.com/nexus/repository/pypi-3.9-nightly/simple/"
 
 [dependency-groups]
 lint = [

--- a/python/Ice/optional/client2/pyproject.toml
+++ b/python/Ice/optional/client2/pyproject.toml
@@ -12,7 +12,7 @@ prerelease = "allow"
 [[tool.uv.index]]
 # Configure the ZeroC nightly index as an additional index, searched *before* the default PyPI index.
 name = "zeroc-nightly"
-url = "https://download.zeroc.com/nexus/repository/pypi-nightly/simple/"
+url = "https://download.zeroc.com/nexus/repository/pypi-3.9-nightly/simple/"
 
 [dependency-groups]
 lint = [

--- a/python/Ice/optional/server1/pyproject.toml
+++ b/python/Ice/optional/server1/pyproject.toml
@@ -12,7 +12,7 @@ prerelease = "allow"
 [[tool.uv.index]]
 # Configure the ZeroC nightly index as an additional index, searched *before* the default PyPI index.
 name = "zeroc-nightly"
-url = "https://download.zeroc.com/nexus/repository/pypi-nightly/simple/"
+url = "https://download.zeroc.com/nexus/repository/pypi-3.9-nightly/simple/"
 
 [dependency-groups]
 lint = [

--- a/python/Ice/optional/server2/pyproject.toml
+++ b/python/Ice/optional/server2/pyproject.toml
@@ -12,7 +12,7 @@ prerelease = "allow"
 [[tool.uv.index]]
 # Configure the ZeroC nightly index as an additional index, searched *before* the default PyPI index.
 name = "zeroc-nightly"
-url = "https://download.zeroc.com/nexus/repository/pypi-nightly/simple/"
+url = "https://download.zeroc.com/nexus/repository/pypi-3.9-nightly/simple/"
 
 [dependency-groups]
 lint = [

--- a/python/IceDiscovery/greeter/client/pyproject.toml
+++ b/python/IceDiscovery/greeter/client/pyproject.toml
@@ -12,7 +12,7 @@ prerelease = "allow"
 [[tool.uv.index]]
 # Configure the ZeroC nightly index as an additional index, searched *before* the default PyPI index.
 name = "zeroc-nightly"
-url = "https://download.zeroc.com/nexus/repository/pypi-nightly/simple/"
+url = "https://download.zeroc.com/nexus/repository/pypi-3.9-nightly/simple/"
 
 [dependency-groups]
 lint = [

--- a/python/IceDiscovery/greeter/server/pyproject.toml
+++ b/python/IceDiscovery/greeter/server/pyproject.toml
@@ -12,7 +12,7 @@ prerelease = "allow"
 [[tool.uv.index]]
 # Configure the ZeroC nightly index as an additional index, searched *before* the default PyPI index.
 name = "zeroc-nightly"
-url = "https://download.zeroc.com/nexus/repository/pypi-nightly/simple/"
+url = "https://download.zeroc.com/nexus/repository/pypi-3.9-nightly/simple/"
 
 [dependency-groups]
 lint = [

--- a/python/IceDiscovery/replication/client/pyproject.toml
+++ b/python/IceDiscovery/replication/client/pyproject.toml
@@ -12,7 +12,7 @@ prerelease = "allow"
 [[tool.uv.index]]
 # Configure the ZeroC nightly index as an additional index, searched *before* the default PyPI index.
 name = "zeroc-nightly"
-url = "https://download.zeroc.com/nexus/repository/pypi-nightly/simple/"
+url = "https://download.zeroc.com/nexus/repository/pypi-3.9-nightly/simple/"
 
 [dependency-groups]
 lint = [

--- a/python/IceDiscovery/replication/server/pyproject.toml
+++ b/python/IceDiscovery/replication/server/pyproject.toml
@@ -12,7 +12,7 @@ prerelease = "allow"
 [[tool.uv.index]]
 # Configure the ZeroC nightly index as an additional index, searched *before* the default PyPI index.
 name = "zeroc-nightly"
-url = "https://download.zeroc.com/nexus/repository/pypi-nightly/simple/"
+url = "https://download.zeroc.com/nexus/repository/pypi-3.9-nightly/simple/"
 
 [dependency-groups]
 lint = [

--- a/python/IceGrid/greeter/client/pyproject.toml
+++ b/python/IceGrid/greeter/client/pyproject.toml
@@ -12,7 +12,7 @@ prerelease = "allow"
 [[tool.uv.index]]
 # Configure the ZeroC nightly index as an additional index, searched *before* the default PyPI index.
 name = "zeroc-nightly"
-url = "https://download.zeroc.com/nexus/repository/pypi-nightly/simple/"
+url = "https://download.zeroc.com/nexus/repository/pypi-3.9-nightly/simple/"
 
 [dependency-groups]
 lint = [

--- a/python/IceGrid/greeter/server/pyproject.toml
+++ b/python/IceGrid/greeter/server/pyproject.toml
@@ -12,7 +12,7 @@ prerelease = "allow"
 [[tool.uv.index]]
 # Configure the ZeroC nightly index as an additional index, searched *before* the default PyPI index.
 name = "zeroc-nightly"
-url = "https://download.zeroc.com/nexus/repository/pypi-nightly/simple/"
+url = "https://download.zeroc.com/nexus/repository/pypi-3.9-nightly/simple/"
 
 [dependency-groups]
 lint = [

--- a/python/IceStorm/weather/sensor/pyproject.toml
+++ b/python/IceStorm/weather/sensor/pyproject.toml
@@ -12,7 +12,7 @@ prerelease = "allow"
 [[tool.uv.index]]
 # Configure the ZeroC nightly index as an additional index, searched *before* the default PyPI index.
 name = "zeroc-nightly"
-url = "https://download.zeroc.com/nexus/repository/pypi-nightly/simple/"
+url = "https://download.zeroc.com/nexus/repository/pypi-3.9-nightly/simple/"
 
 [dependency-groups]
 lint = [

--- a/python/IceStorm/weather/station/pyproject.toml
+++ b/python/IceStorm/weather/station/pyproject.toml
@@ -12,7 +12,7 @@ prerelease = "allow"
 [[tool.uv.index]]
 # Configure the ZeroC nightly index as an additional index, searched *before* the default PyPI index.
 name = "zeroc-nightly"
-url = "https://download.zeroc.com/nexus/repository/pypi-nightly/simple/"
+url = "https://download.zeroc.com/nexus/repository/pypi-3.9-nightly/simple/"
 
 [dependency-groups]
 lint = [


### PR DESCRIPTION
This PR updates demos in `main` to use 3.9-nightly builds.