### PR TITLE
Say where to run service commands with relative paths

### DIFF
--- a/cpp/DataStorm/node/README.md
+++ b/cpp/DataStorm/node/README.md
@@ -35,7 +35,7 @@ cmake --build build
 
 ## Running the demo
 
-To run the demo, start a DataStorm node:
+To run the demo, start a DataStorm node from this demo's directory:
 
 ```shell
 dsnode --Ice.Config=node.conf

--- a/cpp/Glacier2/callback/README.md
+++ b/cpp/Glacier2/callback/README.md
@@ -57,7 +57,7 @@ cmake --build build
    build\server
    ```
 
-2. Start the Glacier2 router in its own terminal:
+2. Start the Glacier2 router in its own terminal, from this demo's directory:
 
    ```shell
    glacier2router --Ice.Config=glacier2.conf

--- a/cpp/Glacier2/greeter/README.md
+++ b/cpp/Glacier2/greeter/README.md
@@ -54,7 +54,7 @@ cmake --build build
    build\server
    ```
 
-2. Start the Glacier2 router in its own terminal:
+2. Start the Glacier2 router in its own terminal, from this demo's directory:
 
    ```shell
    glacier2router --Ice.Config=glacier2.conf

--- a/cpp/Glacier2/session/README.md
+++ b/cpp/Glacier2/session/README.md
@@ -59,7 +59,7 @@ cmake --build build
    build\server
    ```
 
-2. Start the Glacier2 router in its own terminal:
+2. Start the Glacier2 router in its own terminal, from this demo's directory:
 
    ```shell
    glacier2router --Ice.Config=glacier2.conf

--- a/cpp/IceBox/greeter/README.md
+++ b/cpp/IceBox/greeter/README.md
@@ -34,7 +34,7 @@ cmake --build build
 
 ## Running the demo
 
-To run this demo, open two terminal windows. In the first window:
+To run this demo, open two terminal windows in this demo's directory. In the first window:
 
 **Linux/macOS:**
 

--- a/cpp/IceGrid/greeter/README.md
+++ b/cpp/IceGrid/greeter/README.md
@@ -46,19 +46,19 @@ cmake --build build
 
 ## Running the demo
 
-1. Start the IceGrid registry in its own terminal:
+1. Start the IceGrid registry in its own terminal, from this demo's directory:
 
    ```shell
    icegridregistry --Ice.Config=registry.conf
    ```
 
-2. Start the IceGrid node in its own terminal:
+2. Start the IceGrid node in its own terminal, from this demo's directory:
 
    ```shell
    icegridnode --Ice.Config=node.conf
    ```
 
-3. Deploy the "GreeterHall" application in this IceGrid deployment:
+3. From this demo's directory, deploy the "GreeterHall" application in this IceGrid deployment:
 
    ```shell
    icegridadmin --Ice.Config=admin.conf -e "application add greeter-hall.xml"

--- a/cpp/IceGrid/icebox/README.md
+++ b/cpp/IceGrid/icebox/README.md
@@ -32,19 +32,19 @@ cmake --build build
 
 ## Running the demo
 
-1. Start the IceGrid registry in its own terminal:
+1. Start the IceGrid registry in its own terminal, from this demo's directory:
 
    ```shell
    icegridregistry --Ice.Config=registry.conf
    ```
 
-2. Start the IceGrid node in its own terminal:
+2. Start the IceGrid node in its own terminal, from this demo's directory:
 
    ```shell
    icegridnode --Ice.Config=node.conf
    ```
 
-3. Deploy the "GreeterHall" application in this IceGrid deployment:
+3. From this demo's directory, deploy the "GreeterHall" application in this IceGrid deployment:
 
    **Linux/macOS:**
 

--- a/cpp/IceGrid/query/README.md
+++ b/cpp/IceGrid/query/README.md
@@ -32,19 +32,19 @@ cmake --build build
 
 ## Running the demo
 
-1. Start the IceGrid registry in its own terminal:
+1. Start the IceGrid registry in its own terminal, from this demo's directory:
 
    ```shell
    icegridregistry --Ice.Config=registry.conf
    ```
 
-2. Start the IceGrid node in its own terminal:
+2. Start the IceGrid node in its own terminal, from this demo's directory:
 
    ```shell
    icegridnode --Ice.Config=node.conf
    ```
 
-3. Deploy the "GreeterHall" application in this IceGrid deployment:
+3. From this demo's directory, deploy the "GreeterHall" application in this IceGrid deployment:
 
    ```shell
    icegridadmin --Ice.Config=admin.conf -e "application add greeter-hall.xml"

--- a/cpp/IceStorm/weather/README.md
+++ b/cpp/IceStorm/weather/README.md
@@ -43,7 +43,7 @@ cmake --build build
 
 ## Running the demo
 
-1. Start the IceStorm service in its own terminal:
+1. Start the IceStorm service in its own terminal, from this demo's directory:
 
    ```shell
    icebox --IceBox.Service.IceStorm="IceStormService,39a0:createIceStorm --Ice.Config=icestorm.conf"

--- a/csharp/Glacier2/Callback/README.md
+++ b/csharp/Glacier2/Callback/README.md
@@ -34,7 +34,7 @@ cd Server
 dotnet run
 ```
 
-Then, start the Glacier2 router in its own terminal:
+Then, start the Glacier2 router in its own terminal, from this demo's directory:
 
 ```shell
 glacier2router --Ice.Config=glacier2.conf

--- a/csharp/Glacier2/Greeter/README.md
+++ b/csharp/Glacier2/Greeter/README.md
@@ -31,7 +31,7 @@ cd Server
 dotnet run
 ```
 
-Then, start the Glacier2 router in its own terminal:
+Then, start the Glacier2 router in its own terminal, from this demo's directory:
 
 ```shell
 glacier2router --Ice.Config=glacier2.conf

--- a/csharp/Glacier2/Session/README.md
+++ b/csharp/Glacier2/Session/README.md
@@ -36,7 +36,7 @@ cd Server
 dotnet run
 ```
 
-Then, start the Glacier2 router in its own terminal:
+Then, start the Glacier2 router in its own terminal, from this demo's directory:
 
 ```shell
 glacier2router --Ice.Config=glacier2.conf

--- a/csharp/IceBox/Greeter/README.md
+++ b/csharp/IceBox/Greeter/README.md
@@ -21,7 +21,7 @@ dotnet build
 
 ## Running the demo
 
-First, start the iceboxnet server:
+First, start the iceboxnet server from this demo's directory:
 
 ```shell
 dotnet iceboxnet --IceBox.Service.Greeter="Service/bin/Debug/net8.0/GreeterService.dll:Service.GreeterService --Ice.Trace.Dispatch"

--- a/csharp/IceGrid/Greeter/README.md
+++ b/csharp/IceGrid/Greeter/README.md
@@ -30,19 +30,19 @@ dotnet build
 
 ## Running the demo
 
-First, start the IceGrid registry in its own terminal:
+First, start the IceGrid registry in its own terminal, from this demo's directory:
 
 ```shell
 icegridregistry --Ice.Config=registry.conf
 ```
 
-Then, start the IceGrid node in its own terminal:
+Then, start the IceGrid node in its own terminal, from this demo's directory:
 
 ```shell
 icegridnode --Ice.Config=node.conf
 ```
 
-Next, deploy the "GreeterHall" application in this IceGrid deployment:
+From this demo's directory, deploy the "GreeterHall" application in this IceGrid deployment:
 
 ```shell
 icegridadmin --Ice.Config=admin.conf -e "application add greeter-hall.xml"

--- a/csharp/IceGrid/IceBox/README.md
+++ b/csharp/IceGrid/IceBox/README.md
@@ -22,19 +22,19 @@ dotnet build
 
 ## Running the demo
 
-Start the IceGrid registry in its own terminal:
+Start the IceGrid registry in its own terminal, from this demo's directory:
 
 ```shell
 icegridregistry --Ice.Config=registry.conf
 ```
 
-Next, start the IceGrid node in its own terminal:
+Next, start the IceGrid node in its own terminal, from this demo's directory:
 
 ```shell
 icegridnode --Ice.Config=node.conf
 ```
 
-Deploy the "GreeterHall" application in this IceGrid deployment:
+From this demo's directory, deploy the "GreeterHall" application in this IceGrid deployment:
 
 ```shell
 icegridadmin --Ice.Config=admin.conf -e "application add greeter-hall.xml"

--- a/csharp/IceGrid/Query/README.md
+++ b/csharp/IceGrid/Query/README.md
@@ -16,19 +16,19 @@ dotnet build
 
 ## Running the demo
 
-First, start the IceGrid registry in its own terminal:
+First, start the IceGrid registry in its own terminal, from this demo's directory:
 
 ```shell
 icegridregistry --Ice.Config=registry.conf
 ```
 
-Then, start the IceGrid node in its own terminal:
+Then, start the IceGrid node in its own terminal, from this demo's directory:
 
 ```shell
 icegridnode --Ice.Config=node.conf
 ```
 
-Next, deploy the "GreeterHall" application in this IceGrid deployment:
+From this demo's directory, deploy the "GreeterHall" application in this IceGrid deployment:
 
 ```shell
 icegridadmin --Ice.Config=admin.conf -e "application add greeter-hall.xml"

--- a/csharp/IceStorm/Weather/README.md
+++ b/csharp/IceStorm/Weather/README.md
@@ -27,7 +27,7 @@ dotnet build
 
 ## Running the demo
 
-First, run the IceStorm service in its own terminal:
+First, run the IceStorm service in its own terminal, from this demo's directory:
 
 ```shell
 icebox --IceBox.Service.IceStorm="IceStormService,39a0:createIceStorm --Ice.Config=icestorm.conf"

--- a/java/Glacier2/callback/README.md
+++ b/java/Glacier2/callback/README.md
@@ -35,7 +35,7 @@ Start the Server program in its own terminal:
 ./gradlew :server:run --quiet
 ```
 
-Next, start the Glacier2 router in its own terminal:
+Next, start the Glacier2 router in its own terminal, from this demo's directory:
 
 ```shell
 glacier2router --Ice.Config=glacier2.conf

--- a/java/Glacier2/greeter/README.md
+++ b/java/Glacier2/greeter/README.md
@@ -32,7 +32,7 @@ Start the Server program in its own terminal:
 ./gradlew :server:run --quiet
 ```
 
-Next, start the Glacier2 router in its own terminal:
+Next, start the Glacier2 router in its own terminal, from this demo's directory:
 
 ```shell
 glacier2router --Ice.Config=glacier2.conf

--- a/java/Glacier2/session/README.md
+++ b/java/Glacier2/session/README.md
@@ -37,7 +37,7 @@ Start the Server program in its own terminal:
 ./gradlew :server:run --quiet
 ```
 
-Next, start the Glacier2 router in its own terminal:
+Next, start the Glacier2 router in its own terminal, from this demo's directory:
 
 ```shell
 glacier2router --Ice.Config=glacier2.conf

--- a/java/IceGrid/greeter/README.md
+++ b/java/IceGrid/greeter/README.md
@@ -41,19 +41,19 @@ directory. This ensures both the server JAR and its dependencies (such as Ice) a
 
 ## Running the demo
 
-First, start the IceGrid registry in its own terminal:
+First, start the IceGrid registry in its own terminal, from this demo's directory:
 
 ```shell
 icegridregistry --Ice.Config=registry.conf
 ```
 
-Then, start the IceGrid node in its own terminal:
+Then, start the IceGrid node in its own terminal, from this demo's directory:
 
 ```shell
 icegridnode --Ice.Config=node.conf
 ```
 
-Next, deploy the "GreeterHall" application in this IceGrid deployment:
+From this demo's directory, deploy the "GreeterHall" application in this IceGrid deployment:
 
 ```shell
 icegridadmin --Ice.Config=admin.conf -e "application add greeter-hall.xml"

--- a/java/IceGrid/icebox/README.md
+++ b/java/IceGrid/icebox/README.md
@@ -34,19 +34,19 @@ directory. This ensures both the server JAR and its dependencies (such as Ice) a
 
 ## Running the demo
 
-First, start the IceGrid registry in its own terminal:
+First, start the IceGrid registry in its own terminal, from this demo's directory:
 
 ```shell
 icegridregistry --Ice.Config=registry.conf
 ```
 
-Then, start the IceGrid node in its own terminal:
+Then, start the IceGrid node in its own terminal, from this demo's directory:
 
 ```shell
 icegridnode --Ice.Config=node.conf
 ```
 
-Next, deploy the "GreeterHall" application in this IceGrid deployment:
+From this demo's directory, deploy the "GreeterHall" application in this IceGrid deployment:
 
 ```shell
 icegridadmin --Ice.Config=admin.conf -e "application add greeter-hall.xml"

--- a/java/IceGrid/query/README.md
+++ b/java/IceGrid/query/README.md
@@ -27,19 +27,19 @@ directory. This ensures both the server JAR and its dependencies (such as Ice) a
 
 ## Running the demo
 
-First, start the IceGrid registry in its own terminal:
+First, start the IceGrid registry in its own terminal, from this demo's directory:
 
 ```shell
 icegridregistry --Ice.Config=registry.conf
 ```
 
-Then, start the IceGrid node in its own terminal:
+Then, start the IceGrid node in its own terminal, from this demo's directory:
 
 ```shell
 icegridnode --Ice.Config=node.conf
 ```
 
-Next, deploy the "GreeterHall" application in this IceGrid deployment:
+From this demo's directory, deploy the "GreeterHall" application in this IceGrid deployment:
 
 ```shell
 icegridadmin --Ice.Config=admin.conf -e "application add greeter-hall.xml"

--- a/java/IceStorm/weather/README.md
+++ b/java/IceStorm/weather/README.md
@@ -29,7 +29,7 @@ To build the demo, run:
 
 ## Running the demo
 
-First, run the IceStorm service in its own terminal:
+First, run the IceStorm service in its own terminal, from this demo's directory:
 
 ```shell
 icebox --IceBox.Service.IceStorm="IceStormService,39a0:createIceStorm --Ice.Config=icestorm.conf"

--- a/python/Glacier2/callback/README.md
+++ b/python/Glacier2/callback/README.md
@@ -38,7 +38,7 @@ uv run main.py
 
 ### 3. Start the Glacier2 router
 
-In a separate terminal, navigate to the demo directory (`python/Glacier2/callback`) and run:
+Start a new terminal, navigate to the demo directory (`python/Glacier2/callback`), and run:
 
 ```shell
 glacier2router --Ice.Config=glacier2.conf

--- a/python/Glacier2/greeter/README.md
+++ b/python/Glacier2/greeter/README.md
@@ -35,7 +35,7 @@ uv run main.py
 
 ### 3. Start the Glacier2 router
 
-In a separate terminal, navigate to the demo directory (`python/Glacier2/greeter`) and run:
+Start a new terminal, navigate to the demo directory (`python/Glacier2/greeter`), and run:
 
 ```shell
 glacier2router --Ice.Config=glacier2.conf

--- a/python/Glacier2/session/README.md
+++ b/python/Glacier2/session/README.md
@@ -40,7 +40,7 @@ uv run main.py
 
 ### 3. Start the Glacier2 router
 
-In a separate terminal, run:
+Start a new terminal, navigate to the demo directory (`python/Glacier2/session`), and run:
 
 ```shell
 glacier2router --Ice.Config=glacier2.conf

--- a/python/IceGrid/greeter/README.md
+++ b/python/IceGrid/greeter/README.md
@@ -34,7 +34,7 @@ uv run slice2py ../slice/Greeter.ice
 
 ### 2. Start the IceGrid registry
 
-In a separate terminal, navigate to the demo directory (`python/IceGrid/greeter`) and run:
+Start a new terminal, navigate to the demo directory (`python/IceGrid/greeter`), and run:
 
 ```shell
 icegridregistry --Ice.Config=registry.conf
@@ -42,7 +42,7 @@ icegridregistry --Ice.Config=registry.conf
 
 ### 3. Start the IceGrid node
 
-In another terminal, navigate to the demo directory (`python/IceGrid/greeter`), then activate the virtual environment
+Start a new terminal, navigate to the demo directory (`python/IceGrid/greeter`), then activate the virtual environment
 and start the node:
 
 #### macOS and Linux
@@ -65,7 +65,7 @@ icegridnode --Ice.Config=node.conf
 
 ### 4. Deploy the Greeter application
 
-In a separate terminal, navigate to the demo directory (`python/IceGrid/greeter`) and use the IceGrid admin tool to
+Start a new terminal, navigate to the demo directory (`python/IceGrid/greeter`), and use the IceGrid admin tool to
 deploy the configuration:
 
 ```shell

--- a/python/IceStorm/weather/README.md
+++ b/python/IceStorm/weather/README.md
@@ -20,7 +20,7 @@ flowchart LR
 
 ## Start IceStorm service
 
-Run the IceStorm service in its own terminal:
+Start a new terminal, navigate to the demo directory (`python/IceStorm/weather`), and run the IceStorm service:
 
 ```shell
 icebox --IceBox.Service.IceStorm="IceStormService,39a0:createIceStorm --Ice.Config=icestorm.conf"

--- a/swift/Glacier2/Callback/README.md
+++ b/swift/Glacier2/Callback/README.md
@@ -33,7 +33,7 @@ First, start the Server program in its own terminal:
 swift run Server
 ```
 
-Then, start the Glacier2 router in its own terminal:
+Then, start the Glacier2 router in its own terminal, from this demo's directory:
 
 ```shell
 glacier2router --Ice.Config=glacier2.conf

--- a/swift/Glacier2/Greeter/README.md
+++ b/swift/Glacier2/Greeter/README.md
@@ -30,7 +30,7 @@ First, start the Server program in its own terminal:
 swift run Server
 ```
 
-Then, start the Glacier2 router in its own terminal:
+Then, start the Glacier2 router in its own terminal, from this demo's directory:
 
 ```shell
 glacier2router --Ice.Config=glacier2.conf

--- a/swift/Glacier2/Session/README.md
+++ b/swift/Glacier2/Session/README.md
@@ -33,7 +33,7 @@ a connection to the server, because the server is on a separate network.
    swift run Server
    ```
 
-3. Start the Glacier2 router in its own terminal:
+3. Start the Glacier2 router in its own terminal, from this demo's directory:
 
    ```shell
    glacier2router --Ice.Config=glacier2.conf

--- a/swift/IceGrid/Greeter/README.md
+++ b/swift/IceGrid/Greeter/README.md
@@ -30,19 +30,19 @@ swift build
 
 ## Running the demo
 
-First, start the IceGrid registry in its own terminal:
+First, start the IceGrid registry in its own terminal, from this demo's directory:
 
 ```shell
 icegridregistry --Ice.Config=registry.conf
 ```
 
-Then, start the IceGrid node in its own terminal:
+Then, start the IceGrid node in its own terminal, from this demo's directory:
 
 ```shell
 icegridnode --Ice.Config=node.conf
 ```
 
-Next, deploy the "GreeterHall" application in this IceGrid deployment:
+From this demo's directory, deploy the "GreeterHall" application in this IceGrid deployment:
 
 ```shell
 icegridadmin --Ice.Config=admin.conf -e "application add greeter-hall.xml"

--- a/swift/IceGrid/Query/README.md
+++ b/swift/IceGrid/Query/README.md
@@ -16,19 +16,19 @@ swift build
 
 ## Running the demo
 
-First, start the IceGrid registry in its own terminal:
+First, start the IceGrid registry in its own terminal, from this demo's directory:
 
 ```shell
 icegridregistry --Ice.Config=registry.conf
 ```
 
-Then, start the IceGrid node in its own terminal:
+Then, start the IceGrid node in its own terminal, from this demo's directory:
 
 ```shell
 icegridnode --Ice.Config=node.conf
 ```
 
-Next, deploy the "GreeterHall" application in this IceGrid deployment:
+From this demo's directory, deploy the "GreeterHall" application in this IceGrid deployment:
 
 ```shell
 icegridadmin --Ice.Config=admin.conf -e "application add greeter-hall.xml"

--- a/swift/IceStorm/Weather/README.md
+++ b/swift/IceStorm/Weather/README.md
@@ -27,7 +27,7 @@ swift build
 
 ## Running the demo
 
-First, run the IceStorm service in its own terminal:
+First, run the IceStorm service in its own terminal, from this demo's directory:
 
 ```shell
 icebox --IceBox.Service.IceStorm="IceStormService,39a0:createIceStorm --Ice.Config=icestorm.conf"


### PR DESCRIPTION
The `glacier2router`, `icegridregistry`, `icegridnode`, `icegridadmin`, `icebox`, `iceboxnet`, and `dsnode` commands in the demo READMEs read their configuration files (or load their services) using paths relative to the current working directory — but most instructions didn't say where to run them, and a config-not-found failure from the wrong directory is confusing.

This PR puts the guidance directly on each service step (59 single-line changes, no new sections or notes):

- **cpp, csharp, java, swift** (30 READMEs): "Start the Glacier2 router in its own terminal:" → "Start the Glacier2 router in its own terminal, from this demo's directory:"; the IceGrid deploy step reads "From this demo's directory, deploy the "GreeterHall" application in this IceGrid deployment:". The IceBox demos are included because `icebox`/`iceboxnet` load the service from a relative path (`./build/GreeterService`, `Service/bin/Debug/net8.0/GreeterService.dll`).
- **python** (5 READMEs): all service steps now use the uniform phrasing "Start a new terminal, navigate to the demo directory (`...`), and run ...". Two had no directory guidance at all: `python/Glacier2/session` ("In a separate terminal, run:") and `python/IceStorm/weather`.

Not annotated, deliberately: plain server/client steps whose relative paths are visible in the command itself (`./build/server`, `cd Server` + `dotnet run`, `swift run Client`, `./gradlew :client:run`), and `java/IceBox/greeter`, which runs IceBox via `./gradlew` with the service loaded from the classpath. The LocatorDiscovery demos run only the client and defer the services to the IceGrid greeter README.

Fixes #849.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
