### PR TITLE
Fix Python Glacier2 session client to rethrow unexpected dispatch errors

### DIFF
--- a/python/Glacier2/session/client/main.py
+++ b/python/Glacier2/session/client/main.py
@@ -144,6 +144,8 @@ async def main():
             if dispatchException.replyStatus == Ice.ReplyStatus.Unauthorized.value:
                 # See code in server.poke_session.box.SharedPokeBox.getUserId.
                 print("The PokeBox proxy remains unusable, as expected.")
+            else:
+                raise
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #807.

The client's final assertion caught every `Ice.DispatchException` but printed only when `replyStatus == Unauthorized` — any other status was silently swallowed and the process exited 0, making a failed run look successful. Python was the only language port without the rethrow; this adds `else: raise`, mirroring the C++ shape.

Verified end-to-end against the nightly (glacier2router + Python server + client): the full demo flow runs through the fixed catch and prints "The PokeBox proxy remains unusable, as expected." with exit 0. `ruff check` and `ruff format --check` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)