### PR TITLE
Remove DebugFastLink (VS2026 support)

### DIFF
--- a/cpp11/msbuild/common.props
+++ b/cpp11/msbuild/common.props
@@ -6,14 +6,6 @@
     </ClCompile>
   </ItemDefinitionGroup>
 
-  <!-- Switch on DEBUG:fastlink -->
-  <ItemDefinitionGroup>
-    <Link>
-      <FullProgramDatabaseFile>false</FullProgramDatabaseFile>
-      <GenerateDebugInformation>DebugFastLink</GenerateDebugInformation>
-    </Link>
-  </ItemDefinitionGroup>
-
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
     <Link>
       <OptimizeReferences>true</OptimizeReferences>

--- a/cpp98/msbuild/common.props
+++ b/cpp98/msbuild/common.props
@@ -6,22 +6,6 @@
     </ClCompile>
   </ItemDefinitionGroup>
 
-  <!--
-      The correct value for GenerateDebugInformation depends on the compiler:
-  -->
-  <ItemDefinitionGroup>
-    <Link>
-      <GenerateDebugInformation>Yes</GenerateDebugInformation>
-    </Link>
-  </ItemDefinitionGroup>
-
-  <ItemDefinitionGroup Condition="'$(DefaultPlatformToolset)'=='v140' or '$(DefaultPlatformToolset)'=='v141' or '$(DefaultPlatformToolset)'=='v142' or '$(DefaultPlatformToolset)'=='v143'">
-    <Link>
-      <FullProgramDatabaseFile>false</FullProgramDatabaseFile>
-      <GenerateDebugInformation>DebugFastLink</GenerateDebugInformation>
-    </Link>
-  </ItemDefinitionGroup>
-
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
     <Link>
       <OptimizeReferences>true</OptimizeReferences>


### PR DESCRIPTION
VS2026 no longer supports DebugFastLink and we were getting a warning.

See https://learn.microsoft.com/en-us/cpp/build/reference/debug-generate-debug-info?view=msvc-170