### PR TITLE
Add a CI check that fails before the test certificates expire

### DIFF
--- a/.github/workflows/certs.yml
+++ b/.github/workflows/certs.yml
@@ -1,0 +1,55 @@
+name: Certificates
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: ["main"]
+    paths:
+      - "certs/**"
+      - ".github/workflows/certs.yml"
+  schedule:
+    - cron: "0 6 * * 1" # Run weekly on Monday at 6am UTC
+
+permissions:
+  contents: read
+
+env:
+  # Fail this many days before a certificate actually expires, so there is time to sync the
+  # refreshed certificates from the ice repository.
+  EXPIRY_WARNING_DAYS: 30
+
+jobs:
+  expiry:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Check test certificate expiry
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+
+          # The .der and .p12 files hold the same three certificates as the .pem files, so
+          # checking the PEMs covers the whole directory.
+          certs=(certs/*_cert.pem)
+          if [ ${#certs[@]} -eq 0 ]; then
+            echo "::error::no certificates found in certs/ - did the layout change?"
+            exit 1
+          fi
+
+          status=0
+          for cert in "${certs[@]}"; do
+            expiry=$(openssl x509 -enddate -noout -in "$cert" | cut -d= -f2)
+            if openssl x509 -checkend $((EXPIRY_WARNING_DAYS * 86400)) -noout -in "$cert" > /dev/null; then
+              echo "ok: $cert expires $expiry"
+            else
+              echo "::error file=$cert::expires $expiry, within $EXPIRY_WARNING_DAYS days"
+              status=1
+            fi
+          done
+
+          if [ $status -ne 0 ]; then
+            echo "::notice::refresh certs/ by copying certs/common/ca from the ice repository (see certs/README.md)"
+          fi
+          exit $status


### PR DESCRIPTION
The certificates in `certs/` expired on June 25, 2026 and nothing noticed for six weeks (#865). CI builds the demos
but never runs one, so an expired certificate cannot fail any existing job.

This adds a `Certificates` workflow that runs `openssl x509 -checkend` over `certs/*_cert.pem` and fails **30 days
before** the earliest expiry. Failing early is the point: a check that only notices after the fact tells us at the
same time as the first user, whereas 30 days is enough to sync the refreshed files from `ice/certs/common/ca`.

## Design notes

- **Weekly schedule plus a `paths` filter on pull requests.** Expiry is a function of time, not of commits, so the
  scheduled run is the one that matters — the June 25 expiry fell in a quiet stretch. The PR trigger only fires for
  changes under `certs/` (or to this workflow), so it adds no noise to unrelated PRs. Modelled on
  `devcontainer.yml`, which already uses this shape.
- **Three PEM files cover every certificate in the directory.** The certificates inside `ca.p12` / `client.p12` /
  `server.p12` have SHA-256 fingerprints identical to the matching `*_cert.pem`, and `ca_cert.der` is the DER form
  of `ca_cert.pem`. There is nothing extra to check by cracking open the other formats. (The `.jks` keystores that
  used to live here went away in #866.)
- **An empty glob fails.** If the files are ever renamed or moved, the loop body would never run and the job would
  pass green while checking nothing. The explicit count guard turns that into a loud failure instead.

## Verified

Ran the workflow's `run:` block verbatim against fixtures built from this repository's certificates before and after
#865:

| fixture | result |
| --- | --- |
| `certs/` before #865 (expired 2026-06-25) | exit 1, one `::error` annotation per certificate |
| `certs/` as it is on `main` today (expires 2027-07-28) | exit 0 |
| a `certs/` directory with no `*_cert.pem` | exit 1, "did the layout change?" |

Threshold semantics checked in both directions against the refreshed certificates, which are ~352 days out: a
400-day threshold trips, a 300-day threshold does not. `actionlint` (which shellchecks `run:` blocks) is clean.

## Scope

Addresses the certificate-expiry half of #867. That issue also asks for CI to run an SSL demo end-to-end, which is a
much larger piece of work with its own history — leaving #867 open for it rather than closing it here.
