### PR TITLE
Ignore auto-generated .vscode/launch.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 # MacOS Finder index
 .DS_STORE
+
+# Auto-generated VS Code launch configurations
+.vscode/launch.json


### PR DESCRIPTION
The Swift VS Code extension auto-generates `.vscode/launch.json` entries for whichever Swift demo packages a developer opens, so the file is per-developer and churns constantly. This adds it to `.gitignore` so it no longer shows up as untracked noise. The shared `.vscode` files (`settings.json`, `extensions.json`, `cspell.json`) remain tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)