### PR TITLE
Run the Java Greeter demos via installDist launchers

### DIFF
--- a/java/Ice/greeter/README.md
+++ b/java/Ice/greeter/README.md
@@ -9,6 +9,9 @@ This demo provides two implementations for the server:
 
 The same client works with both.
 
+> [!NOTE]
+> On Windows, run all the commands below in Git Bash or PowerShell; they don't work in the cmd.exe Command Prompt.
+
 ## Building the demo
 
 The demo has three Gradle projects, **client**, **server**, and **serveramd**, all using the [application plugin].
@@ -16,27 +19,30 @@ The demo has three Gradle projects, **client**, **server**, and **serveramd**, a
 To build the demo, run:
 
 ```shell
-./gradlew build
+./gradlew installDist
 ```
+
+This creates a self-contained distribution under build/install/ for each application, with launcher scripts in its
+bin/ directory.
 
 ## Running the demo
 
 First, start one of the server applications:
 
 ```shell
-./gradlew :server:run --quiet
+./server/build/install/server/bin/server
 ```
 
 or
 
 ```shell
-./gradlew :serveramd:run --quiet
+./serveramd/build/install/serveramd/bin/serveramd
 ```
 
 Then, in a separate terminal, start the client application:
 
 ```shell
-./gradlew :client:run --quiet
+./client/build/install/client/bin/client
 ```
 
 [Application plugin]: https://docs.gradle.org/current/userguide/application_plugin.html

--- a/java/IceGrid/greeter/README.md
+++ b/java/IceGrid/greeter/README.md
@@ -16,6 +16,10 @@ flowchart LR
     Client ==> |greet request| Server
 ```
 
+> [!NOTE]
+> On Windows, run all the commands below in Git Bash or PowerShell; not all of them work in the cmd.exe Command
+> Prompt.
+
 ## Ice prerequisites
 
 - Install IceGrid. See [Ice service installation].
@@ -72,7 +76,7 @@ icegridadmin --Ice.Config=admin.conf -e "application add greeter-hall-with-repli
 Finally, run the client application:
 
 ```shell
-./gradlew :client:run --quiet
+./client/build/install/client/bin/client
 ```
 
 [Application plugin]: https://docs.gradle.org/current/userguide/application_plugin.html


### PR DESCRIPTION
Implements the proposal in #868 for the Java `Ice/greeter` and `IceGrid/greeter` demos.

- `Ice/greeter`: build with `./gradlew installDist` and run the applications via the generated launcher scripts instead of `gradlew run`.
- `IceGrid/greeter`: run the client via its launcher script (the build already used `installDist`).
- Instead of separate Linux/macOS and Windows command flavors, each README keeps a single set of commands with a note telling Windows users to run them in Git Bash or PowerShell.

Both demos were tested on Windows (PowerShell and Git Bash) and the commands work as documented, including clean Ctrl+C shutdown of the servers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)