### PR TITLE
Fix Java IceBox greeter service to read Greeter.Name

### DIFF
--- a/java/IceGrid/icebox/service/src/main/java/com/example/icegrid/icebox/service/GreeterService.java
+++ b/java/IceGrid/icebox/service/src/main/java/com/example/icegrid/icebox/service/GreeterService.java
@@ -24,7 +24,7 @@ public class GreeterService implements Service {
 
         // Retrieve the greeter name and greeter identity from the IceGrid-generated config file.
         Properties properties = communicator.getProperties();
-        String greeterName = properties.getProperty("Ice.ProgramName");
+        String greeterName = properties.getProperty("Greeter.Name");
         Identity greeterIdentity = Util.stringToIdentity(properties.getProperty("Greeter.Identity"));
 
         // Register the Chatbot servant with the adapter.


### PR DESCRIPTION
Fixes #812.

The Java IceBox greeter service read `Ice.ProgramName`, so the `Greeter.Name=Syd` property deployed by `greeter-hall.xml` was dead configuration — editing it had no effect, silently defeating the demo's teaching point (per-service configuration through the IceGrid descriptor).

The service now reads `Greeter.Name`, matching the C# service. The adjacent `Greeter.Identity` read was already correct.

Verified with a clean build of `java/IceGrid/icebox`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)