### PR TITLE
Fix Swift middleware client to only catch Unauthorized dispatch errors

### DIFF
--- a/swift/Ice/Middleware/Sources/Client/main.swift
+++ b/swift/Ice/Middleware/Sources/Client/main.swift
@@ -24,8 +24,12 @@ let validToken = "iced tea"
 do {
     let unexpected = try await greeter.greet(NSUserName(), context: ["token": "pineapple"])
     print("Received unexpected greeting: \(unexpected)")
-} catch is DispatchException {
-    // Expected with an invalid (or missing) token. See AuthorizationMiddleware.
+} catch let error as DispatchException {
+    // An Unauthorized error is expected with an invalid (or missing) token; rethrow anything else.
+    // See AuthorizationMiddleware.
+    if error.replyStatus != ReplyStatus.unauthorized.rawValue {
+        throw error
+    }
 }
 
 // Send a request with the correct token in the request context.


### PR DESCRIPTION
Fixes #811.

The Swift middleware client caught every `DispatchException` with an empty catch block, so a non-Unauthorized dispatch error — e.g. `ObjectNotExist` from a misconfigured server — was silently absorbed and the demo appeared to pass. The catch now checks `replyStatus` and rethrows anything else, matching the C# exception filter and the Java rethrow, and using the same shape as the Swift Glacier2 session client.

Verified both paths at runtime against the nightly:
- demo server: the Unauthorized rejection of the invalid token is caught quietly and the valid-token greeting succeeds (exit 0);
- a server on 4061 without a `greeter` identity: `ObjectNotExistException` now propagates to the top level instead of being swallowed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)