### PR TITLE
Bump openrewrite plugin to 7.35.0 (3.8)

### DIFF
--- a/java/Ice/middleware/client/src/main/java/com/example/ice/middleware/client/Client.java
+++ b/java/Ice/middleware/client/src/main/java/com/example/ice/middleware/client/Client.java
@@ -27,9 +27,9 @@ class Client {
                 String unexpected = greeter.greet(System.getProperty("user.name"), Map.of("token", "pineapple"));
                 System.out.println("Received unexpected greeting: '" + unexpected + "'");
             } catch (DispatchException dispatchException) {
-                if (ReplyStatus.valueOf(dispatchException.replyStatus) == ReplyStatus.Unauthorized) {
-                    // Expected with an invalid (or missing) token. See AuthorizationMiddleware.
-                } else {
+                // An Unauthorized error is expected with an invalid (or missing) token; rethrow anything
+                // else. See AuthorizationMiddleware.
+                if (ReplyStatus.valueOf(dispatchException.replyStatus) != ReplyStatus.Unauthorized) {
                     throw dispatchException;
                 }
             }

--- a/java/Ice/secure/client/src/main/java/com/example/ice/secure/client/Client.java
+++ b/java/Ice/secure/client/src/main/java/com/example/ice/secure/client/Client.java
@@ -66,12 +66,8 @@ class Client {
             trustManagerFactory.init(keyStore);
             sslContext.init(null, trustManagerFactory.getTrustManagers(), null);
             return sslContext;
-        } catch (
-            CertificateException
-                | IOException
-                | KeyManagementException
-                | KeyStoreException
-                | NoSuchAlgorithmException ex) {
+        } catch (CertificateException | IOException | KeyManagementException | KeyStoreException
+            | NoSuchAlgorithmException ex) {
             // Should never happen in this demo.
             throw new RuntimeException("SSL initialization error.", ex);
         }

--- a/java/Ice/secure/server/src/main/java/com/example/ice/secure/server/Server.java
+++ b/java/Ice/secure/server/src/main/java/com/example/ice/secure/server/Server.java
@@ -83,13 +83,8 @@ final class Server {
             keyManagerFactory.init(keyStore, password);
             sslContext.init(keyManagerFactory.getKeyManagers(), null, null);
             return sslContext;
-        } catch (
-            CertificateException
-                | IOException
-                | KeyManagementException
-                | KeyStoreException
-                | NoSuchAlgorithmException
-                | UnrecoverableKeyException ex) {
+        } catch (CertificateException | IOException | KeyManagementException | KeyStoreException
+            | NoSuchAlgorithmException | UnrecoverableKeyException ex) {
             // Should never happen in this demo.
             throw new RuntimeException("SSL initialization error.", ex);
         }

--- a/java/build-logic/build.gradle.kts
+++ b/java/build-logic/build.gradle.kts
@@ -13,5 +13,5 @@ repositories {
 dependencies {
     // This is the only way to pull in a specific version of the 'openrewrite' plugin. Convention plugins like this one
     // can't specify plugin versions in the `plugins {}` DSL block (where you normally would).
-    implementation("org.openrewrite.rewrite:org.openrewrite.rewrite.gradle.plugin:7.7.0")
+    implementation("org.openrewrite.rewrite:org.openrewrite.rewrite.gradle.plugin:7.35.0")
 }

--- a/java/build-logic/src/main/kotlin/zeroc-linting.gradle.kts
+++ b/java/build-logic/src/main/kotlin/zeroc-linting.gradle.kts
@@ -38,7 +38,6 @@ tasks.withType<Checkstyle>().configureEach {
 
 rewrite {
     activeRecipe("com.zeroc.IceRewriteRecipes")
-    activeStyle("com.zeroc.IceRewriteStyle")
     configFile = file("$rootDir/../../config/rewrite.yml")
 
     exclusion(

--- a/java/config/checkstyle/checkstyle.xml
+++ b/java/config/checkstyle/checkstyle.xml
@@ -84,6 +84,14 @@
   <!-- 'TreeWalker' is what Checkstyle uses to traverse the source code's AST. -->
   <!-- Any checks that require some language awareness must be in this module. -->
   <module name="TreeWalker">
+    <module name="Indentation">
+      <property name="basicOffset" value="4"/>
+      <property name="lineWrappingIndentation" value="4"/>
+      <property name="caseIndent" value="4"/>
+      <property name="throwsIndent" value="4"/>
+      <property name="arrayInitIndent" value="4"/>
+      <property name="braceAdjustment" value="0"/>
+    </module>
     <module name="OuterTypeFilename"/>
     <module name="IllegalTokenText">
       <property name="tokens" value="STRING_LITERAL, CHAR_LITERAL"/>

--- a/java/config/rewrite.yml
+++ b/java/config/rewrite.yml
@@ -1,3 +1,4 @@
+# OpenRewrite derives its code style from our Checkstyle config (checkstyle/checkstyle.xml).
 type: specs.openrewrite.org/v1beta/recipe
 name: com.zeroc.IceRewriteRecipes
 displayName: "ZeroC Java Lints"
@@ -32,16 +33,3 @@ recipeList:
   - org.openrewrite.java.format.RemoveTrailingWhitespace
   - org.openrewrite.java.format.Spaces
   - org.openrewrite.java.format.TabsAndIndents
-
----
-
-type: specs.openrewrite.org/v1beta/style
-name: com.zeroc.IceRewriteStyle
-displayName: "ZeroC Java Style"
-styleConfigs:
-  - org.openrewrite.java.style.TabsAndIndentsStyle:
-      indentSize: 4
-      continuationIndent: 4
-      tabSize: 4
-  - org.openrewrite.java.style.OperatorWrapStyle:
-      wrapOption: NL


### PR DESCRIPTION
Port of #784 to the 3.8 branch (supersedes #783). All relevant files were identical between the two branches, so this is the same change:

- bump the openrewrite gradle plugin from 7.7.0 to 7.35.0
- make `checkstyle.xml` the single source of truth: full `Indentation` settings there, ZeroC style deleted from `rewrite.yml`
- rewrap the secure demos' `catch` clauses and replace the middleware client's empty `if` block for the newly-enforced checks

See #784 for the background on why the bump required this.