### PR TITLE
Fix sampleFilter Ctrl+C disarm and add missing inline in common/Time.h

### DIFF
--- a/cpp/DataStorm/sampleFilter/Writer.cpp
+++ b/cpp/DataStorm/sampleFilter/Writer.cpp
@@ -51,10 +51,12 @@ main(int argc, char* argv[])
     auto shutdownPromise = std::promise<void>();
     auto shutdownFuture = shutdownPromise.get_future();
     ctrlCHandler.setCallback(
-        [&shutdownPromise](int)
+        [&ctrlCHandler, &shutdownPromise](int)
         {
             std::cout << "Shutting down..." << std::endl;
             shutdownPromise.set_value();
+            // Reset the callback to nullptr to avoid calling it again.
+            ctrlCHandler.setCallback(nullptr);
         });
 
     // Publish temperature readings.

--- a/cpp/common/Time.h
+++ b/cpp/common/Time.h
@@ -43,7 +43,7 @@ namespace Time
     /// @return The time stamp.
     inline std::int64_t toTimeStamp(const std::chrono::system_clock::time_point& timePoint)
     {
-        const int daysBeforeEpoch = 719162;
+        const int daysBeforeEpoch = 719'162;
 
         std::int64_t timeStampMicro = std::chrono::duration_cast<std::chrono::microseconds>(
                                           timePoint.time_since_epoch() + daysBeforeEpoch * std::chrono::hours{24})
@@ -56,9 +56,9 @@ namespace Time
     /// Converts a time stamp to a time point.
     /// @param timeStamp The time stamp.
     /// @return The time point.
-    std::chrono::system_clock::time_point toTimePoint(std::int64_t timeStamp)
+    inline std::chrono::system_clock::time_point toTimePoint(std::int64_t timeStamp)
     {
-        const int daysBeforeEpoch = 719162;
+        const int daysBeforeEpoch = 719'162;
 
         std::chrono::microseconds timePointMicro{timeStamp / 10}; // timeStamp is in ticks (100 nanoseconds)
         return std::chrono::system_clock::time_point{timePointMicro - daysBeforeEpoch * std::chrono::hours{24}};


### PR DESCRIPTION
Fixes #818.

- **sampleFilter writer**: the Ctrl+C callback called `shutdownPromise.set_value()` without disarming itself; a second Ctrl+C during the shutdown window called `set_value` on an already-satisfied promise → uncaught `std::future_error` → abort. The callback now resets itself to `nullptr` after fulfilling the promise, matching the IceStorm weather sensor and the cancellation server. The other 27 `setCallback` sites in the C++ demos only call `communicator->shutdown()`, which is idempotent, so no other demo needs this.
- **common/Time.h**: `toTimePoint` was the only non-`inline` function in this shared header — latent duplicate-symbol link error for any future two-TU consumer. Also switched the `daysBeforeEpoch` constants to digit separators (`719'162`), matching the Java helper's `719_162L`.

Verified against the nightly: the unfixed writer reproducibly aborts with SIGABRT when the second Ctrl+C lands during teardown (reader stalled with SIGSTOP to hold the window open), and the fixed writer exits cleanly under the same test; both sampleFilter and the weather demo (a two-function Time.h consumer) build cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)