### PR TITLE
Fix cpp98 throughput compile error on macOS

### DIFF
--- a/cpp98/Ice/throughput/Client.cpp
+++ b/cpp98/Ice/throughput/Client.cpp
@@ -425,7 +425,7 @@ run(const Ice::CommunicatorPtr& communicator)
                         break;
                     }
                 }
-                double mbit = repetitions * seqSize * wireSize * 8.0 / tm.toMicroSeconds();
+                double mbit = repetitions * seqSize * wireSize * 8.0 / static_cast<double>(tm.toMicroSeconds());
                 if(c == 'e')
                 {
                     mbit *= 2;


### PR DESCRIPTION
The stable macOS C++ build hit `-Wimplicit-int-float-conversion` (a `-Werror` on the macos-26 clang) at `cpp98/Ice/throughput/Client.cpp:428`, where `tm.toMicroSeconds()` (an `Int64`) was implicitly converted to `double` in the throughput calculation. This casts it explicitly. The cpp11 demo isn't affected because its `duration` uses a `float` representation.

This intentionally leaves the nightly jobs in place. They fail because the `nuget-3.7-nightly` feed is empty — it has none of the `zeroc.ice.v142` / `zeroc.ice.v143` / `zeroc.ice.net` packages that 3.8 and 3.9 nightly publish — so that's a nightly-publish problem to fix at the source rather than something to work around here.
