### PR TITLE
Fix PHP optional client2 require and assorted PHP demo defects

### DIFF
--- a/php/Glacier2/greeter/Client.php
+++ b/php/Glacier2/greeter/Client.php
@@ -14,7 +14,7 @@ $communicator = Ice\initialize($argv);
 $router = Glacier2\RouterPrxHelper::createProxy($communicator, 'Glacier2/router:tcp -h localhost -p 4063');
 
 // Retrieve my username.
-$username = get_current_user();
+$username = getenv('USER') ?: getenv('USERNAME') ?: 'guest';
 
 // Create a session with the Glacier2 router. In this demo, the Glacier2 router is configured to accept any
 // username/password combination. This call establishes a network connection to the Glacier2 router; the lifetime of

--- a/php/Ice/config/Client.php
+++ b/php/Ice/config/Client.php
@@ -21,6 +21,6 @@ $communicator = Ice\initialize(new Ice\InitializationData($properties));
 $greeter = VisitorCenter\GreeterPrxHelper::uncheckedCast($communicator->propertyToProxy("Greeter.Proxy"));
 
 // Send a request to the remote object and get the response.
-$greeting = $greeter->greet(get_current_user());
+$greeting = $greeter->greet(getenv('USER') ?: getenv('USERNAME') ?: 'guest');
 
 echo "$greeting\n";

--- a/php/Ice/context/Client.php
+++ b/php/Ice/context/Client.php
@@ -17,7 +17,7 @@ $greeter = VisitorCenter\GreeterPrxHelper::createProxy($communicator, 'greeter:t
 // Send a request to the remote object and get the response. We request a French greeting by setting 'language' in
 // the context parameter.
 $context = ["language" => "fr"];
-$greeting = $greeter->greet(get_current_user(), $context);
+$greeting = $greeter->greet(getenv('USER') ?: getenv('USERNAME') ?: 'guest', $context);
 echo "$greeting\n";
 
 // Do it again, this time creating a new proxy containing a context.

--- a/php/Ice/customError/Client.php
+++ b/php/Ice/customError/Client.php
@@ -14,7 +14,7 @@ $communicator = Ice\initialize($argv);
 // or IP address.
 $greeter = VisitorCenter\GreeterPrxHelper::createProxy($communicator, 'greeter:tcp -h localhost -p 4061');
 
-$names = [get_current_user(), '', 'alice', 'bob', 'carol', 'dave', 'billy bob'];
+$names = [getenv('USER') ?: getenv('USERNAME') ?: 'guest', '', 'alice', 'bob', 'carol', 'dave', 'billy bob'];
 
 foreach ($names as $name) {
     try {

--- a/php/Ice/greeter/Client.php
+++ b/php/Ice/greeter/Client.php
@@ -15,6 +15,6 @@ $communicator = Ice\initialize($argv);
 $greeter = VisitorCenter\GreeterPrxHelper::createProxy($communicator, 'greeter:tcp -h hello.zeroc.com -p 4061');
 
 // Send a request to the remote object and get the response.
-$greeting = $greeter->greet(get_current_user());
+$greeting = $greeter->greet(getenv('USER') ?: getenv('USERNAME') ?: 'guest');
 
 echo "$greeting\n";

--- a/php/Ice/inheritance/Client.php
+++ b/php/Ice/inheritance/Client.php
@@ -20,7 +20,7 @@ listRecursive($rootDir, 0);
 // The "depth" parameter is the current nesting level (for indentation).
 function listRecursive($dir, $depth) {
     $depth += 1;
-    $indent = str_repeat(" ", $depth);
+    $indent = str_repeat("\t", $depth);
 
     $contents = $dir->list();
 

--- a/php/Ice/invocationTimeout/Client.php
+++ b/php/Ice/invocationTimeout/Client.php
@@ -21,7 +21,7 @@ $slowGreeter = VisitorCenter\GreeterPrxHelper::createProxy(
     "slowGreeter:tcp -h localhost -p 4061")->ice_invocationTimeout(4000);
 
 # Send a request to the regular greeter and get the response.
-$greeting = $greeter->greet(get_current_user());
+$greeting = $greeter->greet(getenv('USER') ?: getenv('USERNAME') ?: 'guest');
 echo $greeting . "\n";
 
 # Send a request to the slow greeter with the 4-second invocation timeout.
@@ -29,7 +29,7 @@ try {
     $greeting = $slowGreeter->greet("alice");
     echo "Received unexpected greeting: $greeting\n";
 } catch (Ice\InvocationTimeoutException $exception) {
-    echo "Caught InvocationTimeoutException, as expected: $exception->getMessage()\n";
+    echo "Caught InvocationTimeoutException, as expected: " . $exception->getMessage() . "\n";
 }
 
 # Verify the regular greeter still works.

--- a/php/Ice/optional/client1/Client.php
+++ b/php/Ice/optional/client1/Client.php
@@ -20,6 +20,6 @@ $humidity = mt_rand(450, 550) / 10.0; // Humidity in percentage (45.0 to 55.0).
 $reading = new ClearSky\AtmosphericConditions($temperature, $humidity);
 
 // Report this reading to the weather station.
-$weatherStation->report('sensor-1', $reading);
+$weatherStation->report('sensor v1', $reading);
 
 echo "sensor v1: sent reading to weather station\n";

--- a/php/Ice/optional/client2/Client.php
+++ b/php/Ice/optional/client2/Client.php
@@ -2,7 +2,7 @@
 // Copyright (c) ZeroC, Inc.
 
 require_once 'Ice.php';
-require_once 'WeatherStation2.php';
+require_once 'WeatherStation.php';
 
 // Create an Ice communicator. We'll use this communicator to create proxies and manage outgoing connections.
 // This communicator is destroyed automatically at the end of the script.
@@ -21,6 +21,6 @@ $pressure = mt_rand(10000, 10500) / 10.0; // Pressure in millibars (1,000.0 to 1
 $reading = new ClearSky\AtmosphericConditions($temperature, $humidity, $pressure);
 
 // Report this reading to the weather station.
-$weatherStation->report('sensor-2', $reading);
+$weatherStation->report('sensor v2', $reading);
 
 echo "sensor v2: sent reading to weather station\n";

--- a/php/IceDiscovery/greeter/Client.php
+++ b/php/IceDiscovery/greeter/Client.php
@@ -20,6 +20,6 @@ $communicator = Ice\initialize($initData);
 $greeter = VisitorCenter\GreeterPrxHelper::createProxy($communicator, 'greeter');
 
 // Send a request to the remote object and get the response.
-$greeting = $greeter->greet(get_current_user());
+$greeting = $greeter->greet(getenv('USER') ?: getenv('USERNAME') ?: 'guest');
 
 echo "$greeting\n";

--- a/php/IceGrid/greeter/Client.php
+++ b/php/IceGrid/greeter/Client.php
@@ -20,7 +20,7 @@ $communicator->setDefaultLocator(
 $greeter = VisitorCenter\GreeterPrxHelper::createProxy($communicator, 'greeter');
 
 // Send a request to the remote object and get the response.
-$greeting = $greeter->greet(get_current_user());
+$greeting = $greeter->greet(getenv('USER') ?: getenv('USERNAME') ?: 'guest');
 echo "$greeting\n";
 
 // Send another request to the remote object. With the default configuration we use for this client, this request

--- a/php/IceGrid/locatorDiscovery/Client.php
+++ b/php/IceGrid/locatorDiscovery/Client.php
@@ -22,7 +22,7 @@ $communicator = Ice\initialize($initData);
 $greeter = VisitorCenter\GreeterPrxHelper::createProxy($communicator, 'greeter');
 
 // Send a request to the remote object and get the response.
-$greeting = $greeter->greet(get_current_user());
+$greeting = $greeter->greet(getenv('USER') ?: getenv('USERNAME') ?: 'guest');
 echo "$greeting\n";
 
 // Send another request to the remote object. With the default configuration we use for this client, this request


### PR DESCRIPTION
Fixes #803.
Fixes #813.

**#803 — broken require in `Ice/optional` client2:** the client required `WeatherStation2.php`, but the Slice file in the directory is `WeatherStation.ice`, the README compiles exactly that file, and client2's `.gitignore` lists `WeatherStation.php` — so following the README verbatim aborted with "Failed opening required 'WeatherStation2.php'". Now requires `WeatherStation.php` like client1. (Renaming the Slice file to `WeatherStation2.ice` à la the compiled mappings would have complicated the shared README instructions, so the one-line require change won.)

**#813 — PHP misc:**
- `invocationTimeout`: `"$exception->getMessage()"` inside interpolation resolves as a property access (undefined-property warning, literal `()` in the output); switched to concatenation like `customError`.
- All nine clients that passed `get_current_user()` — the script-file *owner*, which is `root`/`www-data` in installed or containerized setups — now use `getenv('USER') ?: getenv('USERNAME') ?: 'guest'` (interactive user on Unix and Windows, with a safe fallback).
- `optional` clients send `'sensor v1'`/`'sensor v2'`, matching their own output lines and the Python/Ruby siblings.
- `inheritance` indents the directory tree with tabs, aligning with the file-content lines and all sibling ports.

All 12 changed files pass `php -l`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)