### PR TITLE
Remove references to C++ NuGet packages not supported in 3.7.11

### DIFF
--- a/cpp11/Chat/client/msbuild/chatgl2client/chatgl2client.vcxproj
+++ b/cpp11/Chat/client/msbuild/chatgl2client/chatgl2client.vcxproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -55,8 +53,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -277,10 +273,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp11/Chat/client/msbuild/chatgl2client/packages.config
+++ b/cpp11/Chat/client/msbuild/chatgl2client/packages.config
@@ -1,7 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp11/Chat/client/msbuild/chatpollclient/chatpollclient.vcxproj
+++ b/cpp11/Chat/client/msbuild/chatpollclient/chatpollclient.vcxproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -165,8 +163,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -274,10 +270,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp11/Chat/client/msbuild/chatpollclient/packages.config
+++ b/cpp11/Chat/client/msbuild/chatpollclient/packages.config
@@ -1,7 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp11/Chat/server/msbuild/packages.config
+++ b/cpp11/Chat/server/msbuild/packages.config
@@ -1,7 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp11/Chat/server/msbuild/server.vcxproj
+++ b/cpp11/Chat/server/msbuild/server.vcxproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -225,8 +223,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
     <Import Project="..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -342,10 +338,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
     <Error Condition="!Exists('..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp11/Glacier2/callback/msbuild/client/client.vcxproj
+++ b/cpp11/Glacier2/callback/msbuild/client/client.vcxproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -55,8 +53,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -264,10 +260,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp11/Glacier2/callback/msbuild/client/packages.config
+++ b/cpp11/Glacier2/callback/msbuild/client/packages.config
@@ -1,7 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp11/Glacier2/callback/msbuild/server/packages.config
+++ b/cpp11/Glacier2/callback/msbuild/server/packages.config
@@ -1,7 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp11/Glacier2/callback/msbuild/server/server.vcxproj
+++ b/cpp11/Glacier2/callback/msbuild/server/server.vcxproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -55,8 +53,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -265,10 +261,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp11/Glacier2/simpleChat/msbuild/client/client.vcxproj
+++ b/cpp11/Glacier2/simpleChat/msbuild/client/client.vcxproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -55,8 +53,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -263,10 +259,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp11/Glacier2/simpleChat/msbuild/client/packages.config
+++ b/cpp11/Glacier2/simpleChat/msbuild/client/packages.config
@@ -1,7 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp11/Glacier2/simpleChat/msbuild/server/packages.config
+++ b/cpp11/Glacier2/simpleChat/msbuild/server/packages.config
@@ -1,7 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp11/Glacier2/simpleChat/msbuild/server/server.vcxproj
+++ b/cpp11/Glacier2/simpleChat/msbuild/server/server.vcxproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -55,8 +53,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -276,10 +272,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp11/Ice/async/msbuild/client/client.vcxproj
+++ b/cpp11/Ice/async/msbuild/client/client.vcxproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -55,8 +53,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -248,10 +244,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp11/Ice/async/msbuild/client/packages.config
+++ b/cpp11/Ice/async/msbuild/client/packages.config
@@ -1,7 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp11/Ice/async/msbuild/server/packages.config
+++ b/cpp11/Ice/async/msbuild/server/packages.config
@@ -1,7 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp11/Ice/async/msbuild/server/server.vcxproj
+++ b/cpp11/Ice/async/msbuild/server/server.vcxproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -55,8 +53,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -250,10 +246,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp11/Ice/asyncInvocation/msbuild/client/client.vcxproj
+++ b/cpp11/Ice/asyncInvocation/msbuild/client/client.vcxproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -55,8 +53,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -250,10 +246,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp11/Ice/asyncInvocation/msbuild/client/packages.config
+++ b/cpp11/Ice/asyncInvocation/msbuild/client/packages.config
@@ -1,7 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp11/Ice/asyncInvocation/msbuild/server/packages.config
+++ b/cpp11/Ice/asyncInvocation/msbuild/server/packages.config
@@ -1,7 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp11/Ice/asyncInvocation/msbuild/server/server.vcxproj
+++ b/cpp11/Ice/asyncInvocation/msbuild/server/server.vcxproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -55,8 +53,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -253,10 +249,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp11/Ice/bidir/msbuild/client/client.vcxproj
+++ b/cpp11/Ice/bidir/msbuild/client/client.vcxproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -56,8 +54,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -251,10 +247,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp11/Ice/bidir/msbuild/client/packages.config
+++ b/cpp11/Ice/bidir/msbuild/client/packages.config
@@ -1,7 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp11/Ice/bidir/msbuild/server/packages.config
+++ b/cpp11/Ice/bidir/msbuild/server/packages.config
@@ -1,7 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp11/Ice/bidir/msbuild/server/server.vcxproj
+++ b/cpp11/Ice/bidir/msbuild/server/server.vcxproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -56,8 +54,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -249,10 +245,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp11/Ice/callback/msbuild/client/client.vcxproj
+++ b/cpp11/Ice/callback/msbuild/client/client.vcxproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -55,8 +53,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -248,10 +244,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp11/Ice/callback/msbuild/client/packages.config
+++ b/cpp11/Ice/callback/msbuild/client/packages.config
@@ -1,7 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp11/Ice/callback/msbuild/server/packages.config
+++ b/cpp11/Ice/callback/msbuild/server/packages.config
@@ -1,7 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp11/Ice/callback/msbuild/server/server.vcxproj
+++ b/cpp11/Ice/callback/msbuild/server/server.vcxproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -56,8 +54,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -249,10 +245,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp11/Ice/context/msbuild/client/client.vcxproj
+++ b/cpp11/Ice/context/msbuild/client/client.vcxproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -55,8 +53,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
@@ -248,10 +244,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />

--- a/cpp11/Ice/context/msbuild/client/packages.config
+++ b/cpp11/Ice/context/msbuild/client/packages.config
@@ -1,7 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp11/Ice/context/msbuild/server/packages.config
+++ b/cpp11/Ice/context/msbuild/server/packages.config
@@ -1,7 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp11/Ice/context/msbuild/server/server.vcxproj
+++ b/cpp11/Ice/context/msbuild/server/server.vcxproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -55,8 +53,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -251,10 +247,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp11/Ice/hello/msbuild/client/client.vcxproj
+++ b/cpp11/Ice/hello/msbuild/client/client.vcxproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -55,8 +53,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -248,10 +244,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp11/Ice/hello/msbuild/client/packages.config
+++ b/cpp11/Ice/hello/msbuild/client/packages.config
@@ -1,7 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp11/Ice/hello/msbuild/server/packages.config
+++ b/cpp11/Ice/hello/msbuild/server/packages.config
@@ -1,7 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp11/Ice/hello/msbuild/server/server.vcxproj
+++ b/cpp11/Ice/hello/msbuild/server/server.vcxproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -55,8 +53,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -248,10 +244,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp11/Ice/interceptor/msbuild/client/client.vcxproj
+++ b/cpp11/Ice/interceptor/msbuild/client/client.vcxproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -55,8 +53,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
@@ -245,10 +241,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />

--- a/cpp11/Ice/interceptor/msbuild/client/packages.config
+++ b/cpp11/Ice/interceptor/msbuild/client/packages.config
@@ -1,7 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp11/Ice/interceptor/msbuild/server/packages.config
+++ b/cpp11/Ice/interceptor/msbuild/server/packages.config
@@ -1,7 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp11/Ice/interceptor/msbuild/server/server.vcxproj
+++ b/cpp11/Ice/interceptor/msbuild/server/server.vcxproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -55,8 +53,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -250,10 +246,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp11/Ice/interleaved/msbuild/client/client.vcxproj
+++ b/cpp11/Ice/interleaved/msbuild/client/client.vcxproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -55,8 +53,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -248,10 +244,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp11/Ice/interleaved/msbuild/client/packages.config
+++ b/cpp11/Ice/interleaved/msbuild/client/packages.config
@@ -1,7 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp11/Ice/interleaved/msbuild/server/packages.config
+++ b/cpp11/Ice/interleaved/msbuild/server/packages.config
@@ -1,7 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp11/Ice/interleaved/msbuild/server/server.vcxproj
+++ b/cpp11/Ice/interleaved/msbuild/server/server.vcxproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -55,8 +53,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -250,10 +246,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp11/Ice/invoke/msbuild/client/client.vcxproj
+++ b/cpp11/Ice/invoke/msbuild/client/client.vcxproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -55,8 +53,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -248,10 +244,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp11/Ice/invoke/msbuild/client/packages.config
+++ b/cpp11/Ice/invoke/msbuild/client/packages.config
@@ -1,7 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp11/Ice/invoke/msbuild/server/packages.config
+++ b/cpp11/Ice/invoke/msbuild/server/packages.config
@@ -1,7 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp11/Ice/invoke/msbuild/server/server.vcxproj
+++ b/cpp11/Ice/invoke/msbuild/server/server.vcxproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -55,8 +53,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -252,10 +248,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp11/Ice/latency/msbuild/client/client.vcxproj
+++ b/cpp11/Ice/latency/msbuild/client/client.vcxproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -56,8 +54,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -249,10 +245,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp11/Ice/latency/msbuild/client/packages.config
+++ b/cpp11/Ice/latency/msbuild/client/packages.config
@@ -1,7 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp11/Ice/latency/msbuild/server/packages.config
+++ b/cpp11/Ice/latency/msbuild/server/packages.config
@@ -1,7 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp11/Ice/latency/msbuild/server/server.vcxproj
+++ b/cpp11/Ice/latency/msbuild/server/server.vcxproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -55,8 +53,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -248,10 +244,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp11/Ice/locator/msbuild/client/client.vcxproj
+++ b/cpp11/Ice/locator/msbuild/client/client.vcxproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -55,8 +53,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -248,10 +244,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp11/Ice/locator/msbuild/client/packages.config
+++ b/cpp11/Ice/locator/msbuild/client/packages.config
@@ -1,7 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp11/Ice/locator/msbuild/locator/locator.vcxproj
+++ b/cpp11/Ice/locator/msbuild/locator/locator.vcxproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -56,8 +54,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -198,10 +194,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp11/Ice/locator/msbuild/locator/packages.config
+++ b/cpp11/Ice/locator/msbuild/locator/packages.config
@@ -1,7 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp11/Ice/locator/msbuild/server/packages.config
+++ b/cpp11/Ice/locator/msbuild/server/packages.config
@@ -1,7 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp11/Ice/locator/msbuild/server/server.vcxproj
+++ b/cpp11/Ice/locator/msbuild/server/server.vcxproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -55,8 +53,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -252,10 +248,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp11/Ice/minimal/msbuild/client/client.vcxproj
+++ b/cpp11/Ice/minimal/msbuild/client/client.vcxproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -55,8 +53,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -251,10 +247,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp11/Ice/minimal/msbuild/client/packages.config
+++ b/cpp11/Ice/minimal/msbuild/client/packages.config
@@ -1,7 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp11/Ice/minimal/msbuild/server/packages.config
+++ b/cpp11/Ice/minimal/msbuild/server/packages.config
@@ -1,7 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp11/Ice/minimal/msbuild/server/server.vcxproj
+++ b/cpp11/Ice/minimal/msbuild/server/server.vcxproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -55,8 +53,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -253,10 +249,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp11/Ice/mtalk/msbuild/client/client.vcxproj
+++ b/cpp11/Ice/mtalk/msbuild/client/client.vcxproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -55,8 +53,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -248,10 +244,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp11/Ice/mtalk/msbuild/client/packages.config
+++ b/cpp11/Ice/mtalk/msbuild/client/packages.config
@@ -1,7 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp11/Ice/multicast/msbuild/client/client.vcxproj
+++ b/cpp11/Ice/multicast/msbuild/client/client.vcxproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -55,8 +53,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -301,10 +297,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp11/Ice/multicast/msbuild/client/packages.config
+++ b/cpp11/Ice/multicast/msbuild/client/packages.config
@@ -1,7 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp11/Ice/multicast/msbuild/server/packages.config
+++ b/cpp11/Ice/multicast/msbuild/server/packages.config
@@ -1,7 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp11/Ice/multicast/msbuild/server/server.vcxproj
+++ b/cpp11/Ice/multicast/msbuild/server/server.vcxproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -55,8 +53,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -301,10 +297,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp11/Ice/nested/msbuild/client/client.vcxproj
+++ b/cpp11/Ice/nested/msbuild/client/client.vcxproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -55,8 +53,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -254,10 +250,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp11/Ice/nested/msbuild/client/packages.config
+++ b/cpp11/Ice/nested/msbuild/client/packages.config
@@ -1,7 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp11/Ice/nested/msbuild/server/packages.config
+++ b/cpp11/Ice/nested/msbuild/server/packages.config
@@ -1,7 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp11/Ice/nested/msbuild/server/server.vcxproj
+++ b/cpp11/Ice/nested/msbuild/server/server.vcxproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -55,8 +53,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -254,10 +250,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp11/Ice/optional/msbuild/client/client.vcxproj
+++ b/cpp11/Ice/optional/msbuild/client/client.vcxproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -55,8 +53,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -252,10 +248,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp11/Ice/optional/msbuild/client/packages.config
+++ b/cpp11/Ice/optional/msbuild/client/packages.config
@@ -1,7 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp11/Ice/optional/msbuild/server/packages.config
+++ b/cpp11/Ice/optional/msbuild/server/packages.config
@@ -1,7 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp11/Ice/optional/msbuild/server/server.vcxproj
+++ b/cpp11/Ice/optional/msbuild/server/server.vcxproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -55,8 +53,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -254,10 +250,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp11/Ice/plugin/msbuild/client/client.vcxproj
+++ b/cpp11/Ice/plugin/msbuild/client/client.vcxproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -55,8 +53,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -252,10 +248,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp11/Ice/plugin/msbuild/client/packages.config
+++ b/cpp11/Ice/plugin/msbuild/client/packages.config
@@ -1,7 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp11/Ice/plugin/msbuild/hello/hello.vcxproj
+++ b/cpp11/Ice/plugin/msbuild/hello/hello.vcxproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -55,8 +53,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -275,10 +271,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp11/Ice/plugin/msbuild/hello/packages.config
+++ b/cpp11/Ice/plugin/msbuild/hello/packages.config
@@ -1,7 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp11/Ice/plugin/msbuild/logger/logger.vcxproj
+++ b/cpp11/Ice/plugin/msbuild/logger/logger.vcxproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -55,8 +53,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -222,10 +218,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp11/Ice/plugin/msbuild/logger/packages.config
+++ b/cpp11/Ice/plugin/msbuild/logger/packages.config
@@ -1,7 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp11/Ice/plugin/msbuild/server/packages.config
+++ b/cpp11/Ice/plugin/msbuild/server/packages.config
@@ -1,7 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp11/Ice/plugin/msbuild/server/server.vcxproj
+++ b/cpp11/Ice/plugin/msbuild/server/server.vcxproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -55,8 +53,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -199,10 +195,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp11/Ice/properties/msbuild/client/client.vcxproj
+++ b/cpp11/Ice/properties/msbuild/client/client.vcxproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -55,8 +53,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -248,10 +244,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp11/Ice/properties/msbuild/client/packages.config
+++ b/cpp11/Ice/properties/msbuild/client/packages.config
@@ -1,7 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp11/Ice/properties/msbuild/server/packages.config
+++ b/cpp11/Ice/properties/msbuild/server/packages.config
@@ -1,7 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp11/Ice/properties/msbuild/server/server.vcxproj
+++ b/cpp11/Ice/properties/msbuild/server/server.vcxproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -56,8 +54,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -249,10 +245,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp11/Ice/qt/msbuild/client.vcxproj
+++ b/cpp11/Ice/qt/msbuild/client.vcxproj
@@ -1,8 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\packages\zeroc.icebuilder.msbuild.5.0.6\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.6\build\zeroc.icebuilder.msbuild.props')" />
-  <Import Project="..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props') " />
-  <Import Project="..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props') " />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">
       <Configuration>Debug</Configuration>
@@ -131,8 +129,6 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets') " />
-    <Import Project="..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets') " />
     <Import Project="..\..\..\packages\zeroc.icebuilder.msbuild.5.0.6\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.6\build\zeroc.icebuilder.msbuild.targets')" />
   </ImportGroup>
   <ProjectExtensions>
@@ -144,10 +140,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
     <Error Condition="!Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.6\build\zeroc.icebuilder.msbuild.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.icebuilder.msbuild.5.0.6\build\zeroc.icebuilder.msbuild.props'))" />
     <Error Condition="!Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.6\build\zeroc.icebuilder.msbuild.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.icebuilder.msbuild.5.0.6\build\zeroc.icebuilder.msbuild.targets'))" />
   </Target>

--- a/cpp11/Ice/qt/msbuild/packages.config
+++ b/cpp11/Ice/qt/msbuild/packages.config
@@ -1,6 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.6" targetFramework="native" />
 </packages>

--- a/cpp11/Ice/session/msbuild/client/client.vcxproj
+++ b/cpp11/Ice/session/msbuild/client/client.vcxproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -55,8 +53,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -252,10 +248,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp11/Ice/session/msbuild/client/packages.config
+++ b/cpp11/Ice/session/msbuild/client/packages.config
@@ -1,7 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp11/Ice/session/msbuild/server/packages.config
+++ b/cpp11/Ice/session/msbuild/server/packages.config
@@ -1,7 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp11/Ice/session/msbuild/server/server.vcxproj
+++ b/cpp11/Ice/session/msbuild/server/server.vcxproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -55,8 +53,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -256,10 +252,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp11/Ice/throughput/msbuild/client/client.vcxproj
+++ b/cpp11/Ice/throughput/msbuild/client/client.vcxproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -56,8 +54,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -249,10 +245,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp11/Ice/throughput/msbuild/client/packages.config
+++ b/cpp11/Ice/throughput/msbuild/client/packages.config
@@ -1,7 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp11/Ice/throughput/msbuild/server/packages.config
+++ b/cpp11/Ice/throughput/msbuild/server/packages.config
@@ -1,7 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp11/Ice/throughput/msbuild/server/server.vcxproj
+++ b/cpp11/Ice/throughput/msbuild/server/server.vcxproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -55,8 +53,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -250,10 +246,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp11/IceBox/hello/msbuild/client/client.vcxproj
+++ b/cpp11/IceBox/hello/msbuild/client/client.vcxproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -55,8 +53,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -252,10 +248,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp11/IceBox/hello/msbuild/client/packages.config
+++ b/cpp11/IceBox/hello/msbuild/client/packages.config
@@ -1,7 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp11/IceBox/hello/msbuild/server/packages.config
+++ b/cpp11/IceBox/hello/msbuild/server/packages.config
@@ -1,7 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp11/IceBox/hello/msbuild/server/server.vcxproj
+++ b/cpp11/IceBox/hello/msbuild/server/server.vcxproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -55,8 +53,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -280,10 +276,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp11/IceDiscovery/hello/msbuild/client/client.vcxproj
+++ b/cpp11/IceDiscovery/hello/msbuild/client/client.vcxproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -55,8 +53,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -252,10 +248,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp11/IceDiscovery/hello/msbuild/client/packages.config
+++ b/cpp11/IceDiscovery/hello/msbuild/client/packages.config
@@ -1,7 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp11/IceDiscovery/hello/msbuild/server/packages.config
+++ b/cpp11/IceDiscovery/hello/msbuild/server/packages.config
@@ -1,7 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp11/IceDiscovery/hello/msbuild/server/server.vcxproj
+++ b/cpp11/IceDiscovery/hello/msbuild/server/server.vcxproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -55,8 +53,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -254,10 +250,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp11/IceDiscovery/replication/msbuild/client/client.vcxproj
+++ b/cpp11/IceDiscovery/replication/msbuild/client/client.vcxproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -55,8 +53,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -256,10 +252,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp11/IceDiscovery/replication/msbuild/client/packages.config
+++ b/cpp11/IceDiscovery/replication/msbuild/client/packages.config
@@ -1,7 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp11/IceDiscovery/replication/msbuild/server/packages.config
+++ b/cpp11/IceDiscovery/replication/msbuild/server/packages.config
@@ -1,7 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp11/IceDiscovery/replication/msbuild/server/server.vcxproj
+++ b/cpp11/IceDiscovery/replication/msbuild/server/server.vcxproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -55,8 +53,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -253,10 +249,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp11/IceGrid/allocate/msbuild/client/client.vcxproj
+++ b/cpp11/IceGrid/allocate/msbuild/client/client.vcxproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -55,8 +53,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -256,10 +252,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp11/IceGrid/allocate/msbuild/client/packages.config
+++ b/cpp11/IceGrid/allocate/msbuild/client/packages.config
@@ -1,7 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp11/IceGrid/allocate/msbuild/server/packages.config
+++ b/cpp11/IceGrid/allocate/msbuild/server/packages.config
@@ -1,7 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp11/IceGrid/allocate/msbuild/server/server.vcxproj
+++ b/cpp11/IceGrid/allocate/msbuild/server/server.vcxproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -55,8 +53,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -256,10 +252,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp11/IceGrid/customLocator/msbuild/client/client.vcxproj
+++ b/cpp11/IceGrid/customLocator/msbuild/client/client.vcxproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -55,8 +53,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -256,10 +252,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp11/IceGrid/customLocator/msbuild/client/packages.config
+++ b/cpp11/IceGrid/customLocator/msbuild/client/packages.config
@@ -1,7 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp11/IceGrid/customLocator/msbuild/locator/locator.vcxproj
+++ b/cpp11/IceGrid/customLocator/msbuild/locator/locator.vcxproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -56,8 +54,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -200,10 +196,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp11/IceGrid/customLocator/msbuild/locator/packages.config
+++ b/cpp11/IceGrid/customLocator/msbuild/locator/packages.config
@@ -1,7 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp11/IceGrid/customLocator/msbuild/server/packages.config
+++ b/cpp11/IceGrid/customLocator/msbuild/server/packages.config
@@ -1,7 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp11/IceGrid/customLocator/msbuild/server/server.vcxproj
+++ b/cpp11/IceGrid/customLocator/msbuild/server/server.vcxproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -55,8 +53,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -255,10 +251,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp11/IceGrid/icebox/msbuild/client/client.vcxproj
+++ b/cpp11/IceGrid/icebox/msbuild/client/client.vcxproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -55,8 +53,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -252,10 +248,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp11/IceGrid/icebox/msbuild/client/packages.config
+++ b/cpp11/IceGrid/icebox/msbuild/client/packages.config
@@ -1,7 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp11/IceGrid/icebox/msbuild/server/packages.config
+++ b/cpp11/IceGrid/icebox/msbuild/server/packages.config
@@ -1,7 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp11/IceGrid/icebox/msbuild/server/server.vcxproj
+++ b/cpp11/IceGrid/icebox/msbuild/server/server.vcxproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -55,8 +53,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -279,10 +275,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp11/IceGrid/replication/msbuild/client/client.vcxproj
+++ b/cpp11/IceGrid/replication/msbuild/client/client.vcxproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -55,8 +53,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -256,10 +252,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp11/IceGrid/replication/msbuild/client/packages.config
+++ b/cpp11/IceGrid/replication/msbuild/client/packages.config
@@ -1,7 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp11/IceGrid/replication/msbuild/server/packages.config
+++ b/cpp11/IceGrid/replication/msbuild/server/packages.config
@@ -1,7 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp11/IceGrid/replication/msbuild/server/server.vcxproj
+++ b/cpp11/IceGrid/replication/msbuild/server/server.vcxproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -55,8 +53,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -263,10 +259,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp11/IceGrid/secure/msbuild/client/client.vcxproj
+++ b/cpp11/IceGrid/secure/msbuild/client/client.vcxproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -55,8 +53,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -256,10 +252,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp11/IceGrid/secure/msbuild/client/packages.config
+++ b/cpp11/IceGrid/secure/msbuild/client/packages.config
@@ -1,7 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp11/IceGrid/secure/msbuild/server/packages.config
+++ b/cpp11/IceGrid/secure/msbuild/server/packages.config
@@ -1,7 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp11/IceGrid/secure/msbuild/server/server.vcxproj
+++ b/cpp11/IceGrid/secure/msbuild/server/server.vcxproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -55,8 +53,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -259,10 +255,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp11/IceGrid/sessionActivation/msbuild/client/client.vcxproj
+++ b/cpp11/IceGrid/sessionActivation/msbuild/client/client.vcxproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -55,8 +53,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -256,10 +252,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp11/IceGrid/sessionActivation/msbuild/client/packages.config
+++ b/cpp11/IceGrid/sessionActivation/msbuild/client/packages.config
@@ -1,7 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp11/IceGrid/sessionActivation/msbuild/server/packages.config
+++ b/cpp11/IceGrid/sessionActivation/msbuild/server/packages.config
@@ -1,7 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp11/IceGrid/sessionActivation/msbuild/server/server.vcxproj
+++ b/cpp11/IceGrid/sessionActivation/msbuild/server/server.vcxproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -55,8 +53,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -255,10 +251,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp11/IceGrid/simple/msbuild/client/client.vcxproj
+++ b/cpp11/IceGrid/simple/msbuild/client/client.vcxproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -55,8 +53,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -256,10 +252,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp11/IceGrid/simple/msbuild/client/packages.config
+++ b/cpp11/IceGrid/simple/msbuild/client/packages.config
@@ -1,7 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp11/IceGrid/simple/msbuild/server/packages.config
+++ b/cpp11/IceGrid/simple/msbuild/server/packages.config
@@ -1,7 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp11/IceGrid/simple/msbuild/server/server.vcxproj
+++ b/cpp11/IceGrid/simple/msbuild/server/server.vcxproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -55,8 +53,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -257,10 +253,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp11/IceStorm/clock/msbuild/publisher/packages.config
+++ b/cpp11/IceStorm/clock/msbuild/publisher/packages.config
@@ -1,7 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp11/IceStorm/clock/msbuild/publisher/publisher.vcxproj
+++ b/cpp11/IceStorm/clock/msbuild/publisher/publisher.vcxproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -55,8 +53,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -254,10 +250,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp11/IceStorm/clock/msbuild/subscriber/packages.config
+++ b/cpp11/IceStorm/clock/msbuild/subscriber/packages.config
@@ -1,7 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp11/IceStorm/clock/msbuild/subscriber/subscriber.vcxproj
+++ b/cpp11/IceStorm/clock/msbuild/subscriber/subscriber.vcxproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -55,8 +53,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -254,10 +250,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp11/IceStorm/counter/msbuild/client/client.vcxproj
+++ b/cpp11/IceStorm/counter/msbuild/client/client.vcxproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -55,8 +53,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -254,10 +250,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp11/IceStorm/counter/msbuild/client/packages.config
+++ b/cpp11/IceStorm/counter/msbuild/client/packages.config
@@ -1,7 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp11/IceStorm/counter/msbuild/server/packages.config
+++ b/cpp11/IceStorm/counter/msbuild/server/packages.config
@@ -1,7 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp11/IceStorm/counter/msbuild/server/server.vcxproj
+++ b/cpp11/IceStorm/counter/msbuild/server/server.vcxproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -55,8 +53,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -259,10 +255,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp11/IceStorm/replicated/msbuild/publisher/packages.config
+++ b/cpp11/IceStorm/replicated/msbuild/publisher/packages.config
@@ -1,7 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp11/IceStorm/replicated/msbuild/publisher/publisher.vcxproj
+++ b/cpp11/IceStorm/replicated/msbuild/publisher/publisher.vcxproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -55,8 +53,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -254,10 +250,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp11/IceStorm/replicated/msbuild/subscriber/packages.config
+++ b/cpp11/IceStorm/replicated/msbuild/subscriber/packages.config
@@ -1,7 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp11/IceStorm/replicated/msbuild/subscriber/subscriber.vcxproj
+++ b/cpp11/IceStorm/replicated/msbuild/subscriber/subscriber.vcxproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -55,8 +53,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -258,10 +254,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp11/IceStorm/replicated2/msbuild/publisher/packages.config
+++ b/cpp11/IceStorm/replicated2/msbuild/publisher/packages.config
@@ -1,7 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp11/IceStorm/replicated2/msbuild/publisher/publisher.vcxproj
+++ b/cpp11/IceStorm/replicated2/msbuild/publisher/publisher.vcxproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -55,8 +53,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -258,10 +254,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp11/IceStorm/replicated2/msbuild/subscriber/packages.config
+++ b/cpp11/IceStorm/replicated2/msbuild/subscriber/packages.config
@@ -1,7 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp11/IceStorm/replicated2/msbuild/subscriber/subscriber.vcxproj
+++ b/cpp11/IceStorm/replicated2/msbuild/subscriber/subscriber.vcxproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -55,8 +53,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -258,10 +254,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp11/Manual/lifecycle/msbuild/client/client.vcxproj
+++ b/cpp11/Manual/lifecycle/msbuild/client/client.vcxproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -57,8 +55,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -258,10 +254,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp11/Manual/lifecycle/msbuild/client/packages.config
+++ b/cpp11/Manual/lifecycle/msbuild/client/packages.config
@@ -1,7 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp11/Manual/lifecycle/msbuild/server/packages.config
+++ b/cpp11/Manual/lifecycle/msbuild/server/packages.config
@@ -1,7 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp11/Manual/lifecycle/msbuild/server/server.vcxproj
+++ b/cpp11/Manual/lifecycle/msbuild/server/server.vcxproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -57,8 +55,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -255,10 +251,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp11/Manual/printer/msbuild/client/client.vcxproj
+++ b/cpp11/Manual/printer/msbuild/client/client.vcxproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -55,8 +53,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -247,10 +243,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp11/Manual/printer/msbuild/client/packages.config
+++ b/cpp11/Manual/printer/msbuild/client/packages.config
@@ -1,7 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp11/Manual/printer/msbuild/server/packages.config
+++ b/cpp11/Manual/printer/msbuild/server/packages.config
@@ -1,7 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp11/Manual/printer/msbuild/server/server.vcxproj
+++ b/cpp11/Manual/printer/msbuild/server/server.vcxproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -55,8 +53,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -247,10 +243,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp11/Manual/simpleFilesystem/msbuild/client/client.vcxproj
+++ b/cpp11/Manual/simpleFilesystem/msbuild/client/client.vcxproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -56,8 +54,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -248,10 +244,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp11/Manual/simpleFilesystem/msbuild/client/packages.config
+++ b/cpp11/Manual/simpleFilesystem/msbuild/client/packages.config
@@ -1,7 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp11/Manual/simpleFilesystem/msbuild/server/packages.config
+++ b/cpp11/Manual/simpleFilesystem/msbuild/server/packages.config
@@ -1,7 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp11/Manual/simpleFilesystem/msbuild/server/server.vcxproj
+++ b/cpp11/Manual/simpleFilesystem/msbuild/server/server.vcxproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -55,8 +53,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -247,10 +243,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp11/README.md
+++ b/cpp11/README.md
@@ -139,7 +139,7 @@ If you are building Debug, add both the Debug and Release `bin` directories with
 command similar to:
 
 ```shell
-set PATH=%USERPROFILE%\ice-demos\cpp11\packages\zeroc.ice.v140.3.7.10\build\native\bin\x64\Debug;%USERPROFILE%\ice-demos\cpp11\packages\zeroc.ice.v140.3.7.10\build\native\bin\x64\Release;%PATH%
+set PATH=%USERPROFILE%\ice-demos\cpp11\packages\zeroc.ice.v143.3.7.10\build\native\bin\x64\Debug;%USERPROFILE%\ice-demos\cpp11\packages\zeroc.ice.v143.3.7.10\build\native\bin\x64\Release;%PATH%
 ```
 
 This is required because the Debug `bin` directories provide only a subset of all
@@ -149,7 +149,7 @@ If you are building Release, you should add only the Release `bin` directory to
 your PATH with a command similar to:
 
 ```shell
-set PATH=%USERPROFILE%\ice-demos\cpp11\packages\zeroc.ice.v140.3.7.10\build\native\bin\x64\Release;%PATH%
+set PATH=%USERPROFILE%\ice-demos\cpp11\packages\zeroc.ice.v143.3.7.10\build\native\bin\x64\Release;%PATH%
 ```
 
 Then refer to the README.md file in each demo directory for usage instructions.

--- a/cpp98/Glacier2/callback/msbuild/client/client.vcxproj
+++ b/cpp98/Glacier2/callback/msbuild/client/client.vcxproj
@@ -1,12 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -30,9 +26,6 @@
     <ProjectGuid>{AF429C66-AF79-4CA1-83CE-EA345DFA4BBA}</ProjectGuid>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup>
-    <DefaultPlatformToolset Condition="'$(VisualStudioVersion)' == '10.0' And  '$(DefaultPlatformToolset)' == ''">v100</DefaultPlatformToolset>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
@@ -62,10 +55,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -271,14 +260,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp98/Glacier2/callback/msbuild/client/packages.config
+++ b/cpp98/Glacier2/callback/msbuild/client/packages.config
@@ -1,9 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v100" version="3.7.10" targetFramework="Native" />
-  <package id="zeroc.ice.v120" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp98/Glacier2/callback/msbuild/server/packages.config
+++ b/cpp98/Glacier2/callback/msbuild/server/packages.config
@@ -1,9 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v100" version="3.7.10" targetFramework="Native" />
-  <package id="zeroc.ice.v120" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp98/Glacier2/callback/msbuild/server/server.vcxproj
+++ b/cpp98/Glacier2/callback/msbuild/server/server.vcxproj
@@ -1,12 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -30,9 +26,6 @@
     <ProjectGuid>{50C35E8E-3504-4DDF-8C5A-787525F16A91}</ProjectGuid>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup>
-    <DefaultPlatformToolset Condition="'$(VisualStudioVersion)' == '10.0' And  '$(DefaultPlatformToolset)' == ''">v100</DefaultPlatformToolset>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
@@ -62,10 +55,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -272,14 +261,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp98/Glacier2/simpleChat/msbuild/client/client.vcxproj
+++ b/cpp98/Glacier2/simpleChat/msbuild/client/client.vcxproj
@@ -1,12 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -30,9 +26,6 @@
     <ProjectGuid>{3202DB5F-A249-4250-AB9D-EAA35AE386F1}</ProjectGuid>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup>
-    <DefaultPlatformToolset Condition="'$(VisualStudioVersion)' == '10.0' And  '$(DefaultPlatformToolset)' == ''">v100</DefaultPlatformToolset>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
@@ -62,10 +55,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -270,14 +259,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp98/Glacier2/simpleChat/msbuild/client/packages.config
+++ b/cpp98/Glacier2/simpleChat/msbuild/client/packages.config
@@ -1,9 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v100" version="3.7.10" targetFramework="Native" />
-  <package id="zeroc.ice.v120" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp98/Glacier2/simpleChat/msbuild/server/packages.config
+++ b/cpp98/Glacier2/simpleChat/msbuild/server/packages.config
@@ -1,9 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v100" version="3.7.10" targetFramework="Native" />
-  <package id="zeroc.ice.v120" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp98/Glacier2/simpleChat/msbuild/server/server.vcxproj
+++ b/cpp98/Glacier2/simpleChat/msbuild/server/server.vcxproj
@@ -1,12 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -30,9 +26,6 @@
     <ProjectGuid>{A5A0DB86-3CB6-4B37-ADC7-5BC49C0E80A8}</ProjectGuid>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup>
-    <DefaultPlatformToolset Condition="'$(VisualStudioVersion)' == '10.0' And  '$(DefaultPlatformToolset)' == ''">v100</DefaultPlatformToolset>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
@@ -62,10 +55,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -283,14 +272,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp98/Ice/async/msbuild/client/client.vcxproj
+++ b/cpp98/Ice/async/msbuild/client/client.vcxproj
@@ -1,12 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -30,9 +26,6 @@
     <ProjectGuid>{85C473C2-E124-44AC-9BE0-8BFA6E5B0BA6}</ProjectGuid>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup>
-    <DefaultPlatformToolset Condition="'$(VisualStudioVersion)' == '10.0' And  '$(DefaultPlatformToolset)' == ''">v100</DefaultPlatformToolset>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
@@ -62,10 +55,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -259,14 +248,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp98/Ice/async/msbuild/client/packages.config
+++ b/cpp98/Ice/async/msbuild/client/packages.config
@@ -1,9 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v100" version="3.7.10" targetFramework="Native" />
-  <package id="zeroc.ice.v120" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp98/Ice/async/msbuild/server/packages.config
+++ b/cpp98/Ice/async/msbuild/server/packages.config
@@ -1,9 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v100" version="3.7.10" targetFramework="Native" />
-  <package id="zeroc.ice.v120" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp98/Ice/async/msbuild/server/server.vcxproj
+++ b/cpp98/Ice/async/msbuild/server/server.vcxproj
@@ -1,12 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -31,9 +27,6 @@
     <RootNamespace>Ice.async.server</RootNamespace>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup>
-    <DefaultPlatformToolset Condition="'$(VisualStudioVersion)' == '10.0' And  '$(DefaultPlatformToolset)' == ''">v100</DefaultPlatformToolset>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
@@ -63,10 +56,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -281,14 +270,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp98/Ice/bidir/msbuild/client/client.vcxproj
+++ b/cpp98/Ice/bidir/msbuild/client/client.vcxproj
@@ -1,12 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -30,9 +26,6 @@
     <ProjectGuid>{7074C2B1-CBA9-494C-BFE5-955721AE44B0}</ProjectGuid>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup>
-    <DefaultPlatformToolset Condition="'$(VisualStudioVersion)' == '10.0' And  '$(DefaultPlatformToolset)' == ''">v100</DefaultPlatformToolset>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
@@ -62,10 +55,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -259,14 +248,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp98/Ice/bidir/msbuild/client/packages.config
+++ b/cpp98/Ice/bidir/msbuild/client/packages.config
@@ -1,9 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v100" version="3.7.10" targetFramework="Native" />
-  <package id="zeroc.ice.v120" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp98/Ice/bidir/msbuild/server/packages.config
+++ b/cpp98/Ice/bidir/msbuild/server/packages.config
@@ -1,9 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v100" version="3.7.10" targetFramework="Native" />
-  <package id="zeroc.ice.v120" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp98/Ice/bidir/msbuild/server/server.vcxproj
+++ b/cpp98/Ice/bidir/msbuild/server/server.vcxproj
@@ -1,12 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -30,9 +26,6 @@
     <ProjectGuid>{FC895988-01DA-4B5C-8D38-C1CB68F93EF5}</ProjectGuid>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup>
-    <DefaultPlatformToolset Condition="'$(VisualStudioVersion)' == '10.0' And  '$(DefaultPlatformToolset)' == ''">v100</DefaultPlatformToolset>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
@@ -62,10 +55,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -261,14 +250,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp98/Ice/callback/msbuild/client/client.vcxproj
+++ b/cpp98/Ice/callback/msbuild/client/client.vcxproj
@@ -1,12 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -30,9 +26,6 @@
     <ProjectGuid>{570A810E-6888-4D21-A6AD-976B0350F42E}</ProjectGuid>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup>
-    <DefaultPlatformToolset Condition="'$(VisualStudioVersion)' == '10.0' And  '$(DefaultPlatformToolset)' == ''">v100</DefaultPlatformToolset>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
@@ -62,10 +55,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -259,14 +248,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp98/Ice/callback/msbuild/client/packages.config
+++ b/cpp98/Ice/callback/msbuild/client/packages.config
@@ -1,9 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v100" version="3.7.10" targetFramework="Native" />
-  <package id="zeroc.ice.v120" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp98/Ice/callback/msbuild/server/packages.config
+++ b/cpp98/Ice/callback/msbuild/server/packages.config
@@ -1,9 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v100" version="3.7.10" targetFramework="Native" />
-  <package id="zeroc.ice.v120" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp98/Ice/callback/msbuild/server/server.vcxproj
+++ b/cpp98/Ice/callback/msbuild/server/server.vcxproj
@@ -1,12 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -30,9 +26,6 @@
     <ProjectGuid>{5B71F2A4-0901-418C-8E11-986EE6362870}</ProjectGuid>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup>
-    <DefaultPlatformToolset Condition="'$(VisualStudioVersion)' == '10.0' And  '$(DefaultPlatformToolset)' == ''">v100</DefaultPlatformToolset>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
@@ -62,10 +55,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -261,14 +250,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp98/Ice/context/msbuild/client/client.vcxproj
+++ b/cpp98/Ice/context/msbuild/client/client.vcxproj
@@ -1,12 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -30,9 +26,6 @@
     <ProjectGuid>{97DE0B9E-0DA8-4304-BAAC-CBC52339B14D}</ProjectGuid>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup>
-    <DefaultPlatformToolset Condition="'$(VisualStudioVersion)' == '10.0' And  '$(DefaultPlatformToolset)' == ''">v100</DefaultPlatformToolset>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
@@ -62,10 +55,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -259,14 +248,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp98/Ice/context/msbuild/client/packages.config
+++ b/cpp98/Ice/context/msbuild/client/packages.config
@@ -1,9 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v100" version="3.7.10" targetFramework="Native" />
-  <package id="zeroc.ice.v120" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp98/Ice/context/msbuild/server/packages.config
+++ b/cpp98/Ice/context/msbuild/server/packages.config
@@ -1,9 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v100" version="3.7.10" targetFramework="Native" />
-  <package id="zeroc.ice.v120" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp98/Ice/context/msbuild/server/server.vcxproj
+++ b/cpp98/Ice/context/msbuild/server/server.vcxproj
@@ -1,12 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -30,9 +26,6 @@
     <ProjectGuid>{2E565430-0E78-44F1-97CD-6995EEED4FCC}</ProjectGuid>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup>
-    <DefaultPlatformToolset Condition="'$(VisualStudioVersion)' == '10.0' And  '$(DefaultPlatformToolset)' == ''">v100</DefaultPlatformToolset>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
@@ -62,10 +55,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -261,14 +250,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp98/Ice/hello/msbuild/client/client.vcxproj
+++ b/cpp98/Ice/hello/msbuild/client/client.vcxproj
@@ -1,12 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -30,9 +26,6 @@
     <ProjectGuid>{710A52F2-A014-4CB2-AF40-348D48DBCDDD}</ProjectGuid>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup>
-    <DefaultPlatformToolset Condition="'$(VisualStudioVersion)' == '10.0' And  '$(DefaultPlatformToolset)' == ''">v100</DefaultPlatformToolset>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
@@ -62,10 +55,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -259,14 +248,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp98/Ice/hello/msbuild/client/packages.config
+++ b/cpp98/Ice/hello/msbuild/client/packages.config
@@ -1,9 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v100" version="3.7.10" targetFramework="Native" />
-  <package id="zeroc.ice.v120" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp98/Ice/hello/msbuild/server/packages.config
+++ b/cpp98/Ice/hello/msbuild/server/packages.config
@@ -1,9 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v100" version="3.7.10" targetFramework="Native" />
-  <package id="zeroc.ice.v120" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp98/Ice/hello/msbuild/server/server.vcxproj
+++ b/cpp98/Ice/hello/msbuild/server/server.vcxproj
@@ -1,12 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -30,9 +26,6 @@
     <ProjectGuid>{25843122-783A-45E0-8D42-612C72D3B183}</ProjectGuid>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup>
-    <DefaultPlatformToolset Condition="'$(VisualStudioVersion)' == '10.0' And  '$(DefaultPlatformToolset)' == ''">v100</DefaultPlatformToolset>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
@@ -62,10 +55,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -261,14 +250,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp98/Ice/invoke/msbuild/client/client.vcxproj
+++ b/cpp98/Ice/invoke/msbuild/client/client.vcxproj
@@ -1,12 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -30,9 +26,6 @@
     <ProjectGuid>{8ADDD766-8657-42B1-96A7-83AF4B70F2C3}</ProjectGuid>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup>
-    <DefaultPlatformToolset Condition="'$(VisualStudioVersion)' == '10.0' And  '$(DefaultPlatformToolset)' == ''">v100</DefaultPlatformToolset>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
@@ -62,10 +55,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -259,14 +248,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp98/Ice/invoke/msbuild/client/packages.config
+++ b/cpp98/Ice/invoke/msbuild/client/packages.config
@@ -1,9 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v100" version="3.7.10" targetFramework="Native" />
-  <package id="zeroc.ice.v120" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp98/Ice/invoke/msbuild/server/packages.config
+++ b/cpp98/Ice/invoke/msbuild/server/packages.config
@@ -1,9 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v100" version="3.7.10" targetFramework="Native" />
-  <package id="zeroc.ice.v120" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp98/Ice/invoke/msbuild/server/server.vcxproj
+++ b/cpp98/Ice/invoke/msbuild/server/server.vcxproj
@@ -1,12 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -30,9 +26,6 @@
     <ProjectGuid>{9D2F23B1-0049-4E6C-86A7-557A5B1F8597}</ProjectGuid>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup>
-    <DefaultPlatformToolset Condition="'$(VisualStudioVersion)' == '10.0' And  '$(DefaultPlatformToolset)' == ''">v100</DefaultPlatformToolset>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
@@ -62,10 +55,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -261,14 +250,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp98/Ice/latency/msbuild/client/client.vcxproj
+++ b/cpp98/Ice/latency/msbuild/client/client.vcxproj
@@ -1,12 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -30,9 +26,6 @@
     <ProjectGuid>{C9E196EB-AB36-48CE-93F4-2BA37BAA7E76}</ProjectGuid>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup>
-    <DefaultPlatformToolset Condition="'$(VisualStudioVersion)' == '10.0' And  '$(DefaultPlatformToolset)' == ''">v100</DefaultPlatformToolset>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
@@ -62,10 +55,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -259,14 +248,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp98/Ice/latency/msbuild/client/packages.config
+++ b/cpp98/Ice/latency/msbuild/client/packages.config
@@ -1,9 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v100" version="3.7.10" targetFramework="Native" />
-  <package id="zeroc.ice.v120" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp98/Ice/latency/msbuild/server/packages.config
+++ b/cpp98/Ice/latency/msbuild/server/packages.config
@@ -1,9 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v100" version="3.7.10" targetFramework="Native" />
-  <package id="zeroc.ice.v120" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp98/Ice/latency/msbuild/server/server.vcxproj
+++ b/cpp98/Ice/latency/msbuild/server/server.vcxproj
@@ -1,12 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -30,9 +26,6 @@
     <ProjectGuid>{DF4C0DA9-DD64-44D1-B56E-FDC3C1CE4A44}</ProjectGuid>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup>
-    <DefaultPlatformToolset Condition="'$(VisualStudioVersion)' == '10.0' And  '$(DefaultPlatformToolset)' == ''">v100</DefaultPlatformToolset>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
@@ -62,10 +55,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -259,14 +248,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp98/Ice/locator/msbuild/client/client.vcxproj
+++ b/cpp98/Ice/locator/msbuild/client/client.vcxproj
@@ -1,12 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -30,9 +26,6 @@
     <ProjectGuid>{51D56919-05A7-4282-A736-CD25ABC2179A}</ProjectGuid>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup>
-    <DefaultPlatformToolset Condition="'$(VisualStudioVersion)' == '10.0' And  '$(DefaultPlatformToolset)' == ''">v100</DefaultPlatformToolset>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
@@ -62,10 +55,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -260,14 +249,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp98/Ice/locator/msbuild/client/packages.config
+++ b/cpp98/Ice/locator/msbuild/client/packages.config
@@ -1,9 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v100" version="3.7.10" targetFramework="Native" />
-  <package id="zeroc.ice.v120" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp98/Ice/locator/msbuild/locator/locator.vcxproj
+++ b/cpp98/Ice/locator/msbuild/locator/locator.vcxproj
@@ -1,12 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -30,9 +26,6 @@
     <ProjectGuid>{F6307AF8-3DD8-4C32-B2DC-0B0FBEF9E6A1}</ProjectGuid>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup>
-    <DefaultPlatformToolset Condition="'$(VisualStudioVersion)' == '10.0' And  '$(DefaultPlatformToolset)' == ''">v100</DefaultPlatformToolset>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
@@ -62,10 +55,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -206,14 +195,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp98/Ice/locator/msbuild/locator/packages.config
+++ b/cpp98/Ice/locator/msbuild/locator/packages.config
@@ -1,9 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v100" version="3.7.10" targetFramework="Native" />
-  <package id="zeroc.ice.v120" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp98/Ice/locator/msbuild/server/packages.config
+++ b/cpp98/Ice/locator/msbuild/server/packages.config
@@ -1,9 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v100" version="3.7.10" targetFramework="Native" />
-  <package id="zeroc.ice.v120" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp98/Ice/locator/msbuild/server/server.vcxproj
+++ b/cpp98/Ice/locator/msbuild/server/server.vcxproj
@@ -1,12 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -30,9 +26,6 @@
     <ProjectGuid>{60208663-4C32-4B9F-A3CA-DA103A56257F}</ProjectGuid>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup>
-    <DefaultPlatformToolset Condition="'$(VisualStudioVersion)' == '10.0' And  '$(DefaultPlatformToolset)' == ''">v100</DefaultPlatformToolset>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
@@ -62,10 +55,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -261,14 +250,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp98/Ice/minimal/msbuild/client/client.vcxproj
+++ b/cpp98/Ice/minimal/msbuild/client/client.vcxproj
@@ -1,12 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -30,9 +26,6 @@
     <ProjectGuid>{82D5187D-67E4-4C2D-B270-6ECC665D426E}</ProjectGuid>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup>
-    <DefaultPlatformToolset Condition="'$(VisualStudioVersion)' == '10.0' And  '$(DefaultPlatformToolset)' == ''">v100</DefaultPlatformToolset>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
@@ -62,10 +55,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -258,14 +247,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp98/Ice/minimal/msbuild/client/packages.config
+++ b/cpp98/Ice/minimal/msbuild/client/packages.config
@@ -1,9 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v100" version="3.7.10" targetFramework="Native" />
-  <package id="zeroc.ice.v120" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp98/Ice/minimal/msbuild/server/packages.config
+++ b/cpp98/Ice/minimal/msbuild/server/packages.config
@@ -1,9 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v100" version="3.7.10" targetFramework="Native" />
-  <package id="zeroc.ice.v120" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp98/Ice/minimal/msbuild/server/server.vcxproj
+++ b/cpp98/Ice/minimal/msbuild/server/server.vcxproj
@@ -1,12 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -30,9 +26,6 @@
     <ProjectGuid>{E768F2F0-04F1-4721-A624-1265AAC40211}</ProjectGuid>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup>
-    <DefaultPlatformToolset Condition="'$(VisualStudioVersion)' == '10.0' And  '$(DefaultPlatformToolset)' == ''">v100</DefaultPlatformToolset>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
@@ -62,10 +55,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -260,14 +249,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp98/Ice/mtalk/msbuild/client/client.vcxproj
+++ b/cpp98/Ice/mtalk/msbuild/client/client.vcxproj
@@ -1,12 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -30,9 +26,6 @@
     <ProjectGuid>{5906BFE3-53BC-4C13-BEA5-B521E0462A56}</ProjectGuid>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup>
-    <DefaultPlatformToolset Condition="'$(VisualStudioVersion)' == '10.0' And  '$(DefaultPlatformToolset)' == ''">v100</DefaultPlatformToolset>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
@@ -62,10 +55,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -263,14 +252,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp98/Ice/mtalk/msbuild/client/packages.config
+++ b/cpp98/Ice/mtalk/msbuild/client/packages.config
@@ -1,9 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v100" version="3.7.10" targetFramework="Native" />
-  <package id="zeroc.ice.v120" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp98/Ice/multicast/msbuild/client/client.vcxproj
+++ b/cpp98/Ice/multicast/msbuild/client/client.vcxproj
@@ -1,12 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -30,9 +26,6 @@
     <ProjectGuid>{2494165B-BD91-4805-B759-8F27983E9655}</ProjectGuid>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup>
-    <DefaultPlatformToolset Condition="'$(VisualStudioVersion)' == '10.0' And  '$(DefaultPlatformToolset)' == ''">v100</DefaultPlatformToolset>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
@@ -62,10 +55,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -308,14 +297,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp98/Ice/multicast/msbuild/client/packages.config
+++ b/cpp98/Ice/multicast/msbuild/client/packages.config
@@ -1,9 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v100" version="3.7.10" targetFramework="Native" />
-  <package id="zeroc.ice.v120" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp98/Ice/multicast/msbuild/server/packages.config
+++ b/cpp98/Ice/multicast/msbuild/server/packages.config
@@ -1,9 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v100" version="3.7.10" targetFramework="Native" />
-  <package id="zeroc.ice.v120" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp98/Ice/multicast/msbuild/server/server.vcxproj
+++ b/cpp98/Ice/multicast/msbuild/server/server.vcxproj
@@ -1,12 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -30,9 +26,6 @@
     <ProjectGuid>{D7B009A5-9EAD-4D3B-AFFC-8E20E42F2A92}</ProjectGuid>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup>
-    <DefaultPlatformToolset Condition="'$(VisualStudioVersion)' == '10.0' And  '$(DefaultPlatformToolset)' == ''">v100</DefaultPlatformToolset>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
@@ -62,10 +55,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -308,14 +297,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp98/Ice/nested/msbuild/client/client.vcxproj
+++ b/cpp98/Ice/nested/msbuild/client/client.vcxproj
@@ -1,12 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -30,9 +26,6 @@
     <ProjectGuid>{C585D79C-46FD-411C-81E2-E000B0831EE0}</ProjectGuid>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup>
-    <DefaultPlatformToolset Condition="'$(VisualStudioVersion)' == '10.0' And  '$(DefaultPlatformToolset)' == ''">v100</DefaultPlatformToolset>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
@@ -62,10 +55,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -261,14 +250,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp98/Ice/nested/msbuild/client/packages.config
+++ b/cpp98/Ice/nested/msbuild/client/packages.config
@@ -1,9 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v100" version="3.7.10" targetFramework="Native" />
-  <package id="zeroc.ice.v120" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp98/Ice/nested/msbuild/server/packages.config
+++ b/cpp98/Ice/nested/msbuild/server/packages.config
@@ -1,9 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v100" version="3.7.10" targetFramework="Native" />
-  <package id="zeroc.ice.v120" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp98/Ice/nested/msbuild/server/server.vcxproj
+++ b/cpp98/Ice/nested/msbuild/server/server.vcxproj
@@ -1,12 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -30,9 +26,6 @@
     <ProjectGuid>{743BB926-8649-447B-B8CF-7D3F41C0AD44}</ProjectGuid>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup>
-    <DefaultPlatformToolset Condition="'$(VisualStudioVersion)' == '10.0' And  '$(DefaultPlatformToolset)' == ''">v100</DefaultPlatformToolset>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
@@ -62,10 +55,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -261,14 +250,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp98/Ice/nrvo/msbuild/client/client.vcxproj
+++ b/cpp98/Ice/nrvo/msbuild/client/client.vcxproj
@@ -1,12 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -30,9 +26,6 @@
     <ProjectGuid>{DE27BEC2-4A03-4651-8C62-97EFE7E89AE7}</ProjectGuid>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup>
-    <DefaultPlatformToolset Condition="'$(VisualStudioVersion)' == '10.0' And  '$(DefaultPlatformToolset)' == ''">v100</DefaultPlatformToolset>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
@@ -62,10 +55,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -261,14 +250,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp98/Ice/nrvo/msbuild/client/packages.config
+++ b/cpp98/Ice/nrvo/msbuild/client/packages.config
@@ -1,9 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v100" version="3.7.10" targetFramework="Native" />
-  <package id="zeroc.ice.v120" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp98/Ice/nrvo/msbuild/server/packages.config
+++ b/cpp98/Ice/nrvo/msbuild/server/packages.config
@@ -1,9 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v100" version="3.7.10" targetFramework="Native" />
-  <package id="zeroc.ice.v120" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp98/Ice/nrvo/msbuild/server/server.vcxproj
+++ b/cpp98/Ice/nrvo/msbuild/server/server.vcxproj
@@ -1,12 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -30,9 +26,6 @@
     <ProjectGuid>{0DFB0C6A-4513-4A05-8AE6-FD6EA6943E95}</ProjectGuid>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup>
-    <DefaultPlatformToolset Condition="'$(VisualStudioVersion)' == '10.0' And  '$(DefaultPlatformToolset)' == ''">v100</DefaultPlatformToolset>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
@@ -62,10 +55,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -263,14 +252,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp98/Ice/optional/msbuild/client/client.vcxproj
+++ b/cpp98/Ice/optional/msbuild/client/client.vcxproj
@@ -1,12 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -30,9 +26,6 @@
     <ProjectGuid>{3EA94765-82A5-412A-8B4B-D88BC940B1F7}</ProjectGuid>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup>
-    <DefaultPlatformToolset Condition="'$(VisualStudioVersion)' == '10.0' And  '$(DefaultPlatformToolset)' == ''">v100</DefaultPlatformToolset>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
@@ -62,10 +55,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -259,14 +248,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp98/Ice/optional/msbuild/client/packages.config
+++ b/cpp98/Ice/optional/msbuild/client/packages.config
@@ -1,9 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v100" version="3.7.10" targetFramework="Native" />
-  <package id="zeroc.ice.v120" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp98/Ice/optional/msbuild/server/packages.config
+++ b/cpp98/Ice/optional/msbuild/server/packages.config
@@ -1,9 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v100" version="3.7.10" targetFramework="Native" />
-  <package id="zeroc.ice.v120" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp98/Ice/optional/msbuild/server/server.vcxproj
+++ b/cpp98/Ice/optional/msbuild/server/server.vcxproj
@@ -1,12 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -30,9 +26,6 @@
     <ProjectGuid>{A40BCFC2-8141-4BF5-AAA5-08F6D13A3B08}</ProjectGuid>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup>
-    <DefaultPlatformToolset Condition="'$(VisualStudioVersion)' == '10.0' And  '$(DefaultPlatformToolset)' == ''">v100</DefaultPlatformToolset>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
@@ -62,10 +55,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -261,14 +250,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp98/Ice/plugin/msbuild/client/client.vcxproj
+++ b/cpp98/Ice/plugin/msbuild/client/client.vcxproj
@@ -1,12 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -30,9 +26,6 @@
     <ProjectGuid>{53C81483-7079-4456-A5C9-59858369D516}</ProjectGuid>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup>
-    <DefaultPlatformToolset Condition="'$(VisualStudioVersion)' == '10.0' And  '$(DefaultPlatformToolset)' == ''">v100</DefaultPlatformToolset>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
@@ -60,10 +53,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -267,14 +256,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp98/Ice/plugin/msbuild/client/packages.config
+++ b/cpp98/Ice/plugin/msbuild/client/packages.config
@@ -1,9 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v100" version="3.7.10" targetFramework="Native" />
-  <package id="zeroc.ice.v120" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp98/Ice/plugin/msbuild/hello/hello.vcxproj
+++ b/cpp98/Ice/plugin/msbuild/hello/hello.vcxproj
@@ -1,12 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -30,9 +26,6 @@
     <ProjectGuid>{C9ABAC2B-9EFA-4841-AB7D-162DE65E8DA2}</ProjectGuid>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup>
-    <DefaultPlatformToolset Condition="'$(VisualStudioVersion)' == '10.0' And  '$(DefaultPlatformToolset)' == ''">v100</DefaultPlatformToolset>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
@@ -60,10 +53,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -290,14 +279,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp98/Ice/plugin/msbuild/hello/packages.config
+++ b/cpp98/Ice/plugin/msbuild/hello/packages.config
@@ -1,9 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v100" version="3.7.10" targetFramework="Native" />
-  <package id="zeroc.ice.v120" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp98/Ice/plugin/msbuild/logger/logger.vcxproj
+++ b/cpp98/Ice/plugin/msbuild/logger/logger.vcxproj
@@ -1,12 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -30,9 +26,6 @@
     <ProjectGuid>{7DD866C9-B1BC-42B8-973B-BAAD917B8468}</ProjectGuid>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup>
-    <DefaultPlatformToolset Condition="'$(VisualStudioVersion)' == '10.0' And  '$(DefaultPlatformToolset)' == ''">v100</DefaultPlatformToolset>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
@@ -60,10 +53,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -237,14 +226,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp98/Ice/plugin/msbuild/logger/packages.config
+++ b/cpp98/Ice/plugin/msbuild/logger/packages.config
@@ -1,9 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v100" version="3.7.10" targetFramework="Native" />
-  <package id="zeroc.ice.v120" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp98/Ice/plugin/msbuild/server/packages.config
+++ b/cpp98/Ice/plugin/msbuild/server/packages.config
@@ -1,9 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v100" version="3.7.10" targetFramework="Native" />
-  <package id="zeroc.ice.v120" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp98/Ice/plugin/msbuild/server/server.vcxproj
+++ b/cpp98/Ice/plugin/msbuild/server/server.vcxproj
@@ -1,12 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -30,9 +26,6 @@
     <ProjectGuid>{0DD23FDB-1BF9-4591-B096-43D925841E9E}</ProjectGuid>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup>
-    <DefaultPlatformToolset Condition="'$(VisualStudioVersion)' == '10.0' And  '$(DefaultPlatformToolset)' == ''">v100</DefaultPlatformToolset>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
@@ -60,10 +53,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -214,14 +203,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp98/Ice/properties/msbuild/client/client.vcxproj
+++ b/cpp98/Ice/properties/msbuild/client/client.vcxproj
@@ -1,12 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -30,9 +26,6 @@
     <ProjectGuid>{51FCF834-E154-445B-9911-1E9F769EABEC}</ProjectGuid>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup>
-    <DefaultPlatformToolset Condition="'$(VisualStudioVersion)' == '10.0' And  '$(DefaultPlatformToolset)' == ''">v100</DefaultPlatformToolset>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
@@ -62,10 +55,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -259,14 +248,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp98/Ice/properties/msbuild/client/packages.config
+++ b/cpp98/Ice/properties/msbuild/client/packages.config
@@ -1,9 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v100" version="3.7.10" targetFramework="Native" />
-  <package id="zeroc.ice.v120" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp98/Ice/properties/msbuild/server/packages.config
+++ b/cpp98/Ice/properties/msbuild/server/packages.config
@@ -1,9 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v100" version="3.7.10" targetFramework="Native" />
-  <package id="zeroc.ice.v120" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp98/Ice/properties/msbuild/server/server.vcxproj
+++ b/cpp98/Ice/properties/msbuild/server/server.vcxproj
@@ -1,12 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -30,9 +26,6 @@
     <ProjectGuid>{C6F1C2A3-9817-4021-97D0-1D3FA9E95EA3}</ProjectGuid>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup>
-    <DefaultPlatformToolset Condition="'$(VisualStudioVersion)' == '10.0' And  '$(DefaultPlatformToolset)' == ''">v100</DefaultPlatformToolset>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
@@ -62,10 +55,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -259,14 +248,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp98/Ice/session/msbuild/client/client.vcxproj
+++ b/cpp98/Ice/session/msbuild/client/client.vcxproj
@@ -1,12 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -30,9 +26,6 @@
     <ProjectGuid>{AE22F05C-FA79-41C2-AD9F-010E176765A3}</ProjectGuid>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup>
-    <DefaultPlatformToolset Condition="'$(VisualStudioVersion)' == '10.0' And  '$(DefaultPlatformToolset)' == ''">v100</DefaultPlatformToolset>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
@@ -62,10 +55,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -259,14 +248,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp98/Ice/session/msbuild/client/packages.config
+++ b/cpp98/Ice/session/msbuild/client/packages.config
@@ -1,9 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v100" version="3.7.10" targetFramework="Native" />
-  <package id="zeroc.ice.v120" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp98/Ice/session/msbuild/server/packages.config
+++ b/cpp98/Ice/session/msbuild/server/packages.config
@@ -1,9 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v100" version="3.7.10" targetFramework="Native" />
-  <package id="zeroc.ice.v120" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp98/Ice/session/msbuild/server/server.vcxproj
+++ b/cpp98/Ice/session/msbuild/server/server.vcxproj
@@ -1,12 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -30,9 +26,6 @@
     <ProjectGuid>{DAA11E89-289F-4812-A662-84048AB7973A}</ProjectGuid>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup>
-    <DefaultPlatformToolset Condition="'$(VisualStudioVersion)' == '10.0' And  '$(DefaultPlatformToolset)' == ''">v100</DefaultPlatformToolset>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
@@ -62,10 +55,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -263,14 +252,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp98/Ice/throughput/msbuild/client/client.vcxproj
+++ b/cpp98/Ice/throughput/msbuild/client/client.vcxproj
@@ -1,12 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -31,9 +27,6 @@
     <RootNamespace>Ice.throughput.client</RootNamespace>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup>
-    <DefaultPlatformToolset Condition="'$(VisualStudioVersion)' == '10.0' And  '$(DefaultPlatformToolset)' == ''">v100</DefaultPlatformToolset>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
@@ -63,10 +56,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -256,14 +245,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp98/Ice/throughput/msbuild/client/packages.config
+++ b/cpp98/Ice/throughput/msbuild/client/packages.config
@@ -1,9 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v100" version="3.7.10" targetFramework="Native" />
-  <package id="zeroc.ice.v120" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp98/Ice/throughput/msbuild/server/packages.config
+++ b/cpp98/Ice/throughput/msbuild/server/packages.config
@@ -1,9 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v100" version="3.7.10" targetFramework="Native" />
-  <package id="zeroc.ice.v120" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp98/Ice/throughput/msbuild/server/server.vcxproj
+++ b/cpp98/Ice/throughput/msbuild/server/server.vcxproj
@@ -1,12 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -30,9 +26,6 @@
     <ProjectGuid>{383AB467-E29D-4A9D-A5D4-699E7A754A88}</ProjectGuid>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup>
-    <DefaultPlatformToolset Condition="'$(VisualStudioVersion)' == '10.0' And  '$(DefaultPlatformToolset)' == ''">v100</DefaultPlatformToolset>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
@@ -62,10 +55,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -257,14 +246,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp98/IceBox/hello/msbuild/client/client.vcxproj
+++ b/cpp98/IceBox/hello/msbuild/client/client.vcxproj
@@ -1,12 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -30,9 +26,6 @@
     <ProjectGuid>{C0A794BE-99CA-4AF8-B246-6A3510BEEF50}</ProjectGuid>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup>
-    <DefaultPlatformToolset Condition="'$(VisualStudioVersion)' == '10.0' And  '$(DefaultPlatformToolset)' == ''">v100</DefaultPlatformToolset>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
@@ -62,10 +55,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -259,14 +248,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp98/IceBox/hello/msbuild/client/packages.config
+++ b/cpp98/IceBox/hello/msbuild/client/packages.config
@@ -1,9 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v100" version="3.7.10" targetFramework="Native" />
-  <package id="zeroc.ice.v120" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp98/IceBox/hello/msbuild/server/packages.config
+++ b/cpp98/IceBox/hello/msbuild/server/packages.config
@@ -1,9 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v100" version="3.7.10" targetFramework="Native" />
-  <package id="zeroc.ice.v120" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp98/IceBox/hello/msbuild/server/server.vcxproj
+++ b/cpp98/IceBox/hello/msbuild/server/server.vcxproj
@@ -1,12 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -30,9 +26,6 @@
     <ProjectGuid>{9DA82A4E-9CE3-4788-AA4E-715FE7F1A03E}</ProjectGuid>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup>
-    <DefaultPlatformToolset Condition="'$(VisualStudioVersion)' == '10.0' And  '$(DefaultPlatformToolset)' == ''">v100</DefaultPlatformToolset>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
@@ -62,10 +55,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -287,14 +276,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp98/IceDiscovery/hello/msbuild/client/client.vcxproj
+++ b/cpp98/IceDiscovery/hello/msbuild/client/client.vcxproj
@@ -1,12 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -30,9 +26,6 @@
     <ProjectGuid>{6BF6F512-253C-4D18-A45C-EC93D12CA263}</ProjectGuid>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup>
-    <DefaultPlatformToolset Condition="'$(VisualStudioVersion)' == '10.0' And  '$(DefaultPlatformToolset)' == ''">v100</DefaultPlatformToolset>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
@@ -62,10 +55,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -259,14 +248,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp98/IceDiscovery/hello/msbuild/client/packages.config
+++ b/cpp98/IceDiscovery/hello/msbuild/client/packages.config
@@ -1,9 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v100" version="3.7.10" targetFramework="Native" />
-  <package id="zeroc.ice.v120" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp98/IceDiscovery/hello/msbuild/server/packages.config
+++ b/cpp98/IceDiscovery/hello/msbuild/server/packages.config
@@ -1,9 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v100" version="3.7.10" targetFramework="Native" />
-  <package id="zeroc.ice.v120" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp98/IceDiscovery/hello/msbuild/server/server.vcxproj
+++ b/cpp98/IceDiscovery/hello/msbuild/server/server.vcxproj
@@ -1,12 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -30,9 +26,6 @@
     <ProjectGuid>{863D903A-41F8-4758-AC73-865334FF3C5F}</ProjectGuid>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup>
-    <DefaultPlatformToolset Condition="'$(VisualStudioVersion)' == '10.0' And  '$(DefaultPlatformToolset)' == ''">v100</DefaultPlatformToolset>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
@@ -62,10 +55,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -261,14 +250,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp98/IceDiscovery/replication/msbuild/client/client.vcxproj
+++ b/cpp98/IceDiscovery/replication/msbuild/client/client.vcxproj
@@ -1,12 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -30,9 +26,6 @@
     <ProjectGuid>{6B90B8B3-2714-437F-BB4A-39D8B2206214}</ProjectGuid>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup>
-    <DefaultPlatformToolset Condition="'$(VisualStudioVersion)' == '10.0' And  '$(DefaultPlatformToolset)' == ''">v100</DefaultPlatformToolset>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
@@ -62,10 +55,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -259,14 +248,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp98/IceDiscovery/replication/msbuild/client/packages.config
+++ b/cpp98/IceDiscovery/replication/msbuild/client/packages.config
@@ -1,9 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v100" version="3.7.10" targetFramework="Native" />
-  <package id="zeroc.ice.v120" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp98/IceDiscovery/replication/msbuild/server/packages.config
+++ b/cpp98/IceDiscovery/replication/msbuild/server/packages.config
@@ -1,9 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v100" version="3.7.10" targetFramework="Native" />
-  <package id="zeroc.ice.v120" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp98/IceDiscovery/replication/msbuild/server/server.vcxproj
+++ b/cpp98/IceDiscovery/replication/msbuild/server/server.vcxproj
@@ -1,12 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -30,9 +26,6 @@
     <ProjectGuid>{48DC4EB0-02FE-41CC-BE3F-00911817E777}</ProjectGuid>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup>
-    <DefaultPlatformToolset Condition="'$(VisualStudioVersion)' == '10.0' And  '$(DefaultPlatformToolset)' == ''">v100</DefaultPlatformToolset>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
@@ -62,10 +55,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -260,14 +249,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp98/IceGrid/allocate/msbuild/client/client.vcxproj
+++ b/cpp98/IceGrid/allocate/msbuild/client/client.vcxproj
@@ -1,12 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -30,9 +26,6 @@
     <ProjectGuid>{F926F833-BC03-4E8F-B0F2-E045DC139845}</ProjectGuid>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup>
-    <DefaultPlatformToolset Condition="'$(VisualStudioVersion)' == '10.0' And  '$(DefaultPlatformToolset)' == ''">v100</DefaultPlatformToolset>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
@@ -62,10 +55,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -259,14 +248,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp98/IceGrid/allocate/msbuild/client/packages.config
+++ b/cpp98/IceGrid/allocate/msbuild/client/packages.config
@@ -1,9 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v100" version="3.7.10" targetFramework="Native" />
-  <package id="zeroc.ice.v120" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp98/IceGrid/allocate/msbuild/server/packages.config
+++ b/cpp98/IceGrid/allocate/msbuild/server/packages.config
@@ -1,9 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v100" version="3.7.10" targetFramework="Native" />
-  <package id="zeroc.ice.v120" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp98/IceGrid/allocate/msbuild/server/server.vcxproj
+++ b/cpp98/IceGrid/allocate/msbuild/server/server.vcxproj
@@ -1,12 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -30,9 +26,6 @@
     <ProjectGuid>{A9DB3AF0-07A2-4B64-A8DE-5C18658BEA14}</ProjectGuid>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup>
-    <DefaultPlatformToolset Condition="'$(VisualStudioVersion)' == '10.0' And  '$(DefaultPlatformToolset)' == ''">v100</DefaultPlatformToolset>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
@@ -62,10 +55,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -263,14 +252,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp98/IceGrid/customLoadBalancing/msbuild/client/client.vcxproj
+++ b/cpp98/IceGrid/customLoadBalancing/msbuild/client/client.vcxproj
@@ -1,12 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -30,9 +26,6 @@
     <ProjectGuid>{D75BF0C7-D1AE-4E11-8E56-C176DD6B5EF9}</ProjectGuid>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup>
-    <DefaultPlatformToolset Condition="'$(VisualStudioVersion)' == '10.0' And  '$(DefaultPlatformToolset)' == ''">v100</DefaultPlatformToolset>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
@@ -62,10 +55,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -259,14 +248,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp98/IceGrid/customLoadBalancing/msbuild/client/packages.config
+++ b/cpp98/IceGrid/customLoadBalancing/msbuild/client/packages.config
@@ -1,9 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v100" version="3.7.10" targetFramework="Native" />
-  <package id="zeroc.ice.v120" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp98/IceGrid/customLoadBalancing/msbuild/plugin/packages.config
+++ b/cpp98/IceGrid/customLoadBalancing/msbuild/plugin/packages.config
@@ -1,9 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v100" version="3.7.10" targetFramework="Native" />
-  <package id="zeroc.ice.v120" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp98/IceGrid/customLoadBalancing/msbuild/plugin/plugin.vcxproj
+++ b/cpp98/IceGrid/customLoadBalancing/msbuild/plugin/plugin.vcxproj
@@ -1,12 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -30,9 +26,6 @@
     <ProjectGuid>{57F470E1-3D19-4BAF-8E74-6AFE2AEF1328}</ProjectGuid>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup>
-    <DefaultPlatformToolset Condition="'$(VisualStudioVersion)' == '10.0' And  '$(DefaultPlatformToolset)' == ''">v100</DefaultPlatformToolset>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
@@ -62,10 +55,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -225,14 +214,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp98/IceGrid/customLoadBalancing/msbuild/server/packages.config
+++ b/cpp98/IceGrid/customLoadBalancing/msbuild/server/packages.config
@@ -1,9 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v100" version="3.7.10" targetFramework="Native" />
-  <package id="zeroc.ice.v120" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp98/IceGrid/customLoadBalancing/msbuild/server/server.vcxproj
+++ b/cpp98/IceGrid/customLoadBalancing/msbuild/server/server.vcxproj
@@ -1,12 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -30,9 +26,6 @@
     <ProjectGuid>{5E88E194-E900-4C61-A1F4-27F158E6D43A}</ProjectGuid>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup>
-    <DefaultPlatformToolset Condition="'$(VisualStudioVersion)' == '10.0' And  '$(DefaultPlatformToolset)' == ''">v100</DefaultPlatformToolset>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
@@ -62,10 +55,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -262,14 +251,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp98/IceGrid/customLocator/msbuild/client/client.vcxproj
+++ b/cpp98/IceGrid/customLocator/msbuild/client/client.vcxproj
@@ -1,12 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -30,9 +26,6 @@
     <ProjectGuid>{1EC976DD-DCCA-4C18-8D97-88B3C583CF58}</ProjectGuid>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup>
-    <DefaultPlatformToolset Condition="'$(VisualStudioVersion)' == '10.0' And  '$(DefaultPlatformToolset)' == ''">v100</DefaultPlatformToolset>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
@@ -62,10 +55,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -259,14 +248,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp98/IceGrid/customLocator/msbuild/client/packages.config
+++ b/cpp98/IceGrid/customLocator/msbuild/client/packages.config
@@ -1,9 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v100" version="3.7.10" targetFramework="Native" />
-  <package id="zeroc.ice.v120" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp98/IceGrid/customLocator/msbuild/locator/locator.vcxproj
+++ b/cpp98/IceGrid/customLocator/msbuild/locator/locator.vcxproj
@@ -1,12 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -31,9 +27,6 @@
     <RootNamespace>IceGrid.customLocator.locator</RootNamespace>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup>
-    <DefaultPlatformToolset Condition="'$(VisualStudioVersion)' == '10.0' And  '$(DefaultPlatformToolset)' == ''">v100</DefaultPlatformToolset>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
@@ -63,10 +56,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -207,14 +196,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp98/IceGrid/customLocator/msbuild/locator/packages.config
+++ b/cpp98/IceGrid/customLocator/msbuild/locator/packages.config
@@ -1,9 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v100" version="3.7.10" targetFramework="Native" />
-  <package id="zeroc.ice.v120" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp98/IceGrid/customLocator/msbuild/server/packages.config
+++ b/cpp98/IceGrid/customLocator/msbuild/server/packages.config
@@ -1,9 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v100" version="3.7.10" targetFramework="Native" />
-  <package id="zeroc.ice.v120" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp98/IceGrid/customLocator/msbuild/server/server.vcxproj
+++ b/cpp98/IceGrid/customLocator/msbuild/server/server.vcxproj
@@ -1,12 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -30,9 +26,6 @@
     <ProjectGuid>{4FA4CD54-05.0.6279-BB1B-A75CEB1E0D1C}</ProjectGuid>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup>
-    <DefaultPlatformToolset Condition="'$(VisualStudioVersion)' == '10.0' And  '$(DefaultPlatformToolset)' == ''">v100</DefaultPlatformToolset>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
@@ -62,10 +55,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -262,14 +251,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp98/IceGrid/icebox/msbuild/client/client.vcxproj
+++ b/cpp98/IceGrid/icebox/msbuild/client/client.vcxproj
@@ -1,12 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -30,9 +26,6 @@
     <ProjectGuid>{278DFA7E-A0A1-4D4C-ACD7-904D99CA8DA1}</ProjectGuid>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup>
-    <DefaultPlatformToolset Condition="'$(VisualStudioVersion)' == '10.0' And  '$(DefaultPlatformToolset)' == ''">v100</DefaultPlatformToolset>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
@@ -62,10 +55,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -259,14 +248,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp98/IceGrid/icebox/msbuild/client/packages.config
+++ b/cpp98/IceGrid/icebox/msbuild/client/packages.config
@@ -1,9 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v100" version="3.7.10" targetFramework="Native" />
-  <package id="zeroc.ice.v120" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp98/IceGrid/icebox/msbuild/server/packages.config
+++ b/cpp98/IceGrid/icebox/msbuild/server/packages.config
@@ -1,9 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v100" version="3.7.10" targetFramework="Native" />
-  <package id="zeroc.ice.v120" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp98/IceGrid/icebox/msbuild/server/server.vcxproj
+++ b/cpp98/IceGrid/icebox/msbuild/server/server.vcxproj
@@ -1,12 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -30,9 +26,6 @@
     <ProjectGuid>{6AD12991-A01E-4464-BC84-F5749F749157}</ProjectGuid>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup>
-    <DefaultPlatformToolset Condition="'$(VisualStudioVersion)' == '10.0' And  '$(DefaultPlatformToolset)' == ''">v100</DefaultPlatformToolset>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
@@ -62,10 +55,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -286,14 +275,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp98/IceGrid/replication/msbuild/client/client.vcxproj
+++ b/cpp98/IceGrid/replication/msbuild/client/client.vcxproj
@@ -1,12 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -30,9 +26,6 @@
     <ProjectGuid>{DBDF5E2D-6F91-406B-819F-661F76856A60}</ProjectGuid>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup>
-    <DefaultPlatformToolset Condition="'$(VisualStudioVersion)' == '10.0' And  '$(DefaultPlatformToolset)' == ''">v100</DefaultPlatformToolset>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
@@ -62,10 +55,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -259,14 +248,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp98/IceGrid/replication/msbuild/client/packages.config
+++ b/cpp98/IceGrid/replication/msbuild/client/packages.config
@@ -1,9 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v100" version="3.7.10" targetFramework="Native" />
-  <package id="zeroc.ice.v120" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp98/IceGrid/replication/msbuild/server/packages.config
+++ b/cpp98/IceGrid/replication/msbuild/server/packages.config
@@ -1,9 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v100" version="3.7.10" targetFramework="Native" />
-  <package id="zeroc.ice.v120" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp98/IceGrid/replication/msbuild/server/server.vcxproj
+++ b/cpp98/IceGrid/replication/msbuild/server/server.vcxproj
@@ -1,12 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -30,9 +26,6 @@
     <ProjectGuid>{60BF2E43-C238-4E77-A80F-37AA9F450727}</ProjectGuid>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup>
-    <DefaultPlatformToolset Condition="'$(VisualStudioVersion)' == '10.0' And  '$(DefaultPlatformToolset)' == ''">v100</DefaultPlatformToolset>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
@@ -62,10 +55,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -270,14 +259,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp98/IceGrid/secure/msbuild/client/client.vcxproj
+++ b/cpp98/IceGrid/secure/msbuild/client/client.vcxproj
@@ -1,12 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -30,9 +26,6 @@
     <ProjectGuid>{93D3D06E-656E-4EA2-BC49-DE90E9B3DBEC}</ProjectGuid>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup>
-    <DefaultPlatformToolset Condition="'$(VisualStudioVersion)' == '10.0' And  '$(DefaultPlatformToolset)' == ''">v100</DefaultPlatformToolset>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
@@ -62,10 +55,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -259,14 +248,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp98/IceGrid/secure/msbuild/client/packages.config
+++ b/cpp98/IceGrid/secure/msbuild/client/packages.config
@@ -1,9 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v100" version="3.7.10" targetFramework="Native" />
-  <package id="zeroc.ice.v120" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp98/IceGrid/secure/msbuild/server/packages.config
+++ b/cpp98/IceGrid/secure/msbuild/server/packages.config
@@ -1,9 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v100" version="3.7.10" targetFramework="Native" />
-  <package id="zeroc.ice.v120" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp98/IceGrid/secure/msbuild/server/server.vcxproj
+++ b/cpp98/IceGrid/secure/msbuild/server/server.vcxproj
@@ -1,12 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -30,9 +26,6 @@
     <ProjectGuid>{6E2F9FA0-E6A6-44DC-8747-3CC7595A6D4E}</ProjectGuid>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup>
-    <DefaultPlatformToolset Condition="'$(VisualStudioVersion)' == '10.0' And  '$(DefaultPlatformToolset)' == ''">v100</DefaultPlatformToolset>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
@@ -62,10 +55,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -266,14 +255,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp98/IceGrid/sessionActivation/msbuild/client/client.vcxproj
+++ b/cpp98/IceGrid/sessionActivation/msbuild/client/client.vcxproj
@@ -1,12 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -30,9 +26,6 @@
     <ProjectGuid>{0F6EA526-A020-4E60-82A2-5B934878D05E}</ProjectGuid>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup>
-    <DefaultPlatformToolset Condition="'$(VisualStudioVersion)' == '10.0' And  '$(DefaultPlatformToolset)' == ''">v100</DefaultPlatformToolset>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
@@ -62,10 +55,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -259,14 +248,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp98/IceGrid/sessionActivation/msbuild/client/packages.config
+++ b/cpp98/IceGrid/sessionActivation/msbuild/client/packages.config
@@ -1,9 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v100" version="3.7.10" targetFramework="Native" />
-  <package id="zeroc.ice.v120" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp98/IceGrid/sessionActivation/msbuild/server/packages.config
+++ b/cpp98/IceGrid/sessionActivation/msbuild/server/packages.config
@@ -1,9 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v100" version="3.7.10" targetFramework="Native" />
-  <package id="zeroc.ice.v120" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp98/IceGrid/sessionActivation/msbuild/server/server.vcxproj
+++ b/cpp98/IceGrid/sessionActivation/msbuild/server/server.vcxproj
@@ -1,12 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -30,9 +26,6 @@
     <ProjectGuid>{C4769D24-8A92-4E7F-92CC-96F07043D944}</ProjectGuid>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup>
-    <DefaultPlatformToolset Condition="'$(VisualStudioVersion)' == '10.0' And  '$(DefaultPlatformToolset)' == ''">v100</DefaultPlatformToolset>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
@@ -62,10 +55,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -262,14 +251,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp98/IceGrid/simple/msbuild/client/client.vcxproj
+++ b/cpp98/IceGrid/simple/msbuild/client/client.vcxproj
@@ -1,12 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -30,9 +26,6 @@
     <ProjectGuid>{215AD5AB-C9A9-4109-8704-53E8F3289B5E}</ProjectGuid>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup>
-    <DefaultPlatformToolset Condition="'$(VisualStudioVersion)' == '10.0' And  '$(DefaultPlatformToolset)' == ''">v100</DefaultPlatformToolset>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
@@ -61,10 +54,6 @@
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -258,14 +247,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp98/IceGrid/simple/msbuild/client/packages.config
+++ b/cpp98/IceGrid/simple/msbuild/client/packages.config
@@ -1,9 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v100" version="3.7.10" targetFramework="Native" />
-  <package id="zeroc.ice.v120" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp98/IceGrid/simple/msbuild/server/packages.config
+++ b/cpp98/IceGrid/simple/msbuild/server/packages.config
@@ -1,9 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v100" version="3.7.10" targetFramework="Native" />
-  <package id="zeroc.ice.v120" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp98/IceGrid/simple/msbuild/server/server.vcxproj
+++ b/cpp98/IceGrid/simple/msbuild/server/server.vcxproj
@@ -1,12 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -30,9 +26,6 @@
     <ProjectGuid>{D0040308-23C7-4BED-B2C7-09414A6FAD28}</ProjectGuid>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup>
-    <DefaultPlatformToolset Condition="'$(VisualStudioVersion)' == '10.0' And  '$(DefaultPlatformToolset)' == ''">v100</DefaultPlatformToolset>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
@@ -61,10 +54,6 @@
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -263,14 +252,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp98/IceStorm/clock/msbuild/publisher/packages.config
+++ b/cpp98/IceStorm/clock/msbuild/publisher/packages.config
@@ -1,9 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v100" version="3.7.10" targetFramework="Native" />
-  <package id="zeroc.ice.v120" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp98/IceStorm/clock/msbuild/publisher/publisher.vcxproj
+++ b/cpp98/IceStorm/clock/msbuild/publisher/publisher.vcxproj
@@ -1,12 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -30,9 +26,6 @@
     <ProjectGuid>{01BF79D2-B6A8-4E93-9BB9-8C2D1F1779F6}</ProjectGuid>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup>
-    <DefaultPlatformToolset Condition="'$(VisualStudioVersion)' == '10.0' And  '$(DefaultPlatformToolset)' == ''">v100</DefaultPlatformToolset>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
@@ -62,10 +55,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -261,14 +250,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp98/IceStorm/clock/msbuild/subscriber/packages.config
+++ b/cpp98/IceStorm/clock/msbuild/subscriber/packages.config
@@ -1,9 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v100" version="3.7.10" targetFramework="Native" />
-  <package id="zeroc.ice.v120" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp98/IceStorm/clock/msbuild/subscriber/subscriber.vcxproj
+++ b/cpp98/IceStorm/clock/msbuild/subscriber/subscriber.vcxproj
@@ -1,12 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -30,9 +26,6 @@
     <ProjectGuid>{16C50485-2400-4C80-B564-ACEB6BFBD845}</ProjectGuid>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup>
-    <DefaultPlatformToolset Condition="'$(VisualStudioVersion)' == '10.0' And  '$(DefaultPlatformToolset)' == ''">v100</DefaultPlatformToolset>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
@@ -62,10 +55,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -261,14 +250,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp98/IceStorm/counter/msbuild/client/client.vcxproj.vcxproj
+++ b/cpp98/IceStorm/counter/msbuild/client/client.vcxproj.vcxproj
@@ -1,12 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -30,9 +26,6 @@
     <ProjectGuid>{79AD1EE6-DFD3-41BB-8CDD-73675F86BC72}</ProjectGuid>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup>
-    <DefaultPlatformToolset Condition="'$(VisualStudioVersion)' == '10.0' And  '$(DefaultPlatformToolset)' == ''">v100</DefaultPlatformToolset>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
@@ -62,10 +55,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -261,14 +250,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp98/IceStorm/counter/msbuild/client/packages.config
+++ b/cpp98/IceStorm/counter/msbuild/client/packages.config
@@ -1,9 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v100" version="3.7.10" targetFramework="Native" />
-  <package id="zeroc.ice.v120" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp98/IceStorm/counter/msbuild/server/packages.config
+++ b/cpp98/IceStorm/counter/msbuild/server/packages.config
@@ -1,9 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v100" version="3.7.10" targetFramework="Native" />
-  <package id="zeroc.ice.v120" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp98/IceStorm/counter/msbuild/server/server.vcxproj
+++ b/cpp98/IceStorm/counter/msbuild/server/server.vcxproj
@@ -1,12 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -30,9 +26,6 @@
     <ProjectGuid>{41635ABC-8CC9-431F-951A-9EA13288DB2D}</ProjectGuid>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup>
-    <DefaultPlatformToolset Condition="'$(VisualStudioVersion)' == '10.0' And  '$(DefaultPlatformToolset)' == ''">v100</DefaultPlatformToolset>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
@@ -62,10 +55,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -266,14 +255,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp98/IceStorm/replicated/msbuild/publisher/packages.config
+++ b/cpp98/IceStorm/replicated/msbuild/publisher/packages.config
@@ -1,9 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v100" version="3.7.10" targetFramework="Native" />
-  <package id="zeroc.ice.v120" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp98/IceStorm/replicated/msbuild/publisher/publisher.vcxproj
+++ b/cpp98/IceStorm/replicated/msbuild/publisher/publisher.vcxproj
@@ -1,12 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -30,9 +26,6 @@
     <ProjectGuid>{1357A2FF-3D5E-41EF-8EE7-3E5CEA51464D}</ProjectGuid>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup>
-    <DefaultPlatformToolset Condition="'$(VisualStudioVersion)' == '10.0' And  '$(DefaultPlatformToolset)' == ''">v100</DefaultPlatformToolset>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
@@ -62,10 +55,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -261,14 +250,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp98/IceStorm/replicated/msbuild/subscriber/packages.config
+++ b/cpp98/IceStorm/replicated/msbuild/subscriber/packages.config
@@ -1,9 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v100" version="3.7.10" targetFramework="Native" />
-  <package id="zeroc.ice.v120" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp98/IceStorm/replicated/msbuild/subscriber/subscriber.vcxproj
+++ b/cpp98/IceStorm/replicated/msbuild/subscriber/subscriber.vcxproj
@@ -1,12 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -30,9 +26,6 @@
     <ProjectGuid>{780D8169-71C8-48C3-8123-02A9DA1A94BC}</ProjectGuid>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup>
-    <DefaultPlatformToolset Condition="'$(VisualStudioVersion)' == '10.0' And  '$(DefaultPlatformToolset)' == ''">v100</DefaultPlatformToolset>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
@@ -62,10 +55,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -265,14 +254,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp98/IceStorm/replicated2/msbuild/publisher/packages.config
+++ b/cpp98/IceStorm/replicated2/msbuild/publisher/packages.config
@@ -1,9 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v100" version="3.7.10" targetFramework="Native" />
-  <package id="zeroc.ice.v120" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp98/IceStorm/replicated2/msbuild/publisher/publisher.vcxproj
+++ b/cpp98/IceStorm/replicated2/msbuild/publisher/publisher.vcxproj
@@ -1,12 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -30,9 +26,6 @@
     <ProjectGuid>{779FDD55-DA02-454C-A3EE-F222337CC27D}</ProjectGuid>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup>
-    <DefaultPlatformToolset Condition="'$(VisualStudioVersion)' == '10.0' And  '$(DefaultPlatformToolset)' == ''">v100</DefaultPlatformToolset>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
@@ -62,10 +55,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -265,14 +254,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp98/IceStorm/replicated2/msbuild/subscriber/packages.config
+++ b/cpp98/IceStorm/replicated2/msbuild/subscriber/packages.config
@@ -1,9 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v100" version="3.7.10" targetFramework="Native" />
-  <package id="zeroc.ice.v120" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp98/IceStorm/replicated2/msbuild/subscriber/subscriber.vcxproj
+++ b/cpp98/IceStorm/replicated2/msbuild/subscriber/subscriber.vcxproj
@@ -1,12 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -30,9 +26,6 @@
     <ProjectGuid>{5C1184D4-7B2F-4366-82AA-11F7B4AD2FA7}</ProjectGuid>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup>
-    <DefaultPlatformToolset Condition="'$(VisualStudioVersion)' == '10.0' And  '$(DefaultPlatformToolset)' == ''">v100</DefaultPlatformToolset>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
@@ -62,10 +55,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -265,14 +254,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp98/Manual/printer/msbuild/client/client.vcxproj
+++ b/cpp98/Manual/printer/msbuild/client/client.vcxproj
@@ -1,12 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -30,9 +26,6 @@
     <ProjectGuid>{4CCAF112-F152-422A-91BE-27C72F638092}</ProjectGuid>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup>
-    <DefaultPlatformToolset Condition="'$(VisualStudioVersion)' == '10.0' And  '$(DefaultPlatformToolset)' == ''">v100</DefaultPlatformToolset>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
@@ -62,10 +55,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -258,14 +247,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp98/Manual/printer/msbuild/client/packages.config
+++ b/cpp98/Manual/printer/msbuild/client/packages.config
@@ -1,9 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v100" version="3.7.10" targetFramework="Native" />
-  <package id="zeroc.ice.v120" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp98/Manual/printer/msbuild/server/packages.config
+++ b/cpp98/Manual/printer/msbuild/server/packages.config
@@ -1,9 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v100" version="3.7.10" targetFramework="Native" />
-  <package id="zeroc.ice.v120" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp98/Manual/printer/msbuild/server/server.vcxproj
+++ b/cpp98/Manual/printer/msbuild/server/server.vcxproj
@@ -1,12 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -30,9 +26,6 @@
     <ProjectGuid>{131C5C24-50C3-4AD6-A8D3-C57CEC50AFB9}</ProjectGuid>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup>
-    <DefaultPlatformToolset Condition="'$(VisualStudioVersion)' == '10.0' And  '$(DefaultPlatformToolset)' == ''">v100</DefaultPlatformToolset>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
@@ -63,10 +56,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -260,14 +249,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp98/Manual/simpleFilesystem/msbuild/client/client.vcxproj
+++ b/cpp98/Manual/simpleFilesystem/msbuild/client/client.vcxproj
@@ -1,12 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -30,9 +26,6 @@
     <ProjectGuid>{4B2FC587-BB5D-4B19-85E0-56E7C7636294}</ProjectGuid>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup>
-    <DefaultPlatformToolset Condition="'$(VisualStudioVersion)' == '10.0' And  '$(DefaultPlatformToolset)' == ''">v100</DefaultPlatformToolset>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
@@ -63,10 +56,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -259,14 +248,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp98/Manual/simpleFilesystem/msbuild/client/packages.config
+++ b/cpp98/Manual/simpleFilesystem/msbuild/client/packages.config
@@ -1,9 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v100" version="3.7.10" targetFramework="Native" />
-  <package id="zeroc.ice.v120" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp98/Manual/simpleFilesystem/msbuild/server/packages.config
+++ b/cpp98/Manual/simpleFilesystem/msbuild/server/packages.config
@@ -1,9 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v100" version="3.7.10" targetFramework="Native" />
-  <package id="zeroc.ice.v120" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v140" version="3.7.10" targetFramework="native" />
-  <package id="zeroc.ice.v141" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v142" version="3.7.10" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.10" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />

--- a/cpp98/Manual/simpleFilesystem/msbuild/server/server.vcxproj
+++ b/cpp98/Manual/simpleFilesystem/msbuild/server/server.vcxproj
@@ -1,12 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" />
-  <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -30,9 +26,6 @@
     <ProjectGuid>{EFCFF55E-CCD2-451E-A0B5-604249ECE4D1}</ProjectGuid>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup>
-    <DefaultPlatformToolset Condition="'$(VisualStudioVersion)' == '10.0' And  '$(DefaultPlatformToolset)' == ''">v100</DefaultPlatformToolset>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
@@ -63,10 +56,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\common.props')" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" />
-    <Import Project="..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
@@ -261,14 +250,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v120.3.7.10\build\native\zeroc.ice.v120.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v140.3.7.10\build\native\zeroc.ice.v140.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v141.3.7.10\build\native\zeroc.ice.v141.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v100.3.7.10\build\native\zeroc.ice.v100.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v142.3.7.10\build\native\zeroc.ice.v142.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\zeroc.ice.v143.3.7.10\build\native\zeroc.ice.v143.props'))" />

--- a/cpp98/README.md
+++ b/cpp98/README.md
@@ -136,7 +136,7 @@ If you are building Debug, add both the Debug and Release `bin` directories with
 command similar to:
 
 ```shell
-set PATH=%USERPROFILE%\ice-demos\cpp98\packages\zeroc.ice.v140.3.7.10\build\native\bin\x64\Debug;%USERPROFILE%\ice-demos\cpp98\packages\zeroc.ice.v140.3.7.10\build\native\bin\x64\Release;%PATH%
+set PATH=%USERPROFILE%\ice-demos\cpp98\packages\zeroc.ice.v143.3.7.10\build\native\bin\x64\Debug;%USERPROFILE%\ice-demos\cpp98\packages\zeroc.ice.v143.3.7.10\build\native\bin\x64\Release;%PATH%
 ```
 
 This is required because the Debug `bin` directories provide only a subset of all
@@ -146,7 +146,7 @@ If you are building Release, you should add only the Release `bin` directory to
 your PATH with a command similar to:
 
 ```shell
-set PATH=%USERPROFILE%\ice-demos\cpp98\packages\zeroc.ice.v140.3.7.10\build\native\bin\x64\Release;%PATH%
+set PATH=%USERPROFILE%\ice-demos\cpp98\packages\zeroc.ice.v143.3.7.10\build\native\bin\x64\Release;%PATH%
 ```
 
 Then refer to the README.md file in each demo directory for usage instructions.


### PR DESCRIPTION
This PR updates C++ `.vcxproj` project files to not reference the C++ NuGet packages removed in the upcoming 3.7.11

We just keep v142 (Visual Studio 2019), and v143 (Visual Studio 2022 or greater).