### PR TITLE
Give client-only demo READMEs actionable prerequisite-server instructions

### DIFF
--- a/java/Ice/android-greeter/README.md
+++ b/java/Ice/android-greeter/README.md
@@ -6,7 +6,8 @@ The demo provides a simple Android client that can be used with any of the Greet
 
 ## Getting Started
 
-First, start a Greeter server implemented in one of languages with server-side support, such as Python, Java, or C#.
+First, start a Greeter server implemented in a language with server-side support (C++, C#, Java, Python, or Swift), for
+example the [Java Greeter server](../greeter): follow the instructions in its README to start this server.
 
 Then, open Android Studio and import the `java/Ice/android-greeter` project.
 You can run the application on either an Android emulator or a physical Android device.

--- a/js/Glacier2/callback/README.md
+++ b/js/Glacier2/callback/README.md
@@ -29,8 +29,9 @@ npm run build
 
 Ice for JavaScript has limited server-side support, and as a result, we can only implement the client in JavaScript.
 
-You first need to start Glacier2 and the Callback server from a demo written in a language with full server-side
-support, such as C++, C#, Java, Python, or Swift.
+You first need to start Glacier2 and the Callback server from a demo written in a language with full server-side support
+(C++, C#, Java, Python, or Swift), for example the [Python Glacier2 Callback demo](../../../python/Glacier2/callback):
+follow the instructions in its README to start the router and the server.
 
 In a separate terminal, start the client application:
 

--- a/js/Ice/bidir/README.md
+++ b/js/Ice/bidir/README.md
@@ -22,7 +22,8 @@ npm run build
 First, start the server application.
 
 Ice for JavaScript has limited server-side support. As a result, you need to start a Bidir server implemented in a
-language that fully supports server-side functionality, such as C++, C#, Java, Python, or Swift.
+language that fully supports server-side functionality (C++, C#, Java, Python, or Swift), for example the [Python Bidir
+server](../../../python/Ice/bidir): follow the instructions in its README to start this server.
 
 In a separate terminal, start the client application:
 

--- a/js/Ice/cancellation/README.md
+++ b/js/Ice/cancellation/README.md
@@ -22,7 +22,8 @@ npm run build
 First, start the server application.
 
 Ice for JavaScript has limited server-side support. As a result, you need to start a Cancellation server implemented in
-a language that fully supports server-side functionality, such as C++, C#, Java, Python, or Swift.
+a language that fully supports server-side functionality (C++, C#, Java, or Swift), for example the [Java Cancellation
+server](../../../java/Ice/cancellation): follow the instructions in its README to start this server.
 
 In a separate terminal, start the client application:
 

--- a/js/Ice/cancellation/README.md
+++ b/js/Ice/cancellation/README.md
@@ -22,7 +22,7 @@ npm run build
 First, start the server application.
 
 Ice for JavaScript has limited server-side support. As a result, you need to start a Cancellation server implemented in
-a language that fully supports server-side functionality (C++, C#, Java, or Swift), for example the [Java Cancellation
+a language that fully supports server-side functionality (C++, C#, or Java), for example the [Java Cancellation
 server](../../../java/Ice/cancellation): follow the instructions in its README to start this server.
 
 In a separate terminal, start the client application:

--- a/js/Ice/context/README.md
+++ b/js/Ice/context/README.md
@@ -21,7 +21,8 @@ npm run build
 First, start the server application.
 
 Ice for JavaScript has limited server-side support. As a result, you need to start a Context server implemented in a
-language that fully supports server-side functionality, such as C++, C#, Java, Python, or Swift.
+language that fully supports server-side functionality (C++, C#, Java, Python, or Swift), for example the [Python
+Context server](../../../python/Ice/context): follow the instructions in its README to start this server.
 
 In a separate terminal, start the client application:
 

--- a/js/Ice/customError/README.md
+++ b/js/Ice/customError/README.md
@@ -23,8 +23,9 @@ npm run build
 
 First, start the server application.
 
-Ice for JavaScript has limited server-side support. As a result, you need to start a Custom Error server implemented in a
-language that fully supports server-side functionality, such as C++, C#, Java, Python, or Swift.
+Ice for JavaScript has limited server-side support. As a result, you need to start a Custom Error server implemented in
+a language that fully supports server-side functionality (C++, C#, Java, Python, or Swift), for example the [Python
+Custom Error server](../../../python/Ice/customError): follow the instructions in its README to start this server.
 
 In a separate terminal, start the client application:
 

--- a/js/Ice/inheritance/README.md
+++ b/js/Ice/inheritance/README.md
@@ -21,7 +21,8 @@ npm run build
 First, start the server application.
 
 Ice for JavaScript has limited server-side support. As a result, you need to start an Inheritance server implemented in
-a language that fully supports server-side functionality, such as C++, C#, Java, Python, or Swift.
+a language that fully supports server-side functionality (C++, C#, Java, Python, or Swift), for example the [Python
+Inheritance server](../../../python/Ice/inheritance): follow the instructions in its README to start this server.
 
 In a separate terminal, start the client application:
 

--- a/js/Ice/optional/README.md
+++ b/js/Ice/optional/README.md
@@ -44,7 +44,8 @@ npm run build
 First, start the server application.
 
 Ice for JavaScript has limited server-side support. As a result, you need to start an Optional server implemented in a
-language that fully supports server-side functionality, such as C++, C#, Java, Python, or Swift.
+language that fully supports server-side functionality (C++, C#, Java, Python, or Swift), for example the [Python
+Optional server](../../../python/Ice/optional): follow the instructions in its README to start this server.
 
 You can start either version 1 or version 2 of the server.
 

--- a/js/Ice/react-greeter/README.md
+++ b/js/Ice/react-greeter/README.md
@@ -21,9 +21,9 @@ npm run build
 
 First, start the server application.
 
-Ice for JavaScript has limited server-side support. As a result, you need to start a Greeter server implemented in a
+Ice for JavaScript has limited server-side support. As a result, you need to start a Config server implemented in a
 language that fully supports server-side functionality (C++, C#, Java, Python, or Swift), for example the [Python
-Greeter server](../../../python/Ice/greeter): follow the instructions in its README to start this server.
+Config server](../../../python/Ice/config): follow the instructions in its README to start this server.
 
 > [!IMPORTANT]
 > Pass `--Ice.Default.Protocol=ws` to the server to instruct it to use the `ws` protocol required for communication

--- a/js/Ice/react-greeter/README.md
+++ b/js/Ice/react-greeter/README.md
@@ -21,8 +21,9 @@ npm run build
 
 First, start the server application.
 
-Ice for JavaScript has limited server-side support. As a result, you need to start a Config server implemented in a
-language that fully supports server-side functionality, such as C++, C#, Java, Python, or Swift.
+Ice for JavaScript has limited server-side support. As a result, you need to start a Greeter server implemented in a
+language that fully supports server-side functionality (C++, C#, Java, Python, or Swift), for example the [Python
+Greeter server](../../../python/Ice/greeter): follow the instructions in its README to start this server.
 
 > [!IMPORTANT]
 > Pass `--Ice.Default.Protocol=ws` to the server to instruct it to use the `ws` protocol required for communication

--- a/js/IceGrid/greeter/README.md
+++ b/js/IceGrid/greeter/README.md
@@ -34,8 +34,9 @@ npm run build
 
 Ice for JavaScript has limited server-side support, and as a result, we can only implement the client in JavaScript.
 
-You first need to deploy an IceGrid Greeter server from a demo written in a language with full server-side
-support, such as C++, C#, Java, Python, or Swift.
+You first need to deploy an IceGrid Greeter server from a demo written in a language with full server-side support (C++,
+C#, Java, Python, or Swift), for example the [Python IceGrid Greeter demo](../../../python/IceGrid/greeter): follow the
+instructions in its README to deploy this server.
 
 In a separate terminal, start the client application:
 

--- a/js/IceStorm/weather/README.md
+++ b/js/IceStorm/weather/README.md
@@ -32,7 +32,8 @@ npm run build
 Ice for JavaScript has limited server-side support, and as a result, we can only implement the sensors in JavaScript.
 
 You first need to start IceStorm and the weather station(s) from a demo written in a language with full server-side
-support, such as C++, C#, Java, Python, or Swift.
+support (C++, C#, Java, Python, or Swift), for example the [Python Weather demo](../../../python/IceStorm/weather):
+follow the instructions in its README to start IceStorm and a weather station.
 
 In a separate terminal, start the sensor application:
 

--- a/matlab/Glacier2/greeter/README.md
+++ b/matlab/Glacier2/greeter/README.md
@@ -14,7 +14,9 @@ flowchart LR
 ## Building and running the demo
 
 Ice for MATLAB supports only client-side applications. As a result, you first need to start the Glacier2 router and a
-Greeter server implemented in a language with server-side support, such as Python, Java, or C#.
+Greeter server implemented in a language with server-side support (C++, C#, Java, Python, or Swift), for example the
+[Python Glacier2 Greeter demo](../../../python/Glacier2/greeter): follow the instructions in its README to start the
+router and the server.
 
 Then, in the MATLAB console:
 

--- a/matlab/Ice/cancellation/README.md
+++ b/matlab/Ice/cancellation/README.md
@@ -9,8 +9,9 @@ timeouts.
 
 ## Building and running the demo
 
-Ice for MATLAB supports only client-side applications. As a result, you first need to start a server implemented
-in a language with server-side support, such as Python, Java, or C#.
+Ice for MATLAB supports only client-side applications. As a result, you first need to start a Cancellation server
+implemented in a language with server-side support (C++, C#, Java, or Swift), for example the [Java Cancellation
+server](../../../java/Ice/cancellation): follow the instructions in its README to start this server.
 
 Then, in the MATLAB console:
 

--- a/matlab/Ice/cancellation/README.md
+++ b/matlab/Ice/cancellation/README.md
@@ -10,7 +10,7 @@ timeouts.
 ## Building and running the demo
 
 Ice for MATLAB supports only client-side applications. As a result, you first need to start a Cancellation server
-implemented in a language with server-side support (C++, C#, Java, or Swift), for example the [Java Cancellation
+implemented in a language with server-side support (C++, C#, or Java), for example the [Java Cancellation
 server](../../../java/Ice/cancellation): follow the instructions in its README to start this server.
 
 Then, in the MATLAB console:

--- a/matlab/Ice/config/README.md
+++ b/matlab/Ice/config/README.md
@@ -9,7 +9,8 @@ This demo shows how to configure a client application using an Ice configuration
 ## Building and running the demo
 
 Ice for MATLAB supports only client-side applications. As a result, you first need to start a Config server implemented
-in a language with server-side support, such as Python, Java, or C#.
+in a language with server-side support (C++, C#, Java, Python, or Swift), for example the [Python Config
+server](../../../python/Ice/config): follow the instructions in its README to start this server.
 
 Then, in the MATLAB console:
 

--- a/matlab/Ice/context/README.md
+++ b/matlab/Ice/context/README.md
@@ -15,7 +15,8 @@ is free to set any entry in this dictionary.
 ## Building and running the demo
 
 Ice for MATLAB supports only client-side applications. As a result, you first need to start a Context server implemented
-in a language with server-side support, such as Python, Java, or C#.
+in a language with server-side support (C++, C#, Java, Python, or Swift), for example the [Python Context
+server](../../../python/Ice/context): follow the instructions in its README to start this server.
 
 Then, in the MATLAB console:
 

--- a/matlab/Ice/customError/README.md
+++ b/matlab/Ice/customError/README.md
@@ -12,7 +12,8 @@ value--there is naturally no throwing across the network.
 ## Building and running the demo
 
 Ice for MATLAB supports only client-side applications. As a result, you first need to start a Custom Error server
-implemented in a language with server-side support, such as Python, Java, or C#.
+implemented in a language with server-side support (C++, C#, Java, Python, or Swift), for example the [Python Custom
+Error server](../../../python/Ice/customError): follow the instructions in its README to start this server.
 
 Then, in the MATLAB console:
 

--- a/matlab/Ice/inheritance/README.md
+++ b/matlab/Ice/inheritance/README.md
@@ -9,7 +9,8 @@ The Inheritance demo shows how to write a simple filesystem application using in
 ## Building and running the demo
 
 Ice for MATLAB supports only client-side applications. As a result, you first need to start an Inheritance server
-implemented in a language with server-side support, such as Python, Java, or C#.
+implemented in a language with server-side support (C++, C#, Java, Python, or Swift), for example the [Python
+Inheritance server](../../../python/Ice/inheritance): follow the instructions in its README to start this server.
 
 Then, in the MATLAB console:
 

--- a/matlab/Ice/optional/README.md
+++ b/matlab/Ice/optional/README.md
@@ -29,7 +29,8 @@ class AtmosphericConditions
 ## Building and running the demo
 
 Ice for MATLAB supports only client-side applications. As a result, you first need to start an Ice Optional server
-implemented in a language with server-side support, such as Python, Java, or C#.
+implemented in a language with server-side support (C++, C#, Java, Python, or Swift), for example the [Python Optional
+server](../../../python/Ice/optional): follow the instructions in its README to start this server.
 
 You can start either version 1 or version 2 of the server.
 

--- a/matlab/IceDiscovery/greeter/README.md
+++ b/matlab/IceDiscovery/greeter/README.md
@@ -9,7 +9,8 @@ This demo illustrates how to use the IceDiscovery plug-in with Ice for MATLAB.
 ## Building and running the demo
 
 Ice for MATLAB supports only client-side applications. As a result, you first need to start a server implemented in a
-language with server-side support, such as Python, Java, or C#.
+language with server-side support (C++, C#, Java, Python, or Swift), for example the [Python IceDiscovery Greeter
+server](../../../python/IceDiscovery/greeter): follow the instructions in its README to start this server.
 
 You can start either the IceDiscovery Greeter server, or two or more IceDiscovery Replication servers.
 

--- a/matlab/IceGrid/greeter/README.md
+++ b/matlab/IceGrid/greeter/README.md
@@ -22,8 +22,9 @@ flowchart LR
 
 ## Building and running the demo
 
-Ice for MATLAB supports only client-side applications. As a result, you first need to deploy the IceGrid Greeter
-server implemented in a language with server-side support, such as Python, Java, or C#.
+Ice for MATLAB supports only client-side applications. As a result, you first need to deploy the IceGrid Greeter server
+implemented in a language with server-side support (C++, C#, Java, Python, or Swift), for example the [Python IceGrid
+Greeter demo](../../../python/IceGrid/greeter): follow the instructions in its README to deploy this server.
 
 Then, in the MATLAB console:
 

--- a/matlab/IceGrid/locatorDiscovery/README.md
+++ b/matlab/IceGrid/locatorDiscovery/README.md
@@ -9,8 +9,9 @@ LocatorDiscovery plug-in.
 
 ## Building and running the demo
 
-Ice for MATLAB supports only client-side applications. As a result, you first need to deploy the IceGrid
-Greeter server implemented in a language with server-side support, such as Python, Java, or C#.
+Ice for MATLAB supports only client-side applications. As a result, you first need to deploy the IceGrid Greeter server
+implemented in a language with server-side support (C++, C#, Java, Python, or Swift), for example the [Python IceGrid
+Greeter demo](../../../python/IceGrid/greeter): follow the instructions in its README to deploy this server.
 
 Then, in the MATLAB console:
 

--- a/matlab/IceStorm/weather/README.md
+++ b/matlab/IceStorm/weather/README.md
@@ -22,7 +22,8 @@ flowchart LR
 Ice for MATLAB supports only client-side applications, and as a result, we can only implement the sensors in MATLAB.
 
 You first need to start IceStorm and the weather station(s) from a demo written in a language with full server-side
-support, such as C++, Python, Java or C#.
+support (C++, C#, Java, Python, or Swift), for example the [Python Weather demo](../../../python/IceStorm/weather):
+follow the instructions in its README to start IceStorm and a weather station.
 
 Then, in the MATLAB console:
 

--- a/php/Glacier2/greeter/README.md
+++ b/php/Glacier2/greeter/README.md
@@ -14,7 +14,9 @@ flowchart LR
 ## Building and running the demo
 
 Ice for PHP supports only client-side applications. As a result, you first need to start the Glacier2 router and a
-Greeter server implemented in a language with server-side support, such as Python, Java, or C#.
+Greeter server implemented in a language with server-side support (C++, C#, Java, Python, or Swift), for example the
+[Python Glacier2 Greeter demo](../../../python/Glacier2/greeter): follow the instructions in its README to start the
+router and the server.
 
 Then, in a separate window:
 

--- a/php/Ice/config/README.md
+++ b/php/Ice/config/README.md
@@ -8,8 +8,9 @@ This demo shows how to configure a client application using an Ice configuration
 
 ## Building and running the demo
 
-Ice for PHP supports only client-side applications. As a result, you first need to start a Config server implemented
-in a language with server-side support, such as Python, Java, or C#.
+Ice for PHP supports only client-side applications. As a result, you first need to start a Config server implemented in
+a language with server-side support (C++, C#, Java, Python, or Swift), for example the [Python Config
+server](../../../python/Ice/config): follow the instructions in its README to start this server.
 
 Then, in a separate window:
 

--- a/php/Ice/context/README.md
+++ b/php/Ice/context/README.md
@@ -17,8 +17,9 @@ in other languages.
 
 ## Building and running the demo
 
-Ice for PHP supports only client-side applications. As a result, you first need to start a Context server implemented
-in a language with server-side support, such as Python, Java, or C#.
+Ice for PHP supports only client-side applications. As a result, you first need to start a Context server implemented in
+a language with server-side support (C++, C#, Java, Python, or Swift), for example the [Python Context
+server](../../../python/Ice/context): follow the instructions in its README to start this server.
 
 Then, in a separate window:
 

--- a/php/Ice/customError/README.md
+++ b/php/Ice/customError/README.md
@@ -12,7 +12,8 @@ value--there is naturally no throwing across the network.
 ## Building and running the demo
 
 Ice for PHP supports only client-side applications. As a result, you first need to start a Custom Error server
-implemented in a language with server-side support, such as Python, Java, or C#.
+implemented in a language with server-side support (C++, C#, Java, Python, or Swift), for example the [Python Custom
+Error server](../../../python/Ice/customError): follow the instructions in its README to start this server.
 
 Then, in a separate window:
 

--- a/php/Ice/inheritance/README.md
+++ b/php/Ice/inheritance/README.md
@@ -8,8 +8,9 @@ The Inheritance demo shows how to write a simple filesystem application using in
 
 ## Building and running the demo
 
-Ice for PHP supports only client-side applications. As a result, you first need to start a Inheritance server
-implemented in a language with server-side support, such as Python, Java, or C#.
+Ice for PHP supports only client-side applications. As a result, you first need to start an Inheritance server
+implemented in a language with server-side support (C++, C#, Java, Python, or Swift), for example the [Python
+Inheritance server](../../../python/Ice/inheritance): follow the instructions in its README to start this server.
 
 Then, in a separate window:
 

--- a/php/Ice/invocationTimeout/README.md
+++ b/php/Ice/invocationTimeout/README.md
@@ -8,8 +8,9 @@ The Invocation Timeout demo shows how to use invocation timeouts.
 
 ## Building and running the demo
 
-Ice for PHP supports only client-side applications. As a result, you first need to start a Greeter server implemented
-in a language with server-side support, such as Python, Java, or C#.
+Ice for PHP supports only client-side applications. As a result, you first need to start an Invocation Timeout server
+implemented in a language with server-side support (Python or Swift), for example the [Python Invocation Timeout
+server](../../../python/Ice/invocation_timeout): follow the instructions in its README to start this server.
 
 Then, in a separate window:
 

--- a/php/Ice/optional/README.md
+++ b/php/Ice/optional/README.md
@@ -29,7 +29,8 @@ class AtmosphericConditions
 ## Building and running the demo
 
 Ice for PHP supports only client-side applications. As a result, you first need to start an Optional server implemented
-in a language with server-side support, such as `python/Ice/optional`, `java/Ice/optional`, or `csharp/Ice/Optional`.
+in a language with server-side support (C++, C#, Java, Python, or Swift), for example the [Python Optional
+server](../../../python/Ice/optional): follow the instructions in its README to start this server.
 
 You can start either version 1 or version 2 of the server.
 

--- a/php/Ice/registeredCommunicator/README.md
+++ b/php/Ice/registeredCommunicator/README.md
@@ -25,8 +25,9 @@ the communicator and its network connections across multiple requests.
 
 A working **Docker** installation is required for running this demo.
 
-Ice for PHP supports only client-side applications. As a result, you first need to start a Greeter server implemented
-in a language with server-side support, such as Python, Java, or C#.
+Ice for PHP supports only client-side applications. As a result, you first need to start a Greeter server implemented in
+a language with server-side support (C++, C#, Java, Python, or Swift), for example the [Python Greeter
+server](../../../python/Ice/greeter): follow the instructions in its README to start this server.
 
 Then, in a separate window:
 

--- a/php/IceDiscovery/greeter/README.md
+++ b/php/IceDiscovery/greeter/README.md
@@ -8,8 +8,9 @@ This demo illustrates how to use the IceDiscovery plug-in with Ice for PHP.
 
 ## Building and running the demo
 
-Ice for PHP supports only client-side applications. As a result, you first need to start a Greeter server implemented
-in a language with server-side support, such as Python, Java, or C#.
+Ice for PHP supports only client-side applications. As a result, you first need to start a Greeter server implemented in
+a language with server-side support (C++, C#, Java, Python, or Swift), for example the [Python IceDiscovery Greeter
+server](../../../python/IceDiscovery/greeter): follow the instructions in its README to start this server.
 
 Then, in a separate window:
 

--- a/php/IceGrid/greeter/README.md
+++ b/php/IceGrid/greeter/README.md
@@ -22,8 +22,9 @@ flowchart LR
 
 ## Building and running the demo
 
-Ice for PHP supports only client-side applications. As a result, you first need to deploy the IceGrid Greeter
-server implemented in a language with server-side support, such as Python, Java, or C#.
+Ice for PHP supports only client-side applications. As a result, you first need to deploy the IceGrid Greeter server
+implemented in a language with server-side support (C++, C#, Java, Python, or Swift), for example the [Python IceGrid
+Greeter demo](../../../python/IceGrid/greeter): follow the instructions in its README to deploy this server.
 
 Then, in a new window:
 

--- a/php/IceGrid/locatorDiscovery/README.md
+++ b/php/IceGrid/locatorDiscovery/README.md
@@ -9,8 +9,9 @@ LocatorDiscovery plug-in.
 
 ## Building and running the demo
 
-Ice for PHP supports only client-side applications. As a result, you first need to deploy the IceGrid
-Greeter server implemented in a language with server-side support, such as Python, Java, or C#.
+Ice for PHP supports only client-side applications. As a result, you first need to deploy the IceGrid Greeter server
+implemented in a language with server-side support (C++, C#, Java, Python, or Swift), for example the [Python IceGrid
+Greeter demo](../../../python/IceGrid/greeter): follow the instructions in its README to deploy this server.
 
 Then, in a new window:
 

--- a/php/IceStorm/weather/README.md
+++ b/php/IceStorm/weather/README.md
@@ -22,7 +22,8 @@ flowchart LR
 Ice for PHP supports only client-side applications, and as a result, we can only implement the sensors in PHP.
 
 You first need to start IceStorm and the weather station(s) from a demo written in a language with full server-side
-support, such as C++, Python, Java or C#.
+support (C++, C#, Java, Python, or Swift), for example the [Python Weather demo](../../../python/IceStorm/weather):
+follow the instructions in its README to start IceStorm and a weather station.
 
 Then, in a separate window:
 

--- a/ruby/Glacier2/greeter/README.md
+++ b/ruby/Glacier2/greeter/README.md
@@ -14,7 +14,9 @@ flowchart LR
 ## Building and running the demo
 
 Ice for Ruby supports only client-side applications. As a result, you first need to start the Glacier2 router and a
-Greeter server implemented in a language with server-side support, such as Python, Java, or C#.
+Greeter server implemented in a language with server-side support (C++, C#, Java, Python, or Swift), for example the
+[Python Glacier2 Greeter demo](../../../python/Glacier2/greeter): follow the instructions in its README to start the
+router and the server.
 
 Then, in a separate window:
 

--- a/ruby/Ice/config/README.md
+++ b/ruby/Ice/config/README.md
@@ -9,7 +9,8 @@ This demo shows how to configure a client application using an Ice configuration
 ## Building and running the demo
 
 Ice for Ruby supports only client-side applications. As a result, you first need to start a Config server implemented
-in a language with server-side support, such as Python, Java, or C#.
+in a language with server-side support (C++, C#, Java, Python, or Swift), for example the
+[Python Config server](../../../python/Ice/config): follow the instructions in its README to start this server.
 
 Then, in a separate window:
 

--- a/ruby/Ice/context/README.md
+++ b/ruby/Ice/context/README.md
@@ -15,7 +15,8 @@ is free to set any entry in this dictionary.
 ## Building and running the demo
 
 Ice for Ruby supports only client-side applications. As a result, you first need to start a Context server implemented
-in a language with server-side support, such as Python, Java, or C#.
+in a language with server-side support (C++, C#, Java, Python, or Swift), for example the [Python Context
+server](../../../python/Ice/context): follow the instructions in its README to start this server.
 
 Then, in a separate window:
 

--- a/ruby/Ice/customError/README.md
+++ b/ruby/Ice/customError/README.md
@@ -11,8 +11,9 @@ value--there is naturally no throwing across the network.
 
 ## Building and running the demo
 
-Ice for Ruby supports only client-side applications. As a result, you first need to start a Greeter server implemented
-in a language with server-side support, such as Python, Java, or C#.
+Ice for Ruby supports only client-side applications. As a result, you first need to start a Custom Error server
+implemented in a language with server-side support (C++, C#, Java, Python, or Swift), for example the [Python Custom
+Error server](../../../python/Ice/customError): follow the instructions in its README to start this server.
 
 Then, in a separate window:
 

--- a/ruby/Ice/inheritance/README.md
+++ b/ruby/Ice/inheritance/README.md
@@ -9,7 +9,8 @@ The Inheritance demo shows how to write a simple filesystem application using in
 ## Building and running the demo
 
 Ice for Ruby supports only client-side applications. As a result, you first need to start an Inheritance server
-implemented in a language with server-side support, such as Python, Java, or C#.
+implemented in a language with server-side support (C++, C#, Java, Python, or Swift), for example the [Python
+Inheritance server](../../../python/Ice/inheritance): follow the instructions in its README to start this server.
 
 Then, in a separate window:
 

--- a/ruby/Ice/invocationTimeout/README.md
+++ b/ruby/Ice/invocationTimeout/README.md
@@ -8,8 +8,9 @@ This demo demonstrates how to set a timeout period for a client as well as how t
 
 ## Building and running the demo
 
-Ice for Ruby supports only client-side applications. As a result, you first need to start an InvocationTimeout server
-implemented in a language with server-side support, such as Python, Java, or C#.
+Ice for Ruby supports only client-side applications. As a result, you first need to start an Invocation Timeout server
+implemented in a language with server-side support (Python or Swift), for example the [Python Invocation Timeout
+server](../../../python/Ice/invocation_timeout): follow the instructions in its README to start this server.
 
 Then, in a separate window:
 

--- a/ruby/Ice/optional/README.md
+++ b/ruby/Ice/optional/README.md
@@ -29,7 +29,8 @@ class AtmosphericConditions
 ## Building and running the demo
 
 Ice for Ruby supports only client-side applications. As a result, you first need to start an Ice Optional server
-implemented in a language with server-side support, such as Python, Java, or C#.
+implemented in a language with server-side support (C++, C#, Java, Python, or Swift), for example the [Python Optional
+server](../../../python/Ice/optional): follow the instructions in its README to start this server.
 
 You can start either version 1 or version 2 of the server from the corresponding language directory (e.g.,
 `cpp/Ice/optional`, `python/Ice/optional`, etc.).

--- a/ruby/IceDiscovery/greeter/README.md
+++ b/ruby/IceDiscovery/greeter/README.md
@@ -8,8 +8,10 @@ This demo illustrates how to use the IceDiscovery plug-in with Ice for Ruby.
 
 ## Building and running the demo
 
-Ice for Ruby supports only client-side applications. As a result, you first need to start an IceDiscovery Greeter server implemented
-in a language with server-side support, such as Python, Java, or C#.
+Ice for Ruby supports only client-side applications. As a result, you first need to start an IceDiscovery Greeter server
+implemented in a language with server-side support (C++, C#, Java, Python, or Swift), for example the [Python
+IceDiscovery Greeter server](../../../python/IceDiscovery/greeter): follow the instructions in its README to start this
+server.
 
 Then, in a separate window:
 

--- a/ruby/IceGrid/greeter/README.md
+++ b/ruby/IceGrid/greeter/README.md
@@ -22,8 +22,9 @@ flowchart LR
 
 ## Building and running the demo
 
-Ice for Ruby supports only client-side applications. As a result, you first need to deploy the IceGrid Greeter
-server implemented in a language with server-side support, such as Python, Java, or C#.
+Ice for Ruby supports only client-side applications. As a result, you first need to deploy the IceGrid Greeter server
+implemented in a language with server-side support (C++, C#, Java, Python, or Swift), for example the [Python IceGrid
+Greeter demo](../../../python/IceGrid/greeter): follow the instructions in its README to deploy this server.
 
 Then, in a separate window:
 

--- a/ruby/IceGrid/locatorDiscovery/README.md
+++ b/ruby/IceGrid/locatorDiscovery/README.md
@@ -9,8 +9,9 @@ LocatorDiscovery plug-in.
 
 ## Building and running the demo
 
-Ice for Ruby supports only client-side applications. As a result, you first need to deploy the IceGrid
-Greeter server implemented in a language with server-side support, such as Python, Java, or C#.
+Ice for Ruby supports only client-side applications. As a result, you first need to deploy the IceGrid Greeter server
+implemented in a language with server-side support (C++, C#, Java, Python, or Swift), for example the [Python IceGrid
+Greeter demo](../../../python/IceGrid/greeter): follow the instructions in its README to deploy this server.
 
 Then, in a separate window:
 

--- a/ruby/IceStorm/weather/README.md
+++ b/ruby/IceStorm/weather/README.md
@@ -22,7 +22,8 @@ flowchart LR
 Ice for Ruby supports only client-side applications, and as a result, we can only implement the sensors in Ruby.
 
 You first need to start IceStorm and the weather station(s) from a demo written in a language with full server-side
-support, such as C++, Python, Java or C#.
+support (C++, C#, Java, Python, or Swift), for example the [Python Weather demo](../../../python/IceStorm/weather):
+follow the instructions in its README to start IceStorm and a weather station.
 
 Then, in a separate window:
 


### PR DESCRIPTION
Addresses the main part of #809 — the 45 prerequisite sections. The related README nits from the issue (NEW-L17: cd-vs-prose mixing, Ruby heading drift, docker-compose spelling, MATLAB IceDiscovery pointer, pre-existing bare URLs) are deliberately left for a follow-up PR, so this PR does NOT close the issue.

All 45 client-only demo READMEs (11 MATLAB, 12 PHP, 11 Ruby, 9 JS, plus `java/Ice/android-greeter` and `js/Ice/react-greeter`) told the user a server must already be running "in a language with server-side support, such as Python, Java, or C#" — without naming a specific counterpart demo, linking it, or telling the user how to start it.

Each README now:

- lists the **languages that actually provide the counterpart** (all five for most demos; `(C++, C#, Java, or Swift)` for cancellation, which has no Python port; `(Python or Swift)` for invocationTimeout);
- links a **canonical example** — Python first, Java for the two cancellation clients, and the same-tree Java server for the Android greeter — deferring build/start commands to that demo's own README (link-only, no duplicated instructions to rot).

The sentence shape adapts per prerequisite kind: plain server, Glacier2 router + server, IceGrid deployment, IceStorm + weather station.

In-passing fixes inside the rewritten sentences: `js/Ice/react-greeter` said "Config server" where it needs a Greeter server; `php/Ice/inheritance` "a Inheritance" → "an"; `java/Ice/android-greeter` "in one of languages" grammar.

Verified: every relative link target exists (case-sensitive check against git); markdownlint reports nothing new (two pre-existing bare-URL MD034s elsewhere in touched files are left for the follow-up nits PR); each replacement matched its README exactly once.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

