### PR TITLE
Fix Swift GreeterApp README alert markup and Glacier2 callback log

### DIFF
--- a/swift/Glacier2/Callback/Sources/Server/SimpleWakeUpService.swift
+++ b/swift/Glacier2/Callback/Sources/Server/SimpleWakeUpService.swift
@@ -17,7 +17,7 @@ struct SimpleWakeUpService: WakeUpService {
         let wakeUpTime = Date(timeStamp: timeStamp)
         let formattedTime = wakeUpTime.formatted(date: .omitted, time: .complete)
 
-        print("Dispatching wakeMeUp request { alarmClock = '\(alarmClock)', timeStamp = '\(formattedTime))' }")
+        print("Dispatching wakeMeUp request { alarmClock = '\(alarmClock)', timeStamp = '\(formattedTime)' }")
 
         // Schedule a wake-up call in a background task.
         Task {

--- a/swift/Ice/GreeterApp/README.md
+++ b/swift/Ice/GreeterApp/README.md
@@ -11,7 +11,7 @@ The client is implemented using SwiftUI and can be run on **macOS**, the **iOS S
 2. Open the `GreeterApp` project in Xcode.
 3. Build and run the application on your platform of choice (macOS, iOS device, or iOS simulator).
 
->![IMPORTANT]
+> [!IMPORTANT]
 > On the first build attempt, you may see the message:
 > _"Plugin “CompileSlice” from package “ice” must be enabled before it can be used."_
 > Click on the message in Xcode to enable the plugin.


### PR DESCRIPTION
Fixes #817.

- `>![IMPORTANT]` in the GreeterApp README put the `!` before the bracket, so GitHub parsed image-reference syntax inside a blockquote and rendered literal text; now `> [!IMPORTANT]` renders the alert callout.
- The Glacier2 callback server log printed `timeStamp = '3:04:05 PM)'` due to a stray parenthesis; the line is now identical to the Ice/Callback sibling.

The Glacier2 Callback package builds cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)