### PR TITLE
Fix cross-language divergences in the Glacier2 session demo

### DIFF
--- a/cpp/Glacier2/session/Client.cpp
+++ b/cpp/Glacier2/session/Client.cpp
@@ -113,6 +113,7 @@ main(int argc, char* argv[])
     // Create a new session. This allows us to reach the PokeBox object again.
     cout << "Creating a new session..." << endl;
     session = router->createSession(userId, "password");
+    assert(session);
 
     try
     {

--- a/csharp/Glacier2/Session/Client/Program.cs
+++ b/csharp/Glacier2/Session/Client/Program.cs
@@ -46,8 +46,8 @@ int currentCount = (await pokeBox.GetInventoryAsync()).Length;
 Console.WriteLine($"{userId}'s PokeBox contains {currentCount} Pokémon.");
 
 // Catch a few Pokémon.
-int addCount = RandomNumberGenerator.GetInt32(1, 6);
-Console.Write($"Catching {addCount} Pokémon... ");
+int addCount = RandomNumberGenerator.GetInt32(1, 7);
+Console.WriteLine($"Catching {addCount} Pokémon... ");
 var newPokemon = new List<string>();
 for (int i = 0; i < addCount; ++i)
 {
@@ -90,6 +90,7 @@ catch (Ice.ConnectionLostException)
 // Create a new session. This allows us to reach the PokeBox object again.
 Console.WriteLine("Creating a new session...");
 session = await router.createSessionAsync(userId, "password");
+Debug.Assert(session is not null);
 
 try
 {

--- a/java/Glacier2/session/client/src/main/java/com/example/glacier2/session/client/Client.java
+++ b/java/Glacier2/session/client/src/main/java/com/example/glacier2/session/client/Client.java
@@ -27,7 +27,7 @@ class Client {
         "Primeape"
     };
 
-    public static void main(String[] args) {
+    public static void main(String[] args) throws PermissionDeniedException, CannotCreateSessionException {
 
         // Retrieve the user ID for this run.
         final String userId = args.length > 0 ? args[0] : System.getProperty("user.name");
@@ -45,13 +45,7 @@ class Client {
             // Create a session with the Glacier2 router. In this demo, the Glacier2 router is configured to accept any
             // username/password combination. This call establishes a network connection to the Glacier2 router; the
             // lifetime of the session is the same as the lifetime of the connection.
-            SessionPrx session;
-            try {
-                session = router.createSession(userId, "password");
-            } catch (PermissionDeniedException | CannotCreateSessionException e) {
-                System.out.println("Could not create session: " + e.getMessage());
-                return;
-            }
+            SessionPrx session = router.createSession(userId, "password");
 
             // We configured a SessionManager on the Glacier2 router, so 'session' is a non-null 'PokeSession'.
             PokeSessionPrx pokeSession = PokeSessionPrx.uncheckedCast(session);
@@ -62,12 +56,12 @@ class Client {
             assert pokeBox != null;
 
             int currentCount = pokeBox.getInventory().size();
-            System.out.println(userId + "'s PokeBox contains " + currentCount + " Pokemon.");
+            System.out.println(userId + "'s PokeBox contains " + currentCount + " Pokémon.");
 
             // Catch a few Pokémon.
             var randomSource = new java.util.Random();
             int addCount = randomSource.nextInt(6) + 1;
-            System.out.println("Catching " + addCount + " Pokemon... ");
+            System.out.println("Catching " + addCount + " Pokémon... ");
             List<String> newPokemon = randomSource.ints(addCount, 0, ALL_POKEMON.length)
                 .mapToObj(i -> ALL_POKEMON[i])
                 .toList();
@@ -75,13 +69,13 @@ class Client {
 
             // Display the contents of the PokeBox.
             List<String> inventory = pokeBox.getInventory();
-            System.out.println(userId + "'s PokeBox now holds " + inventory.size() + " Pokemon:");
+            System.out.println(userId + "'s PokeBox now holds " + inventory.size() + " Pokémon:");
             for (String pokemon : inventory) {
                 System.out.println("\t" + pokemon);
             }
 
             if (inventory.size() > 10) {
-                System.out.println("Oh no! All the Pokemon escaped!");
+                System.out.println("Oh no! All the Pokémon escaped!");
                 pokeBox.releaseAll();
             }
 
@@ -102,12 +96,8 @@ class Client {
 
             // Create a new session. This allows us to reach the PokeBox object again.
             System.out.println("Creating a new session...");
-            try {
-                session = router.createSession(userId, "password");
-            } catch (PermissionDeniedException | CannotCreateSessionException e) {
-                System.out.println("Could not create new session: " + e.getMessage());
-                return;
-            }
+            session = router.createSession(userId, "password");
+            assert session != null;
 
             try {
                 // The pokeBox proxy no longer works as it was created with the token of an old session.

--- a/python/Glacier2/session/client/main.py
+++ b/python/Glacier2/session/client/main.py
@@ -119,7 +119,7 @@ async def main():
             await pokeBox.releaseAllAsync()
 
         # Exiting, closing the connection, or calling destroyAsync on the session terminates both PokeSession and the
-        # internal session state maintained by the Glacier router.
+        # internal session state maintained by the Glacier2 router.
         print("Destroying the session...")
         await pokeSession.destroyAsync()
 
@@ -135,6 +135,7 @@ async def main():
         # Create a new session. This allows us to reach the PokeBox object again.
         print("Creating a new session...")
         session = await router.createSessionAsync(userId, "password")
+        assert session is not None
 
         try:
             # The pokeBox proxy no longer works as it was created with the token of an old session.


### PR DESCRIPTION
Fixes #819.

Swift was already correct on every point; the other four ports converge on it:

- **C# catch count**: `RandomNumberGenerator.GetInt32(1, 6)` has an exclusive upper bound, so C# could never catch 6 Pokémon; now `GetInt32(1, 7)`, matching the 1–6 of C++/Java/Python/Swift.
- **Recreated session validated** in C++ (`assert(session)`), C# (`Debug.Assert`), Java (`assert`), and Python (`assert`) instead of a dead assignment, mirroring Swift's guard and each port's own first-session validation style.
- **Java fails loudly on session-creation failure**: both print-and-return catch blocks removed; `main` declares the checked Glacier2 exceptions, so a failure exits non-zero like every other port (net −10 lines).
- **Java prints "Pokémon"** in its four output lines, consistent with its own comments and the siblings. (The inventory listing already prints `Nidoran♀`/`Nidoran♂` in all ports, so this adds no new non-ASCII exposure.)
- **C#** terminates the "Catching…" line with `WriteLine`.
- **Python** comment typo: "Glacier router" → "Glacier2 router".

Verified: Python `py_compile` + ruff clean, C++ demo builds against the nightly, C# `dotnet build` 0 errors, Java `:client:build` green.

Note: touches `python/Glacier2/session/client/main.py` in a different hunk than #831 — no conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)