### PR TITLE
Fix invocation timeout in Java cancellation client: 4 ms -> 4 seconds

### DIFF
--- a/java/Ice/cancellation/client/src/main/java/com/example/ice/cancellation/client/Client.java
+++ b/java/Ice/cancellation/client/src/main/java/com/example/ice/cancellation/client/Client.java
@@ -8,6 +8,7 @@ import com.zeroc.Ice.InvocationTimeoutException;
 import com.zeroc.Ice.OperationInterruptedException;
 import com.zeroc.Ice.UnknownException;
 
+import java.time.Duration;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -67,7 +68,7 @@ class Client {
 
             // Create another slow greeter proxy with an invocation timeout of 4 seconds (the default invocation timeout
             // is infinite).
-            GreeterPrx slowGreeter4s = slowGreeter.ice_invocationTimeout(4);
+            GreeterPrx slowGreeter4s = slowGreeter.ice_invocationTimeout(Duration.ofSeconds(4));
 
             // Send a request to the slow greeter with the 4-second invocation timeout.
             try {


### PR DESCRIPTION
Fixes #804.

The Java cancellation client passed `4` to the `int` overload of `ice_invocationTimeout`, which takes milliseconds — so the request timed out after ~4 ms while the comment (and the demo's narration) promise 4 seconds. Java was the only outlier among the nine language ports.

Now uses `Duration.ofSeconds(4)`, matching the intent and the other ports (`4s` in C++, `TimeSpan.FromSeconds(4)` in C#, `4000` ms elsewhere).

Verified with a clean `:client:build` of the cancellation demo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)