### PR TITLE
Add a v1/v2 compatibility matrix to the Optional demo READMEs

### DIFF
--- a/cpp/Ice/optional/README.md
+++ b/cpp/Ice/optional/README.md
@@ -97,6 +97,11 @@ and
 build\client2
 ```
 
-Thanks to `optional`, version 1 and version 2 of the clients and servers interoperate seamlessly.
+Thanks to `optional`, version 1 and version 2 of the clients and servers interoperate seamlessly:
+
+|               | Server v1                                            | Server v2                          |
+|---------------|------------------------------------------------------|------------------------------------|
+| **Client v1** | The reading has no pressure field.                   | The reading's pressure is not set. |
+| **Client v2** | The server ignores the pressure sent by the client.  | The reading includes the pressure. |
 
 [Ice for C++ installation]: https://github.com/zeroc-ice/ice/blob/main/NIGHTLY.md#ice-for-c

--- a/csharp/Ice/Optional/README.md
+++ b/csharp/Ice/Optional/README.md
@@ -63,4 +63,9 @@ cd Client2
 dotnet run
 ```
 
-Thanks to `optional`, version 1 and version 2 of the clients and servers interoperate seamlessly.
+Thanks to `optional`, version 1 and version 2 of the clients and servers interoperate seamlessly:
+
+|               | Server v1                                            | Server v2                          |
+|---------------|------------------------------------------------------|------------------------------------|
+| **Client v1** | The reading has no pressure field.                   | The reading's pressure is not set. |
+| **Client v2** | The server ignores the pressure sent by the client.  | The reading includes the pressure. |

--- a/java/Ice/optional/README.md
+++ b/java/Ice/optional/README.md
@@ -63,4 +63,11 @@ and
 ./gradlew :client2:run --quiet
 ```
 
+Thanks to `optional`, version 1 and version 2 of the clients and servers interoperate seamlessly:
+
+|               | Server v1                                            | Server v2                          |
+|---------------|------------------------------------------------------|------------------------------------|
+| **Client v1** | The reading has no pressure field.                   | The reading's pressure is not set. |
+| **Client v2** | The server ignores the pressure sent by the client.  | The reading includes the pressure. |
+
 [Application plugin]: https://docs.gradle.org/current/userguide/application_plugin.html

--- a/js/Ice/optional/README.md
+++ b/js/Ice/optional/README.md
@@ -61,4 +61,9 @@ Next, navigate to the client2 directory and run version 2 of the client:
 node client.js
 ```
 
-Thanks to `optional`, version 1 and version 2 of the clients and servers interoperate seamlessly.
+Thanks to `optional`, version 1 and version 2 of the clients and servers interoperate seamlessly:
+
+|               | Server v1                                            | Server v2                          |
+|---------------|------------------------------------------------------|------------------------------------|
+| **Client v1** | The reading has no pressure field.                   | The reading's pressure is not set. |
+| **Client v2** | The server ignores the pressure sent by the client.  | The reading includes the pressure. |

--- a/matlab/Ice/optional/README.md
+++ b/matlab/Ice/optional/README.md
@@ -60,6 +60,11 @@ slice2matlab WeatherStation.ice
 client
 ```
 
-Thanks to `optional`, version 1 and version 2 of the clients and servers interoperate seamlessly.
+Thanks to `optional`, version 1 and version 2 of the clients and servers interoperate seamlessly:
+
+|               | Server v1                                            | Server v2                          |
+|---------------|------------------------------------------------------|------------------------------------|
+| **Client v1** | The reading has no pressure field.                   | The reading's pressure is not set. |
+| **Client v2** | The server ignores the pressure sent by the client.  | The reading includes the pressure. |
 
 [Ice for MATLAB installation]: https://github.com/zeroc-ice/ice/blob/main/NIGHTLY.md#ice-for-matlab

--- a/php/Ice/optional/README.md
+++ b/php/Ice/optional/README.md
@@ -60,6 +60,11 @@ slice2php WeatherStation.ice
 php Client.php
 ```
 
-Thanks to `optional`, version 1 and version 2 of the clients and servers interoperate seamlessly.
+Thanks to `optional`, version 1 and version 2 of the clients and servers interoperate seamlessly:
+
+|               | Server v1                                            | Server v2                          |
+|---------------|------------------------------------------------------|------------------------------------|
+| **Client v1** | The reading has no pressure field.                   | The reading's pressure is not set. |
+| **Client v2** | The server ignores the pressure sent by the client.  | The reading includes the pressure. |
 
 [Ice for PHP installation]: https://github.com/zeroc-ice/ice/blob/main/NIGHTLY.md#ice-for-php

--- a/python/Ice/optional/README.md
+++ b/python/Ice/optional/README.md
@@ -79,6 +79,11 @@ Use the Slice-to-Python compiler to generate Python code from the appropriate Sl
 uv run main.py
 ```
 
-Thanks to the `optional` keyword, version 1 and version 2 of the clients and servers interoperate seamlessly.
+Thanks to the `optional` keyword, version 1 and version 2 of the clients and servers interoperate seamlessly:
+
+|               | Server v1                                            | Server v2                          |
+|---------------|------------------------------------------------------|------------------------------------|
+| **Client v1** | The reading has no pressure field.                   | The reading's pressure is not set. |
+| **Client v2** | The server ignores the pressure sent by the client.  | The reading includes the pressure. |
 
 [Installing uv]: https://docs.astral.sh/uv/getting-started/installation/

--- a/ruby/Ice/optional/README.md
+++ b/ruby/Ice/optional/README.md
@@ -60,6 +60,11 @@ slice2rb WeatherStation.ice
 ruby client.rb
 ```
 
-Thanks to `optional`, version 1 and version 2 of the clients and servers interoperate seamlessly.
+Thanks to `optional`, version 1 and version 2 of the clients and servers interoperate seamlessly:
+
+|               | Server v1                                            | Server v2                          |
+|---------------|------------------------------------------------------|------------------------------------|
+| **Client v1** | The reading has no pressure field.                   | The reading's pressure is not set. |
+| **Client v2** | The server ignores the pressure sent by the client.  | The reading includes the pressure. |
 
 [Ice for Ruby installation]: https://github.com/zeroc-ice/ice/blob/main/NIGHTLY.md#ice-for-ruby

--- a/swift/Ice/Optional/README.md
+++ b/swift/Ice/Optional/README.md
@@ -56,4 +56,9 @@ and
 swift run Client2
 ```
 
-Thanks to `optional`, version 1 and version 2 of the clients and servers interoperate seamlessly.
+Thanks to `optional`, version 1 and version 2 of the clients and servers interoperate seamlessly:
+
+|               | Server v1                                            | Server v2                          |
+|---------------|------------------------------------------------------|------------------------------------|
+| **Client v1** | The reading has no pressure field.                   | The reading's pressure is not set. |
+| **Client v2** | The server ignores the pressure sent by the client.  | The reading includes the pressure. |


### PR DESCRIPTION
This PR adds a compact compatibility matrix to the Optional demo READMEs, showing what happens to the pressure reading in each Client v1/v2 × Server v1/v2 combination:

|               | Server v1                                            | Server v2                          |
|---------------|------------------------------------------------------|------------------------------------|
| **Client v1** | The reading has no pressure field.                   | The reading's pressure is not set. |
| **Client v2** | The server ignores the pressure sent by the client.  | The reading includes the pressure. |

The existing closing sentence ("Thanks to `optional`, version 1 and version 2 of the clients and servers interoperate seamlessly.") becomes the intro for the table.

Notes:

- #845 lists six languages, but cpp, php, and js have the identical demo, so all nine Optional READMEs get the same table.
- `java/Ice/optional` was missing the closing sentence entirely; it gains both the sentence and the table.
- Behavior verified with the Python demo — all four combinations produce exactly what the table says (e.g. server1 prints the v2 client's reading without pressure; server2 prints `pressure=None` for the v1 client).

Fixes #845.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
