### PR TITLE
Ignore VS Code Java tooling output in the java tree

### DIFF
--- a/java/build-logic/.gitignore
+++ b/java/build-logic/.gitignore
@@ -2,3 +2,4 @@
 bin
 build
 .gradle
+.kotlin

--- a/java/util/.gitignore
+++ b/java/util/.gitignore
@@ -1,2 +1,3 @@
 .gradle
+bin
 build


### PR DESCRIPTION
Fixes #835.

The demos are standalone, copyable units, each carrying its own `.gitignore` — so the fix adds the missing entries to the two affected projects' own files rather than introducing tree-level common configuration:

- `java/build-logic/.gitignore`: adds `.kotlin` (Kotlin tooling error reports written during Gradle builds)
- `java/util/.gitignore`: adds `bin` (the Java language server's class output; the demo projects' `.gitignore`s already have it)

Verified with `git check-ignore` against both real junk paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
