### PR TITLE
Fix 32-bit overflow and wrong-unit epoch offset in Java Time helper

### DIFF
--- a/java/util/src/main/java/com/example/util/Time.java
+++ b/java/util/src/main/java/com/example/util/Time.java
@@ -4,7 +4,7 @@ package com.example.util;
 
 public class Time {
     // daysBeforeEpoch converted to milliseconds
-    private static final long MILLIS_BEFORE_EPOCH = 719162 * 24 * 60 * 60 * 1000;
+    private static final long MILLIS_BEFORE_EPOCH = 719162L * 24 * 60 * 60 * 1000;
 
     // number of ticks per millisecond
     private static final long TICKS_PER_MILLISECOND = 10_000;
@@ -16,7 +16,7 @@ public class Time {
      * @return The time stamp.
      */
     public static long toTimeStamp(java.time.ZonedDateTime dateTime) {
-        return dateTime.toInstant().toEpochMilli() * TICKS_PER_MILLISECOND + MILLIS_BEFORE_EPOCH;
+        return (dateTime.toInstant().toEpochMilli() + MILLIS_BEFORE_EPOCH) * TICKS_PER_MILLISECOND;
     }
 
     /**
@@ -26,7 +26,7 @@ public class Time {
      * @return The zoned date time.
      */
     public static java.time.ZonedDateTime toZonedDateTime(long timeStamp) {
-        long epochMilli = (timeStamp - MILLIS_BEFORE_EPOCH) / TICKS_PER_MILLISECOND;
+        long epochMilli = timeStamp / TICKS_PER_MILLISECOND - MILLIS_BEFORE_EPOCH;
         return java.time.Instant.ofEpochMilli(epochMilli).atZone(java.time.ZoneOffset.UTC);
     }
 


### PR DESCRIPTION
Fixes #802.

The shared Java `Time` helper (used by the `Ice/bidir`, `Ice/callback`, and `Glacier2/callback` clients and servers) had two bugs that broke the Slice timestamp contract for any cross-language pairing:

- `MILLIS_BEFORE_EPOCH` was computed with all-`int` arithmetic, wrapping to 304,928,768 ms (~3.5 days) instead of the intended 62,135,596,800,000 ms.
- The offset was applied in milliseconds *after* the tick multiplication (and subtracted before the division in the reverse direction), i.e. in the wrong unit.

Both conversion directions now match the JS (`js/Ice/bidir/timeUtil.ts`) and C++ (`cpp/common/Time.h`) helpers: `(epochMillis + MILLIS_BEFORE_EPOCH) * TICKS_PER_MILLISECOND`.

Verified by compiling the fixed helper and checking that:

- the Unix epoch converts to exactly 621,355,968,000,000,000 ticks (the well-known .NET `DateTime.UnixEpoch.Ticks` value) and back;
- a current timestamp round-trips exactly;
- `java/Ice/bidir` builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)