### PR TITLE
Run all Java demos via installDist launchers

### DIFF
--- a/java/Glacier2/callback/README.md
+++ b/java/Glacier2/callback/README.md
@@ -13,6 +13,10 @@ flowchart LR
     g --connection1--> s[Server:4061<br>hosts WakeUpService] --connection2--> g
 ```
 
+> [!NOTE]
+> On Windows, run all the commands below in Git Bash or PowerShell; not all of them work in the cmd.exe Command
+> Prompt.
+
 ## Ice prerequisites
 
 - Install Glacier2. See [Ice service installation].
@@ -24,15 +28,18 @@ The demo has two Gradle projects, **client** and **server**, both using the [app
 To build the demo, run:
 
 ```shell
-./gradlew build
+./gradlew installDist
 ```
+
+This creates a self-contained distribution under build/install/ for each application, with launcher scripts in its
+bin/ directory.
 
 ## Running the demo
 
 Start the Server program in its own terminal:
 
 ```shell
-./gradlew :server:run --quiet
+./server/build/install/server/bin/server
 ```
 
 Next, start the Glacier2 router in its own terminal, from this demo's directory:
@@ -48,7 +55,7 @@ glacier2router --Ice.Config=glacier2.conf
 Finally, in a separate terminal, start the client application:
 
 ```shell
-./gradlew :client:run --quiet
+./client/build/install/client/bin/client
 ```
 
 [Application plugin]: https://docs.gradle.org/current/userguide/application_plugin.html

--- a/java/Glacier2/greeter/README.md
+++ b/java/Glacier2/greeter/README.md
@@ -10,6 +10,10 @@ flowchart LR
 In a typical Glacier2 deployment, the client can establish a connection to the Glacier2 router but cannot establish
 a connection to the server, because the server is on a separate network.
 
+> [!NOTE]
+> On Windows, run all the commands below in Git Bash or PowerShell; not all of them work in the cmd.exe Command
+> Prompt.
+
 ## Ice prerequisites
 
 - Install Glacier2. See [Ice service installation].
@@ -21,15 +25,18 @@ The demo has two Gradle projects, **client** and **server**, both using the [app
 To build the demo, run:
 
 ```shell
-./gradlew build
+./gradlew installDist
 ```
+
+This creates a self-contained distribution under build/install/ for each application, with launcher scripts in its
+bin/ directory.
 
 ## Running the demo
 
 Start the Server program in its own terminal:
 
 ```shell
-./gradlew :server:run --quiet
+./server/build/install/server/bin/server
 ```
 
 Next, start the Glacier2 router in its own terminal, from this demo's directory:
@@ -45,7 +52,7 @@ glacier2router --Ice.Config=glacier2.conf
 Finally, in a separate terminal, start the client application:
 
 ```shell
-./gradlew :client:run --quiet
+./client/build/install/client/bin/client
 ```
 
 [Application plugin]: https://docs.gradle.org/current/userguide/application_plugin.html

--- a/java/Glacier2/session/README.md
+++ b/java/Glacier2/session/README.md
@@ -15,6 +15,10 @@ flowchart LR
 In a typical Glacier2 deployment, the client can establish a connection to the Glacier2 router but cannot establish
 a connection to the server, because the server is on a separate network.
 
+> [!NOTE]
+> On Windows, run all the commands below in Git Bash or PowerShell; not all of them work in the cmd.exe Command
+> Prompt.
+
 ## Ice prerequisites
 
 - Install Glacier2. See [Ice service installation].
@@ -26,15 +30,18 @@ The demo has two Gradle projects, **client** and **server**, both using the [app
 To build the demo, run:
 
 ```shell
-./gradlew build
+./gradlew installDist
 ```
+
+This creates a self-contained distribution under build/install/ for each application, with launcher scripts in its
+bin/ directory.
 
 ## Running the demo
 
 Start the Server program in its own terminal:
 
 ```shell
-./gradlew :server:run --quiet
+./server/build/install/server/bin/server
 ```
 
 Next, start the Glacier2 router in its own terminal, from this demo's directory:
@@ -49,9 +56,9 @@ glacier2router --Ice.Config=glacier2.conf
 Finally, in a separate terminal, run the client application several times:
 
 ```shell
-./gradlew :client:run --quiet --args="ash"
-./gradlew :client:run --quiet --args="ash"
-./gradlew :client:run --quiet --args="ash"
+./client/build/install/client/bin/client ash
+./client/build/install/client/bin/client ash
+./client/build/install/client/bin/client ash
 ```
 
 If you don't specify a name, the client uses the current username.

--- a/java/Ice/bidir/README.md
+++ b/java/Ice/bidir/README.md
@@ -13,6 +13,9 @@ flowchart LR
 
 This is particularly useful when the client application is behind a firewall that does not allow incoming connections.
 
+> [!NOTE]
+> On Windows, run all the commands below in Git Bash or PowerShell; they don't work in the cmd.exe Command Prompt.
+
 ## Building the demo
 
 The demo has two Gradle projects, **client** and **server**, both using the [application plugin].
@@ -20,21 +23,24 @@ The demo has two Gradle projects, **client** and **server**, both using the [app
 To build the demo, run:
 
 ```shell
-./gradlew build
+./gradlew installDist
 ```
+
+This creates a self-contained distribution under build/install/ for each application, with launcher scripts in its
+bin/ directory.
 
 ## Running the demo
 
 First, start the server application:
 
 ```shell
-./gradlew :server:run --quiet
+./server/build/install/server/bin/server
 ```
 
 Then, in a separate terminal, start the client application:
 
 ```shell
-./gradlew :client:run --quiet
+./client/build/install/client/bin/client
 ```
 
 [Application plugin]: https://docs.gradle.org/current/userguide/application_plugin.html

--- a/java/Ice/callback/README.md
+++ b/java/Ice/callback/README.md
@@ -11,6 +11,9 @@ flowchart LR
     s --connection2--> c
 ```
 
+> [!NOTE]
+> On Windows, run all the commands below in Git Bash or PowerShell; they don't work in the cmd.exe Command Prompt.
+
 ## Building the demo
 
 The demo has two Gradle projects, **client** and **server**, both using the [application plugin].
@@ -18,21 +21,24 @@ The demo has two Gradle projects, **client** and **server**, both using the [app
 To build the demo, run:
 
 ```shell
-./gradlew build
+./gradlew installDist
 ```
+
+This creates a self-contained distribution under build/install/ for each application, with launcher scripts in its
+bin/ directory.
 
 ## Running the demo
 
 First, start the server application:
 
 ```shell
-./gradlew :server:run --quiet
+./server/build/install/server/bin/server
 ```
 
 Then, in a separate terminal, start the client application:
 
 ```shell
-./gradlew :client:run --quiet
+./client/build/install/client/bin/client
 ```
 
 [Application plugin]: https://docs.gradle.org/current/userguide/application_plugin.html

--- a/java/Ice/cancellation/README.md
+++ b/java/Ice/cancellation/README.md
@@ -3,6 +3,9 @@
 The Cancellation demo shows how to cancel an invocation by interrupting the thread waiting for a response, or by
 cancelling the future returned by an async invocation. It also shows a related feature: invocation timeouts.
 
+> [!NOTE]
+> On Windows, run all the commands below in Git Bash or PowerShell; they don't work in the cmd.exe Command Prompt.
+
 ## Building the demo
 
 The demo has two Gradle projects, **client** and **server**, both using the [application plugin].
@@ -10,21 +13,24 @@ The demo has two Gradle projects, **client** and **server**, both using the [app
 To build the demo, run:
 
 ```shell
-./gradlew build
+./gradlew installDist
 ```
+
+This creates a self-contained distribution under build/install/ for each application, with launcher scripts in its
+bin/ directory.
 
 ## Running the demo
 
 First, start the server application:
 
 ```shell
-./gradlew :server:run --quiet
+./server/build/install/server/bin/server
 ```
 
 Then, in a separate terminal, start the client application:
 
 ```shell
-./gradlew :client:run --quiet --args="--Ice.Trace.Network"
+./client/build/install/client/bin/client --Ice.Trace.Network
 ```
 
 > [!NOTE]

--- a/java/Ice/config/README.md
+++ b/java/Ice/config/README.md
@@ -20,13 +20,13 @@ bin/ directory.
 
 ## Running the demo
 
-First, start the server application:
+First, start the server application from this demo's directory:
 
 ```shell
 ./server/build/install/server/bin/server
 ```
 
-Then, in a separate terminal, start the client application:
+Then, in a separate terminal, start the client application from this demo's directory:
 
 ```shell
 ./client/build/install/client/bin/client

--- a/java/Ice/config/README.md
+++ b/java/Ice/config/README.md
@@ -2,6 +2,9 @@
 
 This demo shows how to configure client and server applications using Ice configuration files.
 
+> [!NOTE]
+> On Windows, run all the commands below in Git Bash or PowerShell; they don't work in the cmd.exe Command Prompt.
+
 ## Building the demo
 
 The demo has two Gradle projects, **client** and **server**, both using the [application plugin].
@@ -9,21 +12,24 @@ The demo has two Gradle projects, **client** and **server**, both using the [app
 To build the demo, run:
 
 ```shell
-./gradlew build
+./gradlew installDist
 ```
+
+This creates a self-contained distribution under build/install/ for each application, with launcher scripts in its
+bin/ directory.
 
 ## Running the demo
 
 First, start the server application:
 
 ```shell
-./gradlew :server:run --quiet
+./server/build/install/server/bin/server
 ```
 
 Then, in a separate terminal, start the client application:
 
 ```shell
-./gradlew :client:run --quiet
+./client/build/install/client/bin/client
 ```
 
 [Application plugin]: https://docs.gradle.org/current/userguide/application_plugin.html

--- a/java/Ice/config/client.conf
+++ b/java/Ice/config/client.conf
@@ -1,10 +1,9 @@
 #
-# Object adapter configuration
+# Application-specific configuration
 #
 
-# Configure the GreeterAdapter adapter to listen on port 4061, on all interfaces.
-# `default` is replaced by the value of Ice.Default.Protocol.
-GreeterAdapter.Endpoints=default -p 4061
+# The address of the target object. `default` is replaced by the value of Ice.Default.Protocol.
+Greeter.Proxy=greeter:default -h localhost -p 4061
 
 #
 # Ice configuration
@@ -15,21 +14,17 @@ GreeterAdapter.Endpoints=default -p 4061
 # Make sure you use the same value in client.conf and server.conf.
 Ice.Default.Protocol=ssl
 
-# Turn on Network and Dispatch logging/tracing.
-Ice.Trace.Network=1
-Ice.Trace.Dispatch=1
-
 #
 # IceSSL configuration
 #
 
 # The directory where the application finds certificates and other files.
-IceSSL.DefaultDir=../../../../certs
+IceSSL.DefaultDir=../../../certs
 
-# The keystore containing this server's certificate.
-IceSSL.Keystore=server.p12
+# The keystore containing this client's certificate.
+IceSSL.Keystore=client.p12
 
-# The keystore the server uses to identify trusted peers.
+# The keystore the client uses to identify trusted peers.
 IceSSL.Truststore=ca.p12
 
 # The password used to read the keystores and decrypt the private key.
@@ -38,4 +33,4 @@ IceSSL.KeystorePassword=password
 IceSSL.TruststorePassword=password
 
 # Turn on security logging/tracing.
-IceSSL.Trace.Security=1
+# IceSSL.Trace.Security=1

--- a/java/Ice/config/server.conf
+++ b/java/Ice/config/server.conf
@@ -1,9 +1,10 @@
 #
-# Application-specific configuration
+# Object adapter configuration
 #
 
-# The address of the target object. `default` is replaced by the value of Ice.Default.Protocol.
-Greeter.Proxy=greeter:default -h localhost -p 4061
+# Configure the GreeterAdapter adapter to listen on port 4061, on all interfaces.
+# `default` is replaced by the value of Ice.Default.Protocol.
+GreeterAdapter.Endpoints=default -p 4061
 
 #
 # Ice configuration
@@ -14,17 +15,21 @@ Greeter.Proxy=greeter:default -h localhost -p 4061
 # Make sure you use the same value in client.conf and server.conf.
 Ice.Default.Protocol=ssl
 
+# Turn on Network and Dispatch logging/tracing.
+Ice.Trace.Network=1
+Ice.Trace.Dispatch=1
+
 #
 # IceSSL configuration
 #
 
 # The directory where the application finds certificates and other files.
-IceSSL.DefaultDir=../../../../certs
+IceSSL.DefaultDir=../../../certs
 
-# The keystore containing this client's certificate.
-IceSSL.Keystore=client.p12
+# The keystore containing this server's certificate.
+IceSSL.Keystore=server.p12
 
-# The keystore the client uses to identify trusted peers.
+# The keystore the server uses to identify trusted peers.
 IceSSL.Truststore=ca.p12
 
 # The password used to read the keystores and decrypt the private key.
@@ -33,4 +38,4 @@ IceSSL.KeystorePassword=password
 IceSSL.TruststorePassword=password
 
 # Turn on security logging/tracing.
-# IceSSL.Trace.Security=1
+IceSSL.Trace.Security=1

--- a/java/Ice/context/README.md
+++ b/java/Ice/context/README.md
@@ -10,26 +10,32 @@ is free to set any entry in this dictionary.
 
 ## Building the demo
 
+> [!NOTE]
+> On Windows, run all the commands below in Git Bash or PowerShell; they don't work in the cmd.exe Command Prompt.
+
 The demo has two Gradle projects, **client** and **server**, both using the [application plugin].
 
 To build the demo, run:
 
 ```shell
-./gradlew build
+./gradlew installDist
 ```
+
+This creates a self-contained distribution under build/install/ for each application, with launcher scripts in its
+bin/ directory.
 
 ## Running the demo
 
 First, start the server application:
 
 ```shell
-./gradlew :server:run --quiet
+./server/build/install/server/bin/server
 ```
 
 Then, in a separate terminal, start the client application:
 
 ```shell
-./gradlew :client:run --quiet
+./client/build/install/client/bin/client
 ```
 
 [Application plugin]: https://docs.gradle.org/current/userguide/application_plugin.html

--- a/java/Ice/customError/README.md
+++ b/java/Ice/customError/README.md
@@ -5,6 +5,9 @@ The Custom error demo shows how to define an exception in Slice, and how to thro
 A Slice-defined exception should be seen as a custom error carried by the response instead of the expected return
 value--there is naturally no throwing across the network.
 
+> [!NOTE]
+> On Windows, run all the commands below in Git Bash or PowerShell; they don't work in the cmd.exe Command Prompt.
+
 ## Building the demo
 
 The demo has two Gradle projects, **client** and **server**, both using the [application plugin].
@@ -12,21 +15,24 @@ The demo has two Gradle projects, **client** and **server**, both using the [app
 To build the demo, run:
 
 ```shell
-./gradlew build
+./gradlew installDist
 ```
+
+This creates a self-contained distribution under build/install/ for each application, with launcher scripts in its
+bin/ directory.
 
 ## Running the demo
 
 First, start the server application:
 
 ```shell
-./gradlew :server:run --quiet
+./server/build/install/server/bin/server
 ```
 
 Then, in a separate terminal, start the client application:
 
 ```shell
-./gradlew :client:run --quiet
+./client/build/install/client/bin/client
 ```
 
 [Application plugin]: https://docs.gradle.org/current/userguide/application_plugin.html

--- a/java/Ice/forwarder/README.md
+++ b/java/Ice/forwarder/README.md
@@ -17,6 +17,9 @@ flowchart LR
 The Forwarding server is generic and can be inserted between any client and server. In particular, the Forwarding server
 does not use any Slice generated code.
 
+> [!NOTE]
+> On Windows, run all the commands below in Git Bash or PowerShell; they don't work in the cmd.exe Command Prompt.
+
 ## Building the demo
 
 The demo has three Gradle projects, **client**, **forwardingserver** and **server**, all using the [application plugin].
@@ -24,27 +27,30 @@ The demo has three Gradle projects, **client**, **forwardingserver** and **serve
 To build the demo, run:
 
 ```shell
-./gradlew build
+./gradlew installDist
 ```
+
+This creates a self-contained distribution under build/install/ for each application, with launcher scripts in its
+bin/ directory.
 
 ## Running the demo
 
 First, start the server application:
 
 ```shell
-./gradlew :server:run --quiet --args="--Ice.Trace.Dispatch"
+./server/build/install/server/bin/server --Ice.Trace.Dispatch
 ```
 
 Next, in a separate terminal, start the forwarding server application:
 
 ```shell
-./gradlew :forwardingserver:run --quiet --args="--Ice.Trace.Dispatch"
+./forwardingserver/build/install/forwardingserver/bin/forwardingserver --Ice.Trace.Dispatch
 ```
 
 Finally, in a separate terminal, start the client application:
 
 ```shell
-./gradlew :client:run --quiet --args="--Ice.Trace.Network"
+./client/build/install/client/bin/client --Ice.Trace.Network
 ```
 
 [Application plugin]: https://docs.gradle.org/current/userguide/application_plugin.html

--- a/java/Ice/inheritance/README.md
+++ b/java/Ice/inheritance/README.md
@@ -2,6 +2,9 @@
 
 The Inheritance demo shows how to write a simple filesystem application using interface inheritance.
 
+> [!NOTE]
+> On Windows, run all the commands below in Git Bash or PowerShell; they don't work in the cmd.exe Command Prompt.
+
 ## Building the demo
 
 The demo has two Gradle projects, **client** and **server**, both using the [application plugin].
@@ -9,21 +12,24 @@ The demo has two Gradle projects, **client** and **server**, both using the [app
 To build the demo, run:
 
 ```shell
-./gradlew build
+./gradlew installDist
 ```
+
+This creates a self-contained distribution under build/install/ for each application, with launcher scripts in its
+bin/ directory.
 
 ## Running the demo
 
 First, start the server application:
 
 ```shell
-./gradlew :server:run --quiet
+./server/build/install/server/bin/server
 ```
 
 Then, in a separate terminal, start the client application:
 
 ```shell
-./gradlew :client:run --quiet
+./client/build/install/client/bin/client
 ```
 
 [Application plugin]: https://docs.gradle.org/current/userguide/application_plugin.html

--- a/java/Ice/middleware/README.md
+++ b/java/Ice/middleware/README.md
@@ -18,26 +18,32 @@ flowchart LR
 
 ## Building the demo
 
+> [!NOTE]
+> On Windows, run all the commands below in Git Bash or PowerShell; they don't work in the cmd.exe Command Prompt.
+
 The demo has two Gradle projects, **client** and **server**, both using the [application plugin].
 
 To build the demo, run:
 
 ```shell
-./gradlew build
+./gradlew installDist
 ```
+
+This creates a self-contained distribution under build/install/ for each application, with launcher scripts in its
+bin/ directory.
 
 ## Running the demo
 
 First, start the server application:
 
 ```shell
-./gradlew :server:run --quiet
+./server/build/install/server/bin/server
 ```
 
 Then, in a separate terminal, start the client application:
 
 ```shell
-./gradlew :client:run --quiet
+./client/build/install/client/bin/client
 ```
 
 [Application plugin]: https://docs.gradle.org/current/userguide/application_plugin.html

--- a/java/Ice/optional/README.md
+++ b/java/Ice/optional/README.md
@@ -22,6 +22,9 @@ class AtmosphericConditions
 }
 ```
 
+> [!NOTE]
+> On Windows, run all the commands below in Git Bash or PowerShell; they don't work in the cmd.exe Command Prompt.
+
 ## Building the demo
 
 The demo has four Gradle projects, all using the [application plugin].
@@ -34,33 +37,36 @@ The demo has four Gradle projects, all using the [application plugin].
 To build the demo, run:
 
 ```shell
-./gradlew build
+./gradlew installDist
 ```
+
+This creates a self-contained distribution under build/install/ for each application, with launcher scripts in its
+bin/ directory.
 
 ## Running the demo
 
 First, start either version 1 or version 2 of the server in its own terminal:
 
 ```shell
-./gradlew :server1:run --quiet
+./server1/build/install/server1/bin/server1
 ```
 
 or
 
 ```shell
-./gradlew :server2:run --quiet
+./server2/build/install/server2/bin/server2
 ```
 
 Then, in a separate terminal, run version 1 and then version 2 of the Client:
 
 ```shell
-./gradlew :client1:run --quiet
+./client1/build/install/client1/bin/client1
 ```
 
 and
 
 ```shell
-./gradlew :client2:run --quiet
+./client2/build/install/client2/bin/client2
 ```
 
 Thanks to `optional`, version 1 and version 2 of the clients and servers interoperate seamlessly:

--- a/java/Ice/secure/README.md
+++ b/java/Ice/secure/README.md
@@ -2,6 +2,9 @@
 
 This demo illustrates how to programmatically configure client and server applications to use SSL secure connections.
 
+> [!NOTE]
+> On Windows, run all the commands below in Git Bash or PowerShell; they don't work in the cmd.exe Command Prompt.
+
 ## Building the demo
 
 The demo has two Gradle projects, **client** and **server**, both using the [application plugin].
@@ -9,25 +12,28 @@ The demo has two Gradle projects, **client** and **server**, both using the [app
 To build the demo, run:
 
 ```shell
-./gradlew build
+./gradlew installDist
 ```
+
+This creates a self-contained distribution under build/install/ for each application, with launcher scripts in its
+bin/ directory.
 
 ## Running the demo
 
 First, start the server application:
 
 ```shell
-./gradlew :server:run --quiet --args="--Ice.Trace.Network"
+./server/build/install/server/bin/server --Ice.Trace.Network
 ```
 
 Then, in a separate terminal, start the client application:
 
 ```shell
-./gradlew :client:run --quiet --args="--Ice.Trace.Network"
+./client/build/install/client/bin/client --Ice.Trace.Network
 ```
 
 [Application plugin]: https://docs.gradle.org/current/userguide/application_plugin.html
 
 > [!NOTE]
-> The `--args="--Ice.Trace.Network"` command-line option turns on Network tracing. For this demo, it shows you that the
+> The `--Ice.Trace.Network` command-line option turns on Network tracing. For this demo, it shows you that the
 > requests are sent using the `ssl` secure transport.

--- a/java/Ice/secure/client/build.gradle.kts
+++ b/java/Ice/secure/client/build.gradle.kts
@@ -22,6 +22,12 @@ sourceSets {
         slice {
             srcDirs("../slice")
         }
+
+        // Package the CA certificate keystore from the top-level certs directory into the application JAR.
+        resources {
+            srcDir("../../../../certs")
+            include("ca.p12")
+        }
     }
 }
 

--- a/java/Ice/secure/client/src/main/java/com/example/ice/secure/client/Client.java
+++ b/java/Ice/secure/client/src/main/java/com/example/ice/secure/client/Client.java
@@ -2,7 +2,6 @@
 
 package com.example.ice.secure.client;
 
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.security.KeyManagementException;
 import java.security.KeyStore;
@@ -42,8 +41,8 @@ class Client {
     /**
      * Creates and initializes an SSLContext for use with the ssl transport.
      *
-     * <p>The SSLContext is configured with the demo CA certificate loaded from a PKCS12 keystore,
-     * which is used as the trust store to validate server certificates.
+     * <p>The SSLContext is configured with the demo CA certificate loaded from a PKCS12 keystore bundled with the
+     * application, which is used as the trust store to validate server certificates.
      *
      * @return the initialized SSLContext
      * @throws RuntimeException if an error occurs during SSL initialization
@@ -52,14 +51,14 @@ class Client {
         try {
             SSLContext sslContext = SSLContext.getInstance("TLS");
             KeyStore keyStore = KeyStore.getInstance("PKCS12");
-            String keyStorePath = "../../../../certs/ca.p12";
 
             // The password for the PKCS12 keystore, hard-coded for simplicity.
             // In a production environment, use a secure method to store and retrieve this password.
             char[] password = "password".toCharArray();
 
-            try (var input = new FileInputStream(keyStorePath)) {
-                keyStore.load(input, password);
+            // The build bundles ca.p12 (from the top-level certs directory) into the application JAR.
+            try (var caCert = Client.class.getResourceAsStream("/ca.p12")) {
+                keyStore.load(caCert, password);
             }
             TrustManagerFactory trustManagerFactory =
                 TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());

--- a/java/Ice/secure/server/build.gradle.kts
+++ b/java/Ice/secure/server/build.gradle.kts
@@ -22,6 +22,12 @@ sourceSets {
         slice {
             srcDirs("../slice")
         }
+
+        // Package the server's keystore from the top-level certs directory into the application JAR.
+        resources {
+            srcDir("../../../../certs")
+            include("server.p12")
+        }
     }
 }
 

--- a/java/Ice/secure/server/src/main/java/com/example/ice/secure/server/Server.java
+++ b/java/Ice/secure/server/src/main/java/com/example/ice/secure/server/Server.java
@@ -2,7 +2,6 @@
 
 package com.example.ice.secure.server;
 
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.security.KeyManagementException;
 import java.security.KeyStore;
@@ -60,7 +59,7 @@ final class Server {
      * Creates and initializes an SSLContext for use with the SSL transport.
      *
      * <p>The SSLContext is configured with the server's certificate and private key, loaded from a PKCS12 keystore
-     * used as the key store to provide the server credentials.
+     * bundled with the application and used as the key store to provide the server credentials.
      *
      * @return the initialized SSLContext
      * @throws RuntimeException if an error occurs during SSL initialization
@@ -69,14 +68,14 @@ final class Server {
         try {
             SSLContext sslContext = SSLContext.getInstance("TLS");
             KeyStore keyStore = KeyStore.getInstance("PKCS12");
-            String keyStorePath = "../../../../certs/server.p12";
 
             // The password for the PKCS12 keystore, hard-coded for simplicity.
             // In a production environment, use a secure method to store and retrieve this password.
             char[] password = "password".toCharArray();
 
-            try (var input = new FileInputStream(keyStorePath)) {
-                keyStore.load(input, password);
+            // The build bundles server.p12 (from the top-level certs directory) into the application JAR.
+            try (var serverCred = Server.class.getResourceAsStream("/server.p12")) {
+                keyStore.load(serverCred, password);
             }
             KeyManagerFactory keyManagerFactory =
                 KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());

--- a/java/IceBox/greeter/README.md
+++ b/java/IceBox/greeter/README.md
@@ -2,6 +2,9 @@
 
 This demo shows how to create an IceBox service in Java.
 
+> [!NOTE]
+> On Windows, run all the commands below in Git Bash or PowerShell; they don't work in the cmd.exe Command Prompt.
+
 ## Building the demo
 
 The demo consists of three Gradle projects:
@@ -16,21 +19,24 @@ The demo consists of three Gradle projects:
 To build the demo, run:
 
 ```shell
-./gradlew build
+./gradlew installDist
 ```
+
+This creates a self-contained distribution under build/install/ for each application, with launcher scripts in its
+bin/ directory.
 
 ## Running the demo
 
 First, start the IceBox server:
 
 ```shell
-./gradlew :iceboxserver:run --quiet --args="--IceBox.Service.Greeter=com.example.icebox.greeter.service.GreeterService --Ice.Trace.Dispatch"
+./iceboxserver/build/install/iceboxserver/bin/iceboxserver --IceBox.Service.Greeter=com.example.icebox.greeter.service.GreeterService --Ice.Trace.Dispatch
 ```
 
 Then, in a separate terminal, start the client application:
 
 ```shell
-./gradlew :client:run --quiet
+./client/build/install/client/bin/client
 ```
 
 [application plugin]: https://docs.gradle.org/current/userguide/application_plugin.html

--- a/java/IceDiscovery/greeter/README.md
+++ b/java/IceDiscovery/greeter/README.md
@@ -3,6 +3,9 @@
 This demo illustrates how to configure the IceDiscovery plug-in. The IceDiscovery plug-in allows a client application
 to discover Ice objects without hardcoding any addressing information.
 
+> [!NOTE]
+> On Windows, run all the commands below in Git Bash or PowerShell; they don't work in the cmd.exe Command Prompt.
+
 ## Building the demo
 
 The demo has two Gradle projects, **client** and **server**, both using the [application plugin].
@@ -10,21 +13,24 @@ The demo has two Gradle projects, **client** and **server**, both using the [app
 To build the demo, run:
 
 ```shell
-./gradlew build
+./gradlew installDist
 ```
+
+This creates a self-contained distribution under build/install/ for each application, with launcher scripts in its
+bin/ directory.
 
 ## Running the demo
 
 First, start the server application:
 
 ```shell
-./gradlew :server:run --quiet
+./server/build/install/server/bin/server
 ```
 
 Then, in a separate terminal, start the client application:
 
 ```shell
-./gradlew :client:run --quiet
+./client/build/install/client/bin/client
 ```
 
 [Application plugin]: https://docs.gradle.org/current/userguide/application_plugin.html

--- a/java/IceDiscovery/replication/README.md
+++ b/java/IceDiscovery/replication/README.md
@@ -33,7 +33,7 @@ Then, in a separate terminal, start the client application:
 ./client/build/install/client/bin/client --Ice.Trace.Locator
 ```
 
->[!NOTE]
+> [!NOTE]
 > The `--Ice.Trace.Locator` command-line option is optional: it turns on tracing (logging) for locator resolution and
 > helps you understand the locator logic implemented by the IceDiscovery plug-in.
 

--- a/java/IceDiscovery/replication/README.md
+++ b/java/IceDiscovery/replication/README.md
@@ -3,6 +3,9 @@
 This demo illustrates how to configure the IceDiscovery plug-in. The IceDiscovery plug-in allows a client application
 to discover Ice objects without hardcoding any addressing information.
 
+> [!NOTE]
+> On Windows, run all the commands below in Git Bash or PowerShell; they don't work in the cmd.exe Command Prompt.
+
 ## Building the demo
 
 The demo has two Gradle projects, **client** and **server**, both using the [application plugin].
@@ -10,21 +13,24 @@ The demo has two Gradle projects, **client** and **server**, both using the [app
 To build the demo, run:
 
 ```shell
-./gradlew build
+./gradlew installDist
 ```
+
+This creates a self-contained distribution under build/install/ for each application, with launcher scripts in its
+bin/ directory.
 
 ## Running the demo
 
 First, start two or more server applications, each in its own terminal:
 
 ```shell
-./gradlew :server:run --quiet --args="--Ice.Trace.Locator"
+./server/build/install/server/bin/server --Ice.Trace.Locator
 ```
 
 Then, in a separate terminal, start the client application:
 
 ```shell
-./gradlew :client:run --quiet --args="--Ice.Trace.Locator"
+./client/build/install/client/bin/client --Ice.Trace.Locator
 ```
 
 >[!NOTE]

--- a/java/IceGrid/greeter/README.md
+++ b/java/IceGrid/greeter/README.md
@@ -40,7 +40,7 @@ Each distribution includes:
 - a bin/ directory with start scripts, and
 - a lib/ directory containing the application JAR and all its runtime dependencies.
 
-In our IceGrid deployment, we call java directly and set the class path to include everything in the distribution’s lib/
+In our IceGrid deployment, we call java directly and set the classpath to include everything in the distribution’s lib/
 directory. This ensures both the server JAR and its dependencies (such as Ice) are available at runtime.
 
 ## Running the demo

--- a/java/IceGrid/greeter/greeter-hall-with-replication.xml
+++ b/java/IceGrid/greeter/greeter-hall-with-replication.xml
@@ -11,7 +11,7 @@
       <!-- An instance of this template is a server with ID GreetServer-${index}. IceGrid starts this server when a
       client looks up an object adapter or a well-known object in this server or in a replica group it references. -->
       <server id="GreetServer-${index}" exe="java" activation="on-demand">
-        <!-- Add the server's runtime dependencies to the class path: the app's JAR and the Ice JAR.
+        <!-- Add the server's runtime dependencies to the classpath: the app's JAR and the Ice JAR.
         The Gradle Application plugin's installDist task copies all required JARs into:
 
           server/build/install/server/lib/

--- a/java/IceGrid/greeter/greeter-hall.xml
+++ b/java/IceGrid/greeter/greeter-hall.xml
@@ -9,7 +9,7 @@
       <!-- Describes the server deployed on node1. IceGrid starts this server when a client looks up an object adapter
       or a well-known object in this server. -->
       <server id="GreetServer" exe="java" activation="on-demand">
-        <!-- Add the server's runtime dependencies to the class path: the app's JAR and the Ice JAR.
+        <!-- Add the server's runtime dependencies to the classpath: the app's JAR and the Ice JAR.
         The Gradle Application plugin's installDist task copies all required JARs into:
 
           server/build/install/server/lib/

--- a/java/IceGrid/icebox/README.md
+++ b/java/IceGrid/icebox/README.md
@@ -2,6 +2,10 @@
 
 The IceGrid IceBox demo illustrates how to deploy an IceBox server with IceGrid.
 
+> [!NOTE]
+> On Windows, run all the commands below in Git Bash or PowerShell; not all of them work in the cmd.exe Command
+> Prompt.
+
 ## Ice prerequisites
 
 - Install IceGrid. See [Ice service installation].
@@ -29,7 +33,7 @@ Each distribution includes:
 - a bin/ directory with start scripts, and
 - a lib/ directory containing the application JAR and all its runtime dependencies.
 
-In our IceGrid deployment, we call java directly and set the class path to include everything in the distribution’s lib/
+In our IceGrid deployment, we call java directly and set the classpath to include everything in the distribution’s lib/
 directory. This ensures both the server JAR and its dependencies (such as Ice) are available at runtime.
 
 ## Running the demo
@@ -55,8 +59,9 @@ icegridadmin --Ice.Config=admin.conf -e "application add greeter-hall.xml"
 Finally, run the client application:
 
 ```shell
-./gradlew :client:run --quiet
+./client/build/install/client/bin/client
 ```
 
 [Application plugin]: https://docs.gradle.org/current/userguide/application_plugin.html
 [Ice service installation]: https://github.com/zeroc-ice/ice/blob/main/NIGHTLY.md#ice-services
+[java-library plugin]: https://docs.gradle.org/current/userguide/java_library_plugin.html

--- a/java/IceGrid/icebox/greeter-hall.xml
+++ b/java/IceGrid/icebox/greeter-hall.xml
@@ -9,7 +9,7 @@
       <!-- Describes the servers deployed on node1. IceGrid starts this server when a client looks up an object adapter
       or a well-known object in this server. Here, we deploy a single IceBox server named "IceBox". -->
       <icebox id="IceBox" activation="on-demand" exe="java">
-        <!-- Add the IceBox server's, and the Greeter service runtime dependencies to the class path.
+        <!-- Add the IceBox server's, and the Greeter service runtime dependencies to the classpath.
 
         The Gradle Application plugin's installDist task copies all required JARs into:
 

--- a/java/IceGrid/locatorDiscovery/README.md
+++ b/java/IceGrid/locatorDiscovery/README.md
@@ -7,7 +7,8 @@ This demo provides a client application that works with the IceGrid/greeter demo
 IceGrid configuration.
 
 > [!NOTE]
-> On Windows, run all the commands below in Git Bash or PowerShell; they don't work in the cmd.exe Command Prompt.
+> On Windows, run all the commands below in Git Bash or PowerShell; not all of them work in the cmd.exe Command
+> Prompt.
 
 ## Ice prerequisites
 

--- a/java/IceGrid/locatorDiscovery/README.md
+++ b/java/IceGrid/locatorDiscovery/README.md
@@ -6,6 +6,9 @@ LocatorDiscovery plug-in.
 This demo provides a client application that works with the IceGrid/greeter demo and reuses its server components and
 IceGrid configuration.
 
+> [!NOTE]
+> On Windows, run all the commands below in Git Bash or PowerShell; they don't work in the cmd.exe Command Prompt.
+
 ## Ice prerequisites
 
 - Install IceGrid. See [Ice service installation].
@@ -17,8 +20,11 @@ The demo has a single Gradle project **client** that uses the [application plugi
 To build the demo, run:
 
 ```shell
-./gradlew build
+./gradlew installDist
 ```
+
+This creates a self-contained distribution under build/install/ for the client application, with launcher scripts in
+its bin/ directory.
 
 ## Running the demo
 
@@ -30,7 +36,7 @@ instructions.
 Then, in a separate terminal, start the client application:
 
 ```shell
-./gradlew :client:run --quiet
+./client/build/install/client/bin/client
 ```
 
 [Ice service installation]: https://github.com/zeroc-ice/ice/blob/main/NIGHTLY.md#ice-services

--- a/java/IceGrid/query/README.md
+++ b/java/IceGrid/query/README.md
@@ -2,6 +2,10 @@
 
 This demo shows how to use the Query object provided by the IceGrid registry to look up a well-known object by type.
 
+> [!NOTE]
+> On Windows, run all the commands below in Git Bash or PowerShell; not all of them work in the cmd.exe Command
+> Prompt.
+
 ## Ice prerequisites
 
 - Install IceGrid. See [Ice service installation].
@@ -22,7 +26,7 @@ Each distribution includes:
 - a bin/ directory with start scripts, and
 - a lib/ directory containing the application JAR and all its runtime dependencies.
 
-In our IceGrid deployment, we call java directly and set the class path to include everything in the distribution’s lib/
+In our IceGrid deployment, we call java directly and set the classpath to include everything in the distribution’s lib/
 directory. This ensures both the server JAR and its dependencies (such as Ice) are available at runtime.
 
 ## Running the demo
@@ -48,7 +52,7 @@ icegridadmin --Ice.Config=admin.conf -e "application add greeter-hall.xml"
 Finally, run the client application:
 
 ```shell
-./gradlew :client:run --quiet
+./client/build/install/client/bin/client
 ```
 
 [Application plugin]: https://docs.gradle.org/current/userguide/application_plugin.html

--- a/java/IceGrid/query/greeter-hall.xml
+++ b/java/IceGrid/query/greeter-hall.xml
@@ -11,7 +11,7 @@
       <!-- An instance of this template is a server with ID GreetServer-${index}. IceGrid starts this server when a
       client looks up an object adapter or a well-known object in this server. -->
       <server id="GreetServer-${index}" exe="java" activation="on-demand">
-        <!-- Add the server's runtime dependencies to the class path: the app's JAR and the Ice JAR.
+        <!-- Add the server's runtime dependencies to the classpath: the app's JAR and the Ice JAR.
         The Gradle Application plugin's installDist task copies all required JARs into:
 
           server/build/install/server/lib/

--- a/java/IceStorm/weather/README.md
+++ b/java/IceStorm/weather/README.md
@@ -13,6 +13,10 @@ flowchart LR
     icestorm --report--> s3[Station #3]
 ```
 
+> [!NOTE]
+> On Windows, run all the commands below in Git Bash or PowerShell; not all of them work in the cmd.exe Command
+> Prompt.
+
 ## Ice prerequisites
 
 - Install IceStorm. See [Ice service installation].
@@ -24,8 +28,11 @@ The demo has two Gradle projects, **sensor** and **station**, both using the [ap
 To build the demo, run:
 
 ```shell
-./gradlew build
+./gradlew installDist
 ```
+
+This creates a self-contained distribution under build/install/ for each application, with launcher scripts in its
+bin/ directory.
 
 ## Running the demo
 
@@ -38,11 +45,11 @@ icebox --IceBox.Service.IceStorm="IceStormService,39a0:createIceStorm --Ice.Conf
 Then, run one or more sensors and weather stations, each in its own terminal. You can start them in any order.
 
 ```shell
-./gradlew :sensor:run
+./sensor/build/install/sensor/bin/sensor
 ```
 
 ```shell
-./gradlew :station:run
+./station/build/install/station/bin/station
 ```
 
 [Application plugin]: https://docs.gradle.org/current/userguide/application_plugin.html


### PR DESCRIPTION
Implements the proposal in #868 for all remaining Java demos, following the model established in #872 for the Greeter demos:

- Build with `./gradlew installDist` and run the applications via the generated launcher scripts instead of `gradlew run`, unwrapping `--args="…"` into plain arguments.
- Each README keeps a single set of commands with a note telling Windows users to run them in Git Bash or PowerShell — the "not all of them work in cmd" variant for demos that also run Ice services (`glacier2router`, `icegridregistry`, `icebox`), which do work in cmd.
- In `Ice/context` and `Ice/middleware`, the note sits under the "Building the demo" heading instead of before it, because those intros already end with a NOTE block and stacking two blockquotes trips markdownlint MD028.

Running the launchers attaches the application JVM to the terminal, so Ctrl+C reaches the application and the shutdown hooks display their messages (#413).

Drive-by cleanups:

- Standardize on "classpath" (over "class path") in the IceGrid READMEs and deployment descriptors.
- Add the missing `java-library plugin` link definition in the IceGrid/icebox README.
- Fix the `Ice/secure` note that still referred to the `--args="--Ice.Trace.Network"` wrapper.

Verified locally: `installDist` builds and the launcher paths match in `IceBox/greeter`, `IceStorm/weather`, and `Ice/optional` (no project overrides the default application name, so the paths generalize), plus an end-to-end run of `Ice/optional` via the launchers, including the server's "Caught Ctrl+C, shutting down..." message on termination — the exact behavior #413 reported missing. Markdownlint passes with the CI invocation.

Closes #868.
Closes #413.

🤖 Generated with [Claude Code](https://claude.com/claude-code)