### PR TITLE
Fix assorted defects in Ruby demos

### DIFF
--- a/ruby/Glacier2/greeter/client.rb
+++ b/ruby/Glacier2/greeter/client.rb
@@ -24,6 +24,10 @@ Ice.initialize(ARGV) do |communicator|
     # the session is the same as the lifetime of the connection.
     session = router.createSession(username, "password")
 
+    # The session returned by createSession is nil because we did not configure a SessionManager on the Glacier2
+    # router.
+    fail unless session.nil?
+
     # Create a proxy to the Greeter object in the server behind the Glacier2 router. Typically, the client cannot
     # connect directly to this server because it's on an unreachable network.
     greeter = VisitorCenter::GreeterPrx.new(communicator, "greeter:tcp -h localhost -p 4061")

--- a/ruby/Ice/customError/client.rb
+++ b/ruby/Ice/customError/client.rb
@@ -26,7 +26,7 @@ Ice.initialize(ARGV) do |communicator|
             greeting = greeter.greet(name)
             puts greeting
         rescue Ice::DispatchException => exception
-            # Converts exception.replyStatus to an Ice.ReplyStatus enumerator. This fails when
+            # Converts exception.replyStatus to an Ice.ReplyStatus enumerator. from_int returns nil when
             # exception.replyStatus does not correspond to a known enumerator.
             replyStatus = Ice::ReplyStatus.from_int(exception.replyStatus)
             puts "Failed to create a greeting for '#{name}': DispatchException { message = '#{exception.message}', "\

--- a/ruby/Ice/inheritance/client.rb
+++ b/ruby/Ice/inheritance/client.rb
@@ -23,10 +23,10 @@ def listRecursive(dir, depth)
         subdir = Filesystem::DirectoryPrx::checkedCast(node)
         print indent + node.name()
         if subdir
-            puts "(directory):"
+            puts " (directory):"
             listRecursive(subdir, depth)
         else
-            puts "(file):"
+            puts " (file):"
 
             # We assume it's a file if it's not a directory.
             file = Filesystem::FilePrx::uncheckedCast(node)

--- a/ruby/Ice/optional/client1/client.rb
+++ b/ruby/Ice/optional/client1/client.rb
@@ -12,8 +12,8 @@ Ice.initialize(ARGV) do |communicator|
     weatherStation = ClearSky::WeatherStationPrx.new(communicator, "weatherStation:tcp -h localhost -p 4061")
 
     # Generate random temperature and humidity values.
-    temperature = (190.0 + rand(40)) / 10.0 # Temperature in degrees Celsius (19.0 to 23.0).
-    humidity = (450.0 + rand(100)) / 10.0   # Humidity in percentage (45.0 to 55.0).
+    temperature = rand(190..230) / 10.0 # Temperature in degrees Celsius (19.0 to 23.0).
+    humidity = rand(450..550) / 10.0   # Humidity in percentage (45.0 to 55.0).
 
     # Create an AtmosphericConditions object with random values.
     reading = ClearSky::AtmosphericConditions.new(temperature, humidity)

--- a/ruby/Ice/optional/client2/client.rb
+++ b/ruby/Ice/optional/client2/client.rb
@@ -12,9 +12,9 @@ Ice.initialize(ARGV) do |communicator|
     weatherStation = ClearSky::WeatherStationPrx.new(communicator, "weatherStation:tcp -h localhost -p 4061")
 
     # Generate random temperature, humidity, and pressure values.
-    temperature = (190.0 + rand(40)) / 10.0   # Temperature in degrees Celsius (19.0 to 23.0).
-    humidity = (450.0 + rand(100)) / 10.0     # Humidity in percentage (45.0 to 55.0).
-    pressure = (10000.0 + rand(500)) / 10.0   # Pressure in millibars (1,000 to 1,050).
+    temperature = rand(190..230) / 10.0   # Temperature in degrees Celsius (19.0 to 23.0).
+    humidity = rand(450..550) / 10.0     # Humidity in percentage (45.0 to 55.0).
+    pressure = rand(10000..10500) / 10.0   # Pressure in millibars (1,000 to 1,050).
 
     # Create an AtmosphericConditions object with random values, including the optional pressure.
     reading = ClearSky::AtmosphericConditions.new(temperature, humidity, pressure)

--- a/ruby/IceStorm/weather/sensor.rb
+++ b/ruby/IceStorm/weather/sensor.rb
@@ -37,8 +37,8 @@ Ice.initialize(ARGV) do |communicator|
 
     while !cancel
         # Generate a random temperature and humidity reading.
-        temperature = (190.0 + rand(40)) / 10.0; # Temperature in degrees Celsius (19.0 to 23.0).
-        humidity = (450.0 + rand(100)) / 10.0; # Humidity in percentage (45.0 to 55.0).
+        temperature = rand(190..230) / 10.0; # Temperature in degrees Celsius (19.0 to 23.0).
+        humidity = rand(450..550) / 10.0; # Humidity in percentage (45.0 to 55.0).
 
         # Create an AtmosphericConditions object with the generated values.
         reading = ClearSky::AtmosphericConditions.new(temperature, humidity)


### PR DESCRIPTION
Fixes #815.

- **rand ranges**: `rand(n)` is exclusive of `n`, so the weather sensor and optional clients topped out one step below their documented maxima (e.g. 22.9 °C vs the commented 23.0). Now uses the inclusive range form (`rand(190..230) / 10.0`), matching the inclusive PHP/Python/MATLAB siblings. Verified empirically: min 19.0, max 23.0 over 100k samples.
- **customError**: the comment claimed `from_int` fails for unknown reply statuses; the generated `from_int` is a hash lookup that returns `nil`, and the comment now says so.
- **inheritance**: added the missing space before `(directory)`/`(file)`, aligning the listing with the C++/PHP/Python output.
- **Glacier2 greeter**: `session` was assigned and never used (`ruby -w` flagged it); the client now checks the null-session teaching point (`fail unless session.nil?` — Ruby's closest one-liner to the siblings' `assert`).

All six files pass `ruby -cw` with no warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)