### PR TITLE
Add copilot-setup-steps.yml to provision the Copilot coding agent

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,48 @@
+name: Copilot Setup Steps
+
+# This workflow provisions the environment for the GitHub Copilot coding agent.
+# The job must be named `copilot-setup-steps` for Copilot to pick it up.
+# It mirrors the toolchain setup used by the Linux jobs in ci.yml.
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+  pull_request:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+
+permissions:
+  contents: read
+
+jobs:
+  copilot-setup-steps:
+    # Use a dedicated GitHub-hosted larger runner rather than the shared
+    # `ubuntu-*` pool, which is sometimes exhausted and leaves the Copilot
+    # agent waiting for a runner. GitHub Actions has no availability-based
+    # fallback (a `runs-on` array is AND-matched, not OR), so we pin the
+    # custom runner directly.
+    runs-on: linux-latest-copilot
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup .NET 8
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+        with:
+          dotnet-version: 8.x
+
+      - name: Setup Node.js
+        uses: ./.github/actions/setup-node
+
+      - name: Setup Java
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
+        with:
+          distribution: "oracle"
+          java-version: "17"
+
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+
+      - name: Install Nightly Ice Builds
+        uses: ./.github/actions/install-nightly-ice


### PR DESCRIPTION
Copies the `copilot-setup-steps.yml` workflow from the ice repository so the Copilot coding agent provisions its environment on the dedicated `linux-latest-copilot` runner instead of the shared `ubuntu-*` pool, which is sometimes exhausted and leaves the agent waiting.

The setup steps themselves had to be adapted: ice's `setup-cpp`/`setup-php`/`setup-python` composite actions don't exist here, so the job now mirrors the `ubuntu-24.04` leg of `ci.yml` — .NET 8, Node, Java 17, and the nightly Ice packages, which also bring in the Slice compilers that the C++ demos need. It adds uv on top of that, since the Python demos are driven through `uv run`. PHP, Ruby, MATLAB, and Swift get no toolchain because none of them have a Linux CI job to mirror. Third-party actions are SHA-pinned with version comments to match the rest of this repo, so the existing Dependabot `github-actions` group picks the file up with no config change.