### PR TITLE
Update Lingering `3.8` References

### DIFF
--- a/cpp/IceStorm/weather/README.md
+++ b/cpp/IceStorm/weather/README.md
@@ -34,7 +34,7 @@ cmake --build build
 1. Start the IceStorm service in its own terminal:
 
    ```shell
-   icebox --IceBox.Service.IceStorm="IceStormService,38a0:createIceStorm --Ice.Config=icestorm.conf"
+   icebox --IceBox.Service.IceStorm="IceStormService,39a0:createIceStorm --Ice.Config=icestorm.conf"
    ```
 
 2. Run one or more sensors and weather stations, each in its own terminal. You can start them in any order.

--- a/csharp/IceStorm/Weather/README.md
+++ b/csharp/IceStorm/Weather/README.md
@@ -30,7 +30,7 @@ dotnet build
 First, run the IceStorm service in its own terminal:
 
 ```shell
-icebox --IceBox.Service.IceStorm="IceStormService,38a0:createIceStorm --Ice.Config=icestorm.conf"
+icebox --IceBox.Service.IceStorm="IceStormService,39a0:createIceStorm --Ice.Config=icestorm.conf"
 ```
 
 Then, run one or more sensors and weather stations, each in its own terminal. You can start them in any order.

--- a/java/IceStorm/weather/README.md
+++ b/java/IceStorm/weather/README.md
@@ -32,7 +32,7 @@ To build the demo, run:
 First, run the IceStorm service in its own terminal:
 
 ```shell
-icebox --IceBox.Service.IceStorm="IceStormService,38a0:createIceStorm --Ice.Config=icestorm.conf"
+icebox --IceBox.Service.IceStorm="IceStormService,39a0:createIceStorm --Ice.Config=icestorm.conf"
 ```
 
 Then, run one or more sensors and weather stations, each in its own terminal. You can start them in any order.

--- a/python/IceStorm/weather/README.md
+++ b/python/IceStorm/weather/README.md
@@ -23,7 +23,7 @@ flowchart LR
 Run the IceStorm service in its own terminal:
 
 ```shell
-icebox --IceBox.Service.IceStorm="IceStormService,38a0:createIceStorm --Ice.Config=icestorm.conf"
+icebox --IceBox.Service.IceStorm="IceStormService,39a0:createIceStorm --Ice.Config=icestorm.conf"
 ```
 
 ## Running the sensor

--- a/swift/IceStorm/Weather/README.md
+++ b/swift/IceStorm/Weather/README.md
@@ -30,7 +30,7 @@ swift build
 First, run the IceStorm service in its own terminal:
 
 ```shell
-icebox --IceBox.Service.IceStorm="IceStormService,38a0:createIceStorm --Ice.Config=icestorm.conf"
+icebox --IceBox.Service.IceStorm="IceStormService,39a0:createIceStorm --Ice.Config=icestorm.conf"
 ```
 
 Then, run one or more sensors and weather stations, each in its own terminal. You can start them in any order.


### PR DESCRIPTION
This PR is the continuation of https://github.com/zeroc-ice/ice/pull/4851 for the demos repo.

The only references left to `3.8` after this change are these two package names in `Dockerfile`s in the `.devcontainer` folder: `libice3.8-c++` and `libzeroc-ice3.8`; see https://github.com/zeroc-ice/ice-demos/blob/562ed8e608f87e94f1c3b9dc06476361385eb817/.devcontainer/Dockerfile#L33

Should these be updated to `3.9`?