### PR TITLE
Explain the hosted hello.zeroc.com default in client-only Greeter READMEs

### DIFF
--- a/js/Ice/greeter/README.md
+++ b/js/Ice/greeter/README.md
@@ -26,5 +26,7 @@ node client.js
 ```
 
 > [!NOTE]
-> Ice for JavaScript has limited server-side support. In this demo, we connect to a Greeter server implemented in a
-> language with full server-side support, such as C++, C#, Java, Python, or Swift.
+> Ice for JavaScript has limited server-side support. By default, the client connects to a Greeter server hosted by
+> ZeroC at `hello.zeroc.com`; as a result, you don't need to start a Greeter server to run this demo. If you want to
+> use your own Greeter server (implemented in a language with full server-side support, such as C++, C#, Java, Python,
+> or Swift), replace `hello.zeroc.com` with `localhost` in the proxy string in `client.ts`.

--- a/js/Ice/greeter/README.md
+++ b/js/Ice/greeter/README.md
@@ -29,4 +29,5 @@ node client.js
 > Ice for JavaScript has limited server-side support. By default, the client connects to a Greeter server hosted by
 > ZeroC at `hello.zeroc.com`; as a result, you don't need to start a Greeter server to run this demo. If you want to
 > use your own Greeter server (implemented in a language with full server-side support, such as C++, C#, Java, Python,
-> or Swift), replace `hello.zeroc.com` with `localhost` in the proxy string in `client.ts`.
+> or Swift), edit the proxy string in `client.ts`: replace `hello.zeroc.com` with `localhost` for a server running on
+> the same computer, or with the server's hostname or IP address for a server running on another computer.

--- a/matlab/Ice/greeter/README.md
+++ b/matlab/Ice/greeter/README.md
@@ -30,6 +30,7 @@ client
 > Ice for MATLAB supports only client-side applications. By default, the client connects to a Greeter server hosted by
 > ZeroC at `hello.zeroc.com`; as a result, you don't need to start a Greeter server to run this demo. If you want to
 > use your own Greeter server (implemented in a language with server-side support, such as C++, C#, Java, Python, or
-> Swift), replace `hello.zeroc.com` with `localhost` in the proxy string in `client.m`.
+> Swift), edit the proxy string in `client.m`: replace `hello.zeroc.com` with `localhost` for a server running on the
+> same computer, or with the server's hostname or IP address for a server running on another computer.
 
 [Ice for MATLAB installation]: https://github.com/zeroc-ice/ice/blob/main/NIGHTLY.md#ice-for-matlab

--- a/matlab/Ice/greeter/README.md
+++ b/matlab/Ice/greeter/README.md
@@ -27,7 +27,9 @@ client
 ```
 
 > [!NOTE]
-> Ice for MATLAB supports only client-side applications. In this demo, we connect to a Greeter server implemented in a
-> language with server-side support, such as C++, C#, Java, Python, or Swift.
+> Ice for MATLAB supports only client-side applications. By default, the client connects to a Greeter server hosted by
+> ZeroC at `hello.zeroc.com`; as a result, you don't need to start a Greeter server to run this demo. If you want to
+> use your own Greeter server (implemented in a language with server-side support, such as C++, C#, Java, Python, or
+> Swift), replace `hello.zeroc.com` with `localhost` in the proxy string in `client.m`.
 
 [Ice for MATLAB installation]: https://github.com/zeroc-ice/ice/blob/main/NIGHTLY.md#ice-for-matlab

--- a/php/Ice/greeter/README.md
+++ b/php/Ice/greeter/README.md
@@ -21,7 +21,9 @@ php Client.php
 ```
 
 > [!NOTE]
-> Ice for PHP supports only client-side applications. In this demo, we connect to a Greeter server implemented in a
-> language with server-side support, such as C++, C#, Java, Python, or Swift.
+> Ice for PHP supports only client-side applications. By default, the client connects to a Greeter server hosted by
+> ZeroC at `hello.zeroc.com`; as a result, you don't need to start a Greeter server to run this demo. If you want to
+> use your own Greeter server (implemented in a language with server-side support, such as C++, C#, Java, Python, or
+> Swift), replace `hello.zeroc.com` with `localhost` in the proxy string in `Client.php`.
 
 [Ice for PHP installation]: https://github.com/zeroc-ice/ice/blob/main/NIGHTLY.md#ice-for-php

--- a/php/Ice/greeter/README.md
+++ b/php/Ice/greeter/README.md
@@ -24,6 +24,7 @@ php Client.php
 > Ice for PHP supports only client-side applications. By default, the client connects to a Greeter server hosted by
 > ZeroC at `hello.zeroc.com`; as a result, you don't need to start a Greeter server to run this demo. If you want to
 > use your own Greeter server (implemented in a language with server-side support, such as C++, C#, Java, Python, or
-> Swift), replace `hello.zeroc.com` with `localhost` in the proxy string in `Client.php`.
+> Swift), edit the proxy string in `Client.php`: replace `hello.zeroc.com` with `localhost` for a server running on the
+> same computer, or with the server's hostname or IP address for a server running on another computer.
 
 [Ice for PHP installation]: https://github.com/zeroc-ice/ice/blob/main/NIGHTLY.md#ice-for-php

--- a/ruby/Ice/greeter/README.md
+++ b/ruby/Ice/greeter/README.md
@@ -24,6 +24,7 @@ ruby client.rb
 > Ice for Ruby supports only client-side applications. By default, the client connects to a Greeter server hosted by
 > ZeroC at `hello.zeroc.com`; as a result, you don't need to start a Greeter server to run this demo. If you want to
 > use your own Greeter server (implemented in a language with server-side support, such as C++, C#, Java, Python, or
-> Swift), replace `hello.zeroc.com` with `localhost` in the proxy string in `client.rb`.
+> Swift), edit the proxy string in `client.rb`: replace `hello.zeroc.com` with `localhost` for a server running on the
+> same computer, or with the server's hostname or IP address for a server running on another computer.
 
 [Ice for Ruby installation]: https://github.com/zeroc-ice/ice/blob/main/NIGHTLY.md#ice-for-ruby

--- a/ruby/Ice/greeter/README.md
+++ b/ruby/Ice/greeter/README.md
@@ -21,7 +21,9 @@ ruby client.rb
 ```
 
 > [!NOTE]
-> Ice for Ruby supports only client-side applications. In this demo, we connect to a Greeter server implemented in a
-> language with server-side support, such as C++, C#, Java, Python, or Swift.
+> Ice for Ruby supports only client-side applications. By default, the client connects to a Greeter server hosted by
+> ZeroC at `hello.zeroc.com`; as a result, you don't need to start a Greeter server to run this demo. If you want to
+> use your own Greeter server (implemented in a language with server-side support, such as C++, C#, Java, Python, or
+> Swift), replace `hello.zeroc.com` with `localhost` in the proxy string in `client.rb`.
 
 [Ice for Ruby installation]: https://github.com/zeroc-ice/ice/blob/main/NIGHTLY.md#ice-for-ruby


### PR DESCRIPTION
The js, matlab, php, and ruby Greeter clients connect by default to the Greeter server hosted by ZeroC at `hello.zeroc.com`, but their READMEs didn't say so — a reader could think they must first start a server, when the demo works out of the box.

This PR extends the existing `> [!NOTE]` block in each README:

> Ice for PHP supports only client-side applications. By default, the client connects to a Greeter server hosted by ZeroC at `hello.zeroc.com`; as a result, you don't need to start a Greeter server to run this demo. If you want to use your own Greeter server (implemented in a language with server-side support, such as C++, C#, Java, Python, or Swift), replace `hello.zeroc.com` with `localhost` in the proxy string in `Client.php`.

The four files get the same wording, varying only the language name and the client file name (`client.ts`, `client.m`, `Client.php`, `client.rb`). The "replace hello.zeroc.com" instruction matches the comment already present in each client's source.

Verified against the hosted server: the js client, built and run with no local server, prints the greeting.

Fixes #847.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
