### PR TITLE
Fix js/Ice/context typecheck against current Ice nightly

### DIFF
--- a/js/Ice/context/client.ts
+++ b/js/Ice/context/client.ts
@@ -33,6 +33,7 @@ greeting = await greeterEs.greet("alice");
 console.log(greeting);
 
 // One more time, this time with an implicit context set on the communicator.
-communicator.getImplicitContext().put("language", "de");
+// getImplicitContext returns null unless the Ice.ImplicitContext property is set, which we do above.
+communicator.getImplicitContext()?.put("language", "de");
 greeting = await greeter.greet("bob");
 console.log(greeting);


### PR DESCRIPTION
## Problem

The JavaScript CI job (`lint-and-format`) is failing on `main`:

```
js/Ice/context: client.ts(36,1): error TS2531: Object is possibly 'null'.
```

Despite the job name, this is **not** an eslint or prettier failure — both pass. The job runs `prettier → lint → build → typecheck` per demo, and it is `tsc --noEmit` that fails.

## Cause

A recent `@zeroc/ice` 3.9 nightly changed the `Communicator` typings:

```ts
// package/src/Ice/Communicator.d.ts
getImplicitContext(): Ice.ImplicitContext | null;
```

The JS demos resolve `"@zeroc/ice": "^3.9.0-nightly.0.0"` from the nightly registry configured in each demo's `.npmrc`, with no committed lockfile — so every CI run picks up the newest nightly. That is why this appeared on an unrelated documentation PR (#790) rather than on the change that caused it. The last green JavaScript run was 2026-07-09; `main` itself has not run this workflow since 2026-07-07.

## Fix

`js/Ice/context/client.ts` sets `Ice.ImplicitContext` to `"Shared"` before constructing the communicator, so the value is never null at runtime — TypeScript simply cannot prove it. Use optional chaining, which is what `swift/Ice/Context/Sources/Client/main.swift:38` already does:

```ts
communicator.getImplicitContext()?.put("language", "de");
```

No behavioral change.

## Verification

I ran the CI loop (`npm install → prettier → lint → build → typecheck`) locally against all 12 JavaScript demos rather than stopping at the first failure, since the CI loop aborts early and could be hiding further breakage. `Ice/context` is the only affected demo; the other 11 pass.

## Note

Worth considering separately: the unpinned nightly range plus absent lockfiles means any upstream typing change lands as a red build on whatever PR happens to be open at the time. Not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)