### PR TITLE
Add least-privilege permissions to workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,9 @@ concurrency:
 env:
   CMAKE_BUILD_PARALLEL_LEVEL: 4
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     name: ${{ matrix.os }}

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -8,6 +8,9 @@ on:
     # The branches below must be a subset of the branches above
     branches: ["main"]
 
+permissions:
+  contents: read
+
 jobs:
   clang-format:
     runs-on: ubuntu-24.04

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -10,6 +10,9 @@ on:
   schedule:
     - cron: "0 0 * * 0" # Run weekly on Sunday at midnight UTC
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-24.04

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -8,6 +8,9 @@ on:
     # The branches below must be a subset of the branches above
     branches: ["main"]
 
+permissions:
+  contents: read
+
 jobs:
   dotnet-format:
     runs-on: ubuntu-24.04

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -7,6 +7,9 @@ on:
     # The branches below must be a subset of the branches above
     branches: ["main"]
 
+permissions:
+  contents: read
+
 jobs:
 
   rewrite:

--- a/.github/workflows/javascript.yml
+++ b/.github/workflows/javascript.yml
@@ -7,6 +7,9 @@ on:
     # The branches below must be a subset of the branches above
     branches: ["main"]
 
+permissions:
+  contents: read
+
 jobs:
   lint-and-format:
     runs-on: ubuntu-24.04

--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -8,6 +8,9 @@ on:
     # The branches below must be a subset of the branches above
     branches: ["main"]
 
+permissions:
+  contents: read
+
 jobs:
   markdownlint:
     runs-on: ubuntu-24.04
@@ -21,7 +24,7 @@ jobs:
           node-version: "lts/*"
 
       - name: Install markdownlint-cli
-        run: npm install -g markdownlint-cli
+        run: npm install -g --ignore-scripts markdownlint-cli
 
       - name: Lint Markdown files
         run: markdownlint --config .markdownlint.json **/*.md

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -8,6 +8,9 @@ on:
     # The branches below must be a subset of the branches above
     branches: ["main"]
 
+permissions:
+  contents: read
+
 jobs:
   ruff:
     runs-on: ubuntu-24.04
@@ -31,7 +34,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install pyright
-        run: npm install -g pyright
+        run: npm install -g --ignore-scripts pyright
 
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -8,6 +8,9 @@ on:
     # The branches below must be a subset of the branches above
     branches: ["main"]
 
+permissions:
+  contents: read
+
 jobs:
   swift-format:
     name: Swift format and lint


### PR DESCRIPTION
Workflows had no `permissions:` block, so each run inherited the repository default of write on nearly everything (contents, packages, actions, security-events).

- Declare top-level `permissions: contents: read` in all nine workflows; none of them write to the repo, publish packages, or use secrets.
- Pass `--ignore-scripts` to the `markdownlint-cli` and `pyright` global installs, so a compromised dependency cannot run an install hook in CI. Neither tree contains install scripts today.