### PR TITLE
Fix assorted README nits in client-only demos

### DIFF
--- a/js/Ice/react-greeter/README.md
+++ b/js/Ice/react-greeter/README.md
@@ -36,4 +36,4 @@ In a separate terminal, start the client application:
 npm run dev
 ```
 
-Open a web browser and navigate to http://localhost:5173 (or the URL shown in the terminal).
+Open a web browser and navigate to <http://localhost:5173> (or the URL shown in the terminal).

--- a/matlab/Glacier2/greeter/README.md
+++ b/matlab/Glacier2/greeter/README.md
@@ -20,7 +20,7 @@ router and the server.
 
 Then, in the MATLAB console:
 
-- Go to the Glacier2/greeter directory
+- Go to the matlab/Glacier2/greeter directory
 
 ```shell
 cd matlab/Glacier2/greeter

--- a/matlab/Ice/cancellation/README.md
+++ b/matlab/Ice/cancellation/README.md
@@ -15,7 +15,7 @@ server](../../../java/Ice/cancellation): follow the instructions in its README t
 
 Then, in the MATLAB console:
 
-- Go to the Ice/cancellation directory
+- Go to the matlab/Ice/cancellation directory
 
 ```shell
 cd matlab/Ice/cancellation

--- a/matlab/Ice/config/README.md
+++ b/matlab/Ice/config/README.md
@@ -14,7 +14,7 @@ server](../../../python/Ice/config): follow the instructions in its README to st
 
 Then, in the MATLAB console:
 
-- Go to the Ice/config directory
+- Go to the matlab/Ice/config directory
 
 ```shell
 cd matlab/Ice/config

--- a/matlab/Ice/context/README.md
+++ b/matlab/Ice/context/README.md
@@ -20,7 +20,7 @@ server](../../../python/Ice/context): follow the instructions in its README to s
 
 Then, in the MATLAB console:
 
-- Go to the Ice/context directory
+- Go to the matlab/Ice/context directory
 
 ```shell
 cd matlab/Ice/context

--- a/matlab/Ice/customError/README.md
+++ b/matlab/Ice/customError/README.md
@@ -17,7 +17,7 @@ Error server](../../../python/Ice/customError): follow the instructions in its R
 
 Then, in the MATLAB console:
 
-- Go to the Ice/customError directory
+- Go to the matlab/Ice/customError directory
 
 ```shell
 cd matlab/Ice/customError

--- a/matlab/Ice/greeter/README.md
+++ b/matlab/Ice/greeter/README.md
@@ -8,7 +8,7 @@ The Greeter demo illustrates how to write a client application with Ice for MATL
 
 ## Building and running the demo
 
-- Go to the Ice/greeter directory
+- Go to the matlab/Ice/greeter directory
 
 ```shell
 cd matlab/Ice/greeter

--- a/matlab/Ice/inheritance/README.md
+++ b/matlab/Ice/inheritance/README.md
@@ -14,7 +14,7 @@ Inheritance server](../../../python/Ice/inheritance): follow the instructions in
 
 Then, in the MATLAB console:
 
-- Go to the Ice/inheritance directory
+- Go to the matlab/Ice/inheritance directory
 
 ```shell
 cd matlab/Ice/inheritance

--- a/matlab/Ice/optional/README.md
+++ b/matlab/Ice/optional/README.md
@@ -36,7 +36,7 @@ You can start either version 1 or version 2 of the server.
 
 Then, in the MATLAB console:
 
-- Go to the Ice/optional/client1 or client2 directory
+- Go to the matlab/Ice/optional/client1 or client2 directory
 
 ```shell
 cd matlab/Ice/optional/client1

--- a/matlab/IceDiscovery/greeter/README.md
+++ b/matlab/IceDiscovery/greeter/README.md
@@ -12,11 +12,9 @@ Ice for MATLAB supports only client-side applications. As a result, you first ne
 language with server-side support (C++, C#, Java, Python, or Swift), for example the [Python IceDiscovery Greeter
 server](../../../python/IceDiscovery/greeter): follow the instructions in its README to start this server.
 
-You can start either the IceDiscovery Greeter server, or two or more IceDiscovery Replication servers.
-
 Then, in the MATLAB console:
 
-- Go to the IceDiscovery/greeter directory
+- Go to the matlab/IceDiscovery/greeter directory
 
 ```shell
 cd matlab/IceDiscovery/greeter

--- a/matlab/IceGrid/greeter/README.md
+++ b/matlab/IceGrid/greeter/README.md
@@ -28,7 +28,7 @@ Greeter demo](../../../python/IceGrid/greeter): follow the instructions in its R
 
 Then, in the MATLAB console:
 
-- Go to the IceGrid/greeter directory
+- Go to the matlab/IceGrid/greeter directory
 
 ```shell
 cd matlab/IceGrid/greeter

--- a/matlab/IceGrid/locatorDiscovery/README.md
+++ b/matlab/IceGrid/locatorDiscovery/README.md
@@ -15,7 +15,7 @@ Greeter demo](../../../python/IceGrid/greeter): follow the instructions in its R
 
 Then, in the MATLAB console:
 
-- Go to the IceGrid/locatorDiscovery directory
+- Go to the matlab/IceGrid/locatorDiscovery directory
 
 ```shell
 cd matlab/IceGrid/locatorDiscovery

--- a/matlab/IceStorm/weather/README.md
+++ b/matlab/IceStorm/weather/README.md
@@ -27,7 +27,7 @@ follow the instructions in its README to start IceStorm and a weather station.
 
 Then, in the MATLAB console:
 
-- Go to the IceStorm/weather directory
+- Go to the matlab/IceStorm/weather directory
 
 ```shell
 cd matlab/IceStorm/weather

--- a/php/Glacier2/greeter/README.md
+++ b/php/Glacier2/greeter/README.md
@@ -20,12 +20,6 @@ router and the server.
 
 Then, in a separate window:
 
-- Go to the Glacier2/greeter directory
-
-```shell
-cd php/Glacier2/greeter
-```
-
 - Compile the Greeter.ice file with the Slice compiler for PHP
 
 ```shell

--- a/php/Ice/optional/README.md
+++ b/php/Ice/optional/README.md
@@ -36,16 +36,16 @@ You can start either version 1 or version 2 of the server.
 
 Then, in a separate window:
 
-- Go to the Ice/optional/client1 or client2 directory
+- Go to the client1 or client2 directory
 
 ```shell
-cd php/Ice/optional/client1
+cd client1
 ```
 
 or
 
 ```shell
-cd php/Ice/optional/client2
+cd client2
 ```
 
 - Compile the WeatherStation.ice file with the Slice compiler for PHP

--- a/php/Ice/registeredCommunicator/README.md
+++ b/php/Ice/registeredCommunicator/README.md
@@ -41,11 +41,11 @@ Then, in a separate window:
 - Run the web server using Docker Compose
 
   ```shell
-  docker-compose up
+  docker compose up
   ```
 
 - Open your Web Browser
-  Navigate to: http://localhost:8080
+  Navigate to: <http://localhost:8080>
 
 > [!NOTE]
 > Passing `--Ice.Trace.Network` command-line option to the server turns on Network tracing. For this demo, it shows you

--- a/php/IceGrid/greeter/README.md
+++ b/php/IceGrid/greeter/README.md
@@ -28,12 +28,6 @@ Greeter demo](../../../python/IceGrid/greeter): follow the instructions in its R
 
 Then, in a new window:
 
-- Go to the IceGrid/greeter directory
-
-```shell
-cd php/IceGrid/greeter
-```
-
 - Compile the Greeter.ice file with the Slice compiler for PHP
 
 ```shell

--- a/php/IceGrid/locatorDiscovery/README.md
+++ b/php/IceGrid/locatorDiscovery/README.md
@@ -15,12 +15,6 @@ Greeter demo](../../../python/IceGrid/greeter): follow the instructions in its R
 
 Then, in a new window:
 
-- Go to the IceGrid/locatorDiscovery directory
-
-```shell
-cd php/IceGrid/locatorDiscovery
-```
-
 - Compile the Greeter.ice file with the Slice compiler for PHP
 
 ```shell

--- a/php/IceStorm/weather/README.md
+++ b/php/IceStorm/weather/README.md
@@ -27,12 +27,6 @@ follow the instructions in its README to start IceStorm and a weather station.
 
 Then, in a separate window:
 
-- Go to the IceStorm/weather directory
-
-```shell
-cd php/IceStorm/weather
-```
-
 - Compile the WeatherStation.ice file with the Slice compiler for PHP
 
 ```shell

--- a/ruby/Ice/context/README.md
+++ b/ruby/Ice/context/README.md
@@ -1,4 +1,4 @@
-# Context
+# Ice Context
 
 The Context demo shows the 3 different ways to set a request context in a client.
 

--- a/ruby/Ice/inheritance/README.md
+++ b/ruby/Ice/inheritance/README.md
@@ -1,4 +1,4 @@
-# Inheritance
+# Ice Inheritance
 
 The Inheritance demo shows how to write a simple filesystem application using interface inheritance.
 

--- a/ruby/Ice/invocationTimeout/README.md
+++ b/ruby/Ice/invocationTimeout/README.md
@@ -1,4 +1,4 @@
-# InvocationTimeout
+# Ice Invocation Timeout
 
 This demo demonstrates how to set a timeout period for a client as well as how to catch a timeout exception.
 

--- a/ruby/Ice/optional/README.md
+++ b/ruby/Ice/optional/README.md
@@ -32,21 +32,20 @@ Ice for Ruby supports only client-side applications. As a result, you first need
 implemented in a language with server-side support (C++, C#, Java, Python, or Swift), for example the [Python Optional
 server](../../../python/Ice/optional): follow the instructions in its README to start this server.
 
-You can start either version 1 or version 2 of the server from the corresponding language directory (e.g.,
-`cpp/Ice/optional`, `python/Ice/optional`, etc.).
+You can start either version 1 or version 2 of the server.
 
-Once you have a server running, you can run the Ruby clients:
+Then, in a separate window:
 
 - Go to the client1 or client2 directory:
 
 ```shell
-cd ruby/Ice/optional/client1
+cd client1
 ```
 
 or
 
 ```shell
-cd ruby/Ice/optional/client2
+cd client2
 ```
 
 - Compile the WeatherStation.ice file with the Slice compiler for Ruby:


### PR DESCRIPTION
This PR fixes the remaining README nits from #809 (the prerequisite-server instructions were addressed in #834, the `.gitignore` entries in #836):

- **MATLAB (12 READMEs)**: the "Go to the ... directory" prose now names the same path as the `cd` command below it (e.g. "Go to the matlab/Ice/config directory"). MATLAB keeps its `cd` steps since the MATLAB console starts in an arbitrary directory; the defect was only the prose/command path mismatch.
- **PHP (4 READMEs)**: removed the "Go to the X directory" + `cd php/X` step from Glacier2/greeter, IceGrid/greeter, IceGrid/locatorDiscovery, and IceStorm/weather, matching the seven sibling PHP READMEs that omit it.
- **php/Ice/optional and ruby/Ice/optional**: these need a client1-vs-client2 choice, so the step stays but becomes demo-relative (`cd client1` / `cd client2`); also aligned ruby's divergent surrounding prose with the php/matlab wording.
- **Ruby headings**: `# Ice Context`, `# Ice Inheritance`, `# Ice Invocation Timeout` — matching the ruby TOC and the convention used by the other languages.
- **matlab/IceDiscovery/greeter**: dropped the "two or more IceDiscovery Replication servers" sentence — there is no MATLAB Replication demo to link, and the other client-only languages don't mention it.
- **php/Ice/registeredCommunicator**: `docker compose up` (the `docker-compose` spelling is deprecated) and `<http://localhost:8080>`; **js/Ice/react-greeter**: `<http://localhost:5173>` (the two MD034 bare URLs, see also #841).

Note: the "a Inheritance server" typo flagged in #809 was already fixed by #834.

Fixes #809.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
