### PR TITLE
Fix undefined userName in MATLAB Glacier2 greeter client

### DIFF
--- a/matlab/Glacier2/greeter/client.m
+++ b/matlab/Glacier2/greeter/client.m
@@ -41,7 +41,7 @@ function client(args)
     greeter = greeter.ice_router(router);
 
     % Send a request to the remote object and get the response.
-    greeting = greeter.greet(userName);
+    greeting = greeter.greet(username);
     fprintf('%s\n', greeting);
 
     % Send a second request to observe the effect in the Glacier2 router log.


### PR DESCRIPTION
Fixes #800.

The client assigns `username` (line 26) and passes it correctly to `createSession`, but passed `userName` to the first `greet` call. MATLAB identifiers are case-sensitive, so the client failed with an undefined-variable error before sending the first request through Glacier2.

A sweep of the MATLAB tree confirms this was the only such case mismatch. (No MATLAB available on this machine, so the fix is verified by inspection only.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)