### PR TITLE
Use catch-where clauses in Swift Middleware and Glacier2 Session clients

### DIFF
--- a/swift/Glacier2/Session/Sources/Client/main.swift
+++ b/swift/Glacier2/Session/Sources/Client/main.swift
@@ -96,11 +96,9 @@ do {
     // The pokeBox proxy no longer works as it was created with the token of an old session.
     _ = try await pokeBox.getInventory()
     print("Error: the PokeBox proxy should not work with a new session!")
-} catch let error as Ice.DispatchException {
-    if error.replyStatus == ReplyStatus.unauthorized.rawValue {
-        // See code in SharedPokeBox.getUserId.
-        print("The PokeBox proxy remains unusable, as expected.")
-    } else {
-        throw error
-    }
+} catch let error as Ice.DispatchException
+    where error.replyStatus == ReplyStatus.unauthorized.rawValue
+{
+    // See code in SharedPokeBox.getUserId.
+    print("The PokeBox proxy remains unusable, as expected.")
 }

--- a/swift/Ice/Middleware/Sources/Client/main.swift
+++ b/swift/Ice/Middleware/Sources/Client/main.swift
@@ -24,12 +24,11 @@ let validToken = "iced tea"
 do {
     let unexpected = try await greeter.greet(NSUserName(), context: ["token": "pineapple"])
     print("Received unexpected greeting: \(unexpected)")
-} catch let error as DispatchException {
-    // An Unauthorized error is expected with an invalid (or missing) token; rethrow anything else.
+} catch let error as DispatchException
+    where error.replyStatus == ReplyStatus.unauthorized.rawValue
+{
+    // An Unauthorized error is expected with an invalid (or missing) token; any other error propagates to the caller.
     // See AuthorizationMiddleware.
-    if error.replyStatus != ReplyStatus.unauthorized.rawValue {
-        throw error
-    }
 }
 
 // Send a request with the correct token in the request context.


### PR DESCRIPTION
Simplifies the expected-error handling in two Swift demo clients by replacing catch blocks that test the reply status and rethrow with `catch ... where` clauses:

- **Ice/Middleware client**: the catch now matches only the expected `unauthorized` reply status; any other error propagates naturally instead of being rethrown explicitly.
- **Glacier2/Session client**: same pattern for the expired-session check on `getInventory`.

Behavior is unchanged. Both demos build cleanly and pass `swift format lint`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)