### PR TITLE
Fix reversed shutdown-wait condition in C++ IceStorm weather sensor

### DIFF
--- a/cpp/IceStorm/weather/Sensor.cpp
+++ b/cpp/IceStorm/weather/Sensor.cpp
@@ -89,7 +89,7 @@ main(int argc, char* argv[])
         weatherStation->report(sensorId, timeStamp, reading);
 
         // Wait for one second or for the shutdown signal.
-        if (shutdownFuture.wait_for(std::chrono::seconds(1)) == std::future_status::timeout)
+        if (shutdownFuture.wait_for(std::chrono::seconds(1)) != std::future_status::timeout)
         {
             break;
         }


### PR DESCRIPTION
Fixes #799.

The sensor's shutdown wait used `== std::future_status::timeout` as its break condition, inverting both behaviors: a normal run exited after a single report (despite printing "Press Ctrl+C to stop"), and after Ctrl+C the loop kept publishing with no pacing.

The comparison is now `!=`, matching the DataStorm sampleFilter writer and the other eight language ports of this sensor.

Verified against a live IceStorm and station (nightly `ice@3.9`): the sensor publishes at 1 report/second until interrupted (5 reports over 4.5 s, all received by the station) and exits 0.65 s after Ctrl+C.

🤖 Generated with [Claude Code](https://claude.com/claude-code)