### PR TITLE
Trust the zeroc-ice tap on macOS so the ice@3.8 alias installs

### DIFF
--- a/.github/actions/install-ice/action.yml
+++ b/.github/actions/install-ice/action.yml
@@ -21,6 +21,13 @@ runs:
         if [ "${{ inputs.quality }}" = "nightly" ]; then
           brew install zeroc-ice/nightly/ice@${{ inputs.channel }}
         else
+          # `ice@3.8` is an alias to the unversioned `ice` formula in zeroc-ice/tap, and
+          # Homebrew only auto-trusts a fully-qualified install target that names a real
+          # formula file. Installing via the alias therefore hits the new tap-trust check
+          # and fails with "Refusing to load formula zeroc-ice/tap/ice from untrusted tap",
+          # so we trust our own tap first. See zeroc-ice/homebrew-tap#16.
+          brew tap zeroc-ice/tap
+          brew trust --tap zeroc-ice/tap
           brew install zeroc-ice/tap/ice@${{ inputs.channel }}
         fi
 

--- a/.github/actions/install-ice/action.yml
+++ b/.github/actions/install-ice/action.yml
@@ -27,7 +27,7 @@ runs:
           # and fails with "Refusing to load formula zeroc-ice/tap/ice from untrusted tap",
           # so we trust our own tap first. See zeroc-ice/homebrew-tap#16.
           brew tap zeroc-ice/tap
-          brew trust --tap zeroc-ice/tap
+          brew trust zeroc-ice/tap
           brew install zeroc-ice/tap/ice@${{ inputs.channel }}
         fi
 

--- a/.github/actions/install-ice/action.yml
+++ b/.github/actions/install-ice/action.yml
@@ -21,11 +21,7 @@ runs:
         if [ "${{ inputs.quality }}" = "nightly" ]; then
           brew install zeroc-ice/nightly/ice@${{ inputs.channel }}
         else
-          # `ice@3.8` is an alias to the unversioned `ice` formula in zeroc-ice/tap, and
-          # Homebrew only auto-trusts a fully-qualified install target that names a real
-          # formula file. Installing via the alias therefore hits the new tap-trust check
-          # and fails with "Refusing to load formula zeroc-ice/tap/ice from untrusted tap",
-          # so we trust our own tap first. See zeroc-ice/homebrew-tap#16.
+          # ice@3.8 is an alias, so brew install won't auto-trust it; trust the tap first.
           brew tap zeroc-ice/tap
           brew trust zeroc-ice/tap
           brew install zeroc-ice/tap/ice@${{ inputs.channel }}


### PR DESCRIPTION
The 3.8 macOS CI job has been failing at "Install Ice" with `Refusing to load formula zeroc-ice/tap/ice from untrusted tap zeroc-ice/tap`. This is Homebrew's tap-trust check: `brew install` only auto-trusts a fully-qualified `user/tap/formula` target when it names a real formula file, but `ice@3.8` is an alias to the unversioned `ice` formula, so the alias install isn't auto-trusted and the resolved `ice` formula is refused. The 3.7 stable job and the nightly jobs don't hit this because `ice@3.7` and the nightly `ice@3.9` are real formula files.

Rather than change the tap (we want to keep the `ice@3.8` alias), this trusts our own tap in the macOS install step before installing, with a comment explaining why. Only the stable path needs it; the nightly path is unaffected. Background in zeroc-ice/homebrew-tap#16.
