### PR TITLE
Pin GitHub Actions to commit SHAs and extend Dependabot to the 3.8 and 3.7 branches

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -5,6 +5,6 @@ runs:
   using: "composite"
   steps:
     - name: Setup Node.js
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: "22.x"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: weekly
+      interval: monthly
     cooldown:
       default-days: 7
     groups:
@@ -82,6 +82,112 @@ updates:
   - package-ecosystem: "swift"
     directories:
       - "/swift/**"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+      semver-minor-days: 14
+      semver-patch-days: 7
+    groups:
+      swift-minor-and-patch:
+        update-types: ["minor", "patch"]
+      swift-major:
+        update-types: ["major"]
+
+  # The blocks below mirror the ones above with target-branch: "3.8" so
+  # Dependabot also opens version-update PRs against the 3.8 release branch.
+  # (Dependabot reads this config from the default branch only; security
+  # updates always target the default branch and cannot be pointed at 3.8.)
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: "3.8"
+    schedule:
+      interval: monthly
+    cooldown:
+      default-days: 7
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "npm"
+    directories:
+      - "/js/**"
+    target-branch: "3.8"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+      semver-minor-days: 14
+      semver-patch-days: 7
+    groups:
+      js-minor-and-patch:
+        update-types: ["minor", "patch"]
+      js-major:
+        update-types: ["major"]
+
+  - package-ecosystem: "pip"
+    directories:
+      - "/python/**"
+    target-branch: "3.8"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+      semver-minor-days: 14
+      semver-patch-days: 7
+    groups:
+      python-minor-and-patch:
+        update-types: ["minor", "patch"]
+      python-major:
+        update-types: ["major"]
+
+  - package-ecosystem: "gradle"
+    directories:
+      - "/java/**"
+    target-branch: "3.8"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+      semver-minor-days: 14
+      semver-patch-days: 7
+    groups:
+      java-minor-and-patch:
+        update-types: ["minor", "patch"]
+      java-major:
+        update-types: ["major"]
+
+  - package-ecosystem: "nuget"
+    directories:
+      - "/csharp/**"
+    target-branch: "3.8"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+      semver-minor-days: 14
+      semver-patch-days: 7
+    groups:
+      dotnet-minor-and-patch:
+        update-types: ["minor", "patch"]
+      dotnet-major:
+        update-types: ["major"]
+
+  - package-ecosystem: "swift"
+    directories:
+      - "/swift/**"
+    target-branch: "3.8"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 3

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,9 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
+    # Two entries are required: "/" is the special value that scans
+    # .github/workflows (plus any root action.yml); "/.github/actions/*"
+    # covers the composite actions, which each have their own action.yml.
     directories:
       - "/"
       - "/.github/actions/*"
@@ -83,6 +86,9 @@ updates:
   # reads this config from the default branch only, and security updates always
   # target the default branch (they cannot be pointed at 3.8).
   - package-ecosystem: "github-actions"
+    # Two entries are required: "/" is the special value that scans
+    # .github/workflows (plus any root action.yml); "/.github/actions/*"
+    # covers the composite actions, which each have their own action.yml.
     directories:
       - "/"
       - "/.github/actions/*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,13 +17,9 @@ updates:
     directories:
       - "/js/**"
     schedule:
-      interval: "monthly"
-    open-pull-requests-limit: 5
+      interval: monthly
     cooldown:
       default-days: 7
-      semver-major-days: 30
-      semver-minor-days: 14
-      semver-patch-days: 7
     groups:
       js-minor-and-patch:
         update-types: ["minor", "patch"]
@@ -34,13 +30,9 @@ updates:
     directories:
       - "/python/**"
     schedule:
-      interval: "monthly"
-    open-pull-requests-limit: 3
+      interval: monthly
     cooldown:
       default-days: 7
-      semver-major-days: 30
-      semver-minor-days: 14
-      semver-patch-days: 7
     groups:
       python-minor-and-patch:
         update-types: ["minor", "patch"]
@@ -51,13 +43,9 @@ updates:
     directories:
       - "/java/**"
     schedule:
-      interval: "monthly"
-    open-pull-requests-limit: 5
+      interval: monthly
     cooldown:
       default-days: 7
-      semver-major-days: 30
-      semver-minor-days: 14
-      semver-patch-days: 7
     groups:
       java-minor-and-patch:
         update-types: ["minor", "patch"]
@@ -68,13 +56,9 @@ updates:
     directories:
       - "/csharp/**"
     schedule:
-      interval: "monthly"
-    open-pull-requests-limit: 5
+      interval: monthly
     cooldown:
       default-days: 7
-      semver-major-days: 30
-      semver-minor-days: 14
-      semver-patch-days: 7
     groups:
       dotnet-minor-and-patch:
         update-types: ["minor", "patch"]
@@ -85,23 +69,19 @@ updates:
     directories:
       - "/swift/**"
     schedule:
-      interval: "monthly"
-    open-pull-requests-limit: 3
+      interval: monthly
     cooldown:
       default-days: 7
-      semver-major-days: 30
-      semver-minor-days: 14
-      semver-patch-days: 7
     groups:
       swift-minor-and-patch:
         update-types: ["minor", "patch"]
       swift-major:
         update-types: ["major"]
 
-  # The blocks below mirror the ones above with target-branch: "3.8" so
-  # Dependabot also opens version-update PRs against the 3.8 release branch.
-  # (Dependabot reads this config from the default branch only; security
-  # updates always target the default branch and cannot be pointed at 3.8.)
+  # The blocks below mirror the ones above with target-branch: "3.8". 3.8 is a
+  # stable release branch, so major version updates are ignored there. Dependabot
+  # reads this config from the default branch only, and security updates always
+  # target the default branch (they cannot be pointed at 3.8).
   - package-ecosystem: "github-actions"
     directories:
       - "/"
@@ -111,6 +91,9 @@ updates:
       interval: monthly
     cooldown:
       default-days: 7
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
     groups:
       github-actions:
         patterns:
@@ -121,87 +104,72 @@ updates:
       - "/js/**"
     target-branch: "3.8"
     schedule:
-      interval: "monthly"
-    open-pull-requests-limit: 5
+      interval: monthly
     cooldown:
       default-days: 7
-      semver-major-days: 30
-      semver-minor-days: 14
-      semver-patch-days: 7
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
     groups:
       js-minor-and-patch:
         update-types: ["minor", "patch"]
-      js-major:
-        update-types: ["major"]
 
   - package-ecosystem: "pip"
     directories:
       - "/python/**"
     target-branch: "3.8"
     schedule:
-      interval: "monthly"
-    open-pull-requests-limit: 3
+      interval: monthly
     cooldown:
       default-days: 7
-      semver-major-days: 30
-      semver-minor-days: 14
-      semver-patch-days: 7
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
     groups:
       python-minor-and-patch:
         update-types: ["minor", "patch"]
-      python-major:
-        update-types: ["major"]
 
   - package-ecosystem: "gradle"
     directories:
       - "/java/**"
     target-branch: "3.8"
     schedule:
-      interval: "monthly"
-    open-pull-requests-limit: 5
+      interval: monthly
     cooldown:
       default-days: 7
-      semver-major-days: 30
-      semver-minor-days: 14
-      semver-patch-days: 7
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
     groups:
       java-minor-and-patch:
         update-types: ["minor", "patch"]
-      java-major:
-        update-types: ["major"]
 
   - package-ecosystem: "nuget"
     directories:
       - "/csharp/**"
     target-branch: "3.8"
     schedule:
-      interval: "monthly"
-    open-pull-requests-limit: 5
+      interval: monthly
     cooldown:
       default-days: 7
-      semver-major-days: 30
-      semver-minor-days: 14
-      semver-patch-days: 7
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
     groups:
       dotnet-minor-and-patch:
         update-types: ["minor", "patch"]
-      dotnet-major:
-        update-types: ["major"]
 
   - package-ecosystem: "swift"
     directories:
       - "/swift/**"
     target-branch: "3.8"
     schedule:
-      interval: "monthly"
-    open-pull-requests-limit: 3
+      interval: monthly
     cooldown:
       default-days: 7
-      semver-major-days: 30
-      semver-minor-days: 14
-      semver-patch-days: 7
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
     groups:
       swift-minor-and-patch:
         update-types: ["minor", "patch"]
-      swift-major:
-        update-types: ["major"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -176,3 +176,21 @@ updates:
     groups:
       swift-minor-and-patch:
         update-types: ["minor", "patch"]
+
+  # 3.7 is in maintenance, so only its GitHub Actions are kept up to date.
+  - package-ecosystem: "github-actions"
+    # Two entries are required: "/" is the special value that scans
+    # .github/workflows (plus any root action.yml); "/.github/actions/*"
+    # covers the composite actions, which each have their own action.yml.
+    directories:
+      - "/"
+      - "/.github/actions/*"
+    target-branch: "3.7"
+    schedule:
+      interval: monthly
+    cooldown:
+      default-days: 7
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,7 +17,7 @@ updates:
     directories:
       - "/js/**"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     open-pull-requests-limit: 5
     cooldown:
       default-days: 7
@@ -34,7 +34,7 @@ updates:
     directories:
       - "/python/**"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     open-pull-requests-limit: 3
     cooldown:
       default-days: 7
@@ -51,7 +51,7 @@ updates:
     directories:
       - "/java/**"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     open-pull-requests-limit: 5
     cooldown:
       default-days: 7
@@ -68,7 +68,7 @@ updates:
     directories:
       - "/csharp/**"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     open-pull-requests-limit: 5
     cooldown:
       default-days: 7
@@ -85,7 +85,7 @@ updates:
     directories:
       - "/swift/**"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     open-pull-requests-limit: 3
     cooldown:
       default-days: 7
@@ -121,7 +121,7 @@ updates:
       - "/js/**"
     target-branch: "3.8"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     open-pull-requests-limit: 5
     cooldown:
       default-days: 7
@@ -139,7 +139,7 @@ updates:
       - "/python/**"
     target-branch: "3.8"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     open-pull-requests-limit: 3
     cooldown:
       default-days: 7
@@ -157,7 +157,7 @@ updates:
       - "/java/**"
     target-branch: "3.8"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     open-pull-requests-limit: 5
     cooldown:
       default-days: 7
@@ -175,7 +175,7 @@ updates:
       - "/csharp/**"
     target-branch: "3.8"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     open-pull-requests-limit: 5
     cooldown:
       default-days: 7
@@ -193,7 +193,7 @@ updates:
       - "/swift/**"
     target-branch: "3.8"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     open-pull-requests-limit: 3
     cooldown:
       default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -97,9 +97,6 @@ updates:
       interval: monthly
     cooldown:
       default-days: 7
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
     groups:
       github-actions:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,9 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/"
+      - "/.github/actions/*"
     schedule:
       interval: monthly
     cooldown:
@@ -101,7 +103,9 @@ updates:
   # (Dependabot reads this config from the default branch only; security
   # updates always target the default branch and cannot be pointed at 3.8.)
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/"
+      - "/.github/actions/*"
     target-branch: "3.8"
     schedule:
       interval: monthly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,10 +30,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup .NET 8
-        uses: actions/setup-dotnet@v5.3.0
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
         with:
           dotnet-version: 8.x
 
@@ -41,7 +41,7 @@ jobs:
         uses: ./.github/actions/setup-node
 
       - name: Setup Java
-        uses: actions/setup-java@v5.3.0
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
         with:
           distribution: "oracle"
           java-version: "17"
@@ -170,7 +170,7 @@ jobs:
         distro: [ubuntu24.04, ubuntu26.04, debian12, debian13, rocky9, rocky10, amzn2023]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Build Docker image
         run: |
@@ -199,10 +199,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Java
-        uses: actions/setup-java@v5.3.0
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
         with:
           distribution: "oracle"
           java-version: "17"

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install Clang Format
         run: |
@@ -44,7 +44,7 @@ jobs:
           clang-tidy-19 --version
 
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install Nightly Ice Builds
         uses: ./.github/actions/install-nightly-ice
@@ -66,7 +66,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       # Read .vscode/settings.json. Ensure each entry in cmake.sourceDirectory is valid.
       - name: Check .vscode/settings.json cmake.sourceDirectory entries

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Build dev containers
         run: |

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Run .NET format
         working-directory: csharp

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Java
-        uses: actions/setup-java@v5.3.0
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
         with:
           distribution: "oracle"
           java-version: "17"

--- a/.github/workflows/javascript.yml
+++ b/.github/workflows/javascript.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Node.js
         uses: ./.github/actions/setup-node

--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "lts/*"
 

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install Ruff
         run: pip install ruff
@@ -28,13 +28,13 @@ jobs:
     runs-on: macos-26
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install pyright
         run: npm install -g pyright
 
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
 
       - name: Run pyright on each demo
         run: |

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -18,7 +18,7 @@ jobs:
         - ${{ github.workspace }}:${{ github.workspace }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       # https://github.com/actions/runner/issues/2033
       - name: Set safe directory


### PR DESCRIPTION
Hardens the GitHub Actions supply chain and simplifies the Dependabot config.

- Pins every third-party action (in workflows *and* composite actions) to a full commit SHA with the version in a trailing comment — a moved tag can no longer change what CI runs, and Dependabot still bumps the SHA and comment together.
- Points the `github-actions` ecosystem at both `/` (workflows) and `/.github/actions/*` (composite actions).
- Extends Dependabot to the release branches via `target-branch`: 3.8 gets every ecosystem, 3.7 gets GitHub Actions only.
- On the release branches, ignores major updates for the language ecosystems (npm/pip/gradle/nuget/swift) but allows them for GitHub Actions.
- Runs everything monthly with a flat 7-day cooldown, and drops `open-pull-requests-limit`.

Dependabot reads this config only from the default branch, and security updates always target the default branch.
