### PR TITLE
Fix the runtime DLL copy on CMake < 3.26

### DIFF
--- a/cpp/DataStorm/customEncoding/CMakeLists.txt
+++ b/cpp/DataStorm/customEncoding/CMakeLists.txt
@@ -8,9 +8,10 @@ add_executable(reader Reader.cpp TimePoint.h)
 target_link_libraries(reader PRIVATE Ice::Ice Ice::DataStorm)
 if(WIN32)
   add_custom_command(TARGET reader POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:reader>
+    COMMAND ${CMAKE_COMMAND} -E copy
       $<TARGET_RUNTIME_DLLS:reader>
       $<GENEX_EVAL:$<TARGET_PROPERTY:Ice::Ice,ICE_RUNTIME_DLLS>>
+      $<TARGET_FILE_DIR:reader>
     COMMAND_EXPAND_LISTS
   )
   ice_copy_pdbs(reader)
@@ -20,9 +21,10 @@ add_executable(writer Writer.cpp TimePoint.h)
 target_link_libraries(writer PRIVATE Ice::Ice Ice::DataStorm)
 if(WIN32)
   add_custom_command(TARGET writer POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:writer>
+    COMMAND ${CMAKE_COMMAND} -E copy
       $<TARGET_RUNTIME_DLLS:writer>
       $<GENEX_EVAL:$<TARGET_PROPERTY:Ice::Ice,ICE_RUNTIME_DLLS>>
+      $<TARGET_FILE_DIR:writer>
     COMMAND_EXPAND_LISTS
   )
   ice_copy_pdbs(writer)

--- a/cpp/DataStorm/greeter/CMakeLists.txt
+++ b/cpp/DataStorm/greeter/CMakeLists.txt
@@ -8,9 +8,10 @@ add_executable(reader Reader.cpp)
 target_link_libraries(reader PRIVATE Ice::Ice Ice::DataStorm)
 if(WIN32)
   add_custom_command(TARGET reader POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:reader>
+    COMMAND ${CMAKE_COMMAND} -E copy
       $<TARGET_RUNTIME_DLLS:reader>
       $<GENEX_EVAL:$<TARGET_PROPERTY:Ice::Ice,ICE_RUNTIME_DLLS>>
+      $<TARGET_FILE_DIR:reader>
     COMMAND_EXPAND_LISTS
   )
   ice_copy_pdbs(reader)
@@ -20,9 +21,10 @@ add_executable(writer Writer.cpp)
 target_link_libraries(writer PRIVATE Ice::Ice Ice::DataStorm)
 if(WIN32)
   add_custom_command(TARGET writer POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:writer>
+    COMMAND ${CMAKE_COMMAND} -E copy
       $<TARGET_RUNTIME_DLLS:writer>
       $<GENEX_EVAL:$<TARGET_PROPERTY:Ice::Ice,ICE_RUNTIME_DLLS>>
+      $<TARGET_FILE_DIR:writer>
     COMMAND_EXPAND_LISTS
   )
   ice_copy_pdbs(writer)

--- a/cpp/DataStorm/keyFilter/CMakeLists.txt
+++ b/cpp/DataStorm/keyFilter/CMakeLists.txt
@@ -8,9 +8,10 @@ add_executable(reader Reader.cpp)
 target_link_libraries(reader PRIVATE Ice::Ice Ice::DataStorm)
 if(WIN32)
   add_custom_command(TARGET reader POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:reader>
+    COMMAND ${CMAKE_COMMAND} -E copy
       $<TARGET_RUNTIME_DLLS:reader>
       $<GENEX_EVAL:$<TARGET_PROPERTY:Ice::Ice,ICE_RUNTIME_DLLS>>
+      $<TARGET_FILE_DIR:reader>
     COMMAND_EXPAND_LISTS
   )
   ice_copy_pdbs(reader)
@@ -20,9 +21,10 @@ add_executable(writer Writer.cpp)
 target_link_libraries(writer PRIVATE Ice::Ice Ice::DataStorm)
 if(WIN32)
   add_custom_command(TARGET writer POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:writer>
+    COMMAND ${CMAKE_COMMAND} -E copy
       $<TARGET_RUNTIME_DLLS:writer>
       $<GENEX_EVAL:$<TARGET_PROPERTY:Ice::Ice,ICE_RUNTIME_DLLS>>
+      $<TARGET_FILE_DIR:writer>
     COMMAND_EXPAND_LISTS
   )
   ice_copy_pdbs(writer)

--- a/cpp/DataStorm/node/CMakeLists.txt
+++ b/cpp/DataStorm/node/CMakeLists.txt
@@ -8,9 +8,10 @@ add_executable(reader Reader.cpp)
 target_link_libraries(reader PRIVATE Ice::Ice Ice::DataStorm)
 if(WIN32)
   add_custom_command(TARGET reader POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:reader>
+    COMMAND ${CMAKE_COMMAND} -E copy
       $<TARGET_RUNTIME_DLLS:reader>
       $<GENEX_EVAL:$<TARGET_PROPERTY:Ice::Ice,ICE_RUNTIME_DLLS>>
+      $<TARGET_FILE_DIR:reader>
     COMMAND_EXPAND_LISTS
   )
   ice_copy_pdbs(reader)
@@ -20,9 +21,10 @@ add_executable(writer Writer.cpp)
 target_link_libraries(writer PRIVATE Ice::Ice Ice::DataStorm)
 if(WIN32)
   add_custom_command(TARGET writer POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:writer>
+    COMMAND ${CMAKE_COMMAND} -E copy
       $<TARGET_RUNTIME_DLLS:writer>
       $<GENEX_EVAL:$<TARGET_PROPERTY:Ice::Ice,ICE_RUNTIME_DLLS>>
+      $<TARGET_FILE_DIR:writer>
     COMMAND_EXPAND_LISTS
   )
   ice_copy_pdbs(writer)

--- a/cpp/DataStorm/sampleFilter/CMakeLists.txt
+++ b/cpp/DataStorm/sampleFilter/CMakeLists.txt
@@ -9,9 +9,10 @@ slice2cpp_generate(reader)
 target_link_libraries(reader PRIVATE Ice::Ice Ice::DataStorm)
 if(WIN32)
   add_custom_command(TARGET reader POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:reader>
+    COMMAND ${CMAKE_COMMAND} -E copy
       $<TARGET_RUNTIME_DLLS:reader>
       $<GENEX_EVAL:$<TARGET_PROPERTY:Ice::Ice,ICE_RUNTIME_DLLS>>
+      $<TARGET_FILE_DIR:reader>
     COMMAND_EXPAND_LISTS
   )
   ice_copy_pdbs(reader)
@@ -22,9 +23,10 @@ slice2cpp_generate(writer)
 target_link_libraries(writer PRIVATE Ice::Ice Ice::DataStorm)
 if(WIN32)
   add_custom_command(TARGET writer POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:writer>
+    COMMAND ${CMAKE_COMMAND} -E copy
       $<TARGET_RUNTIME_DLLS:writer>
       $<GENEX_EVAL:$<TARGET_PROPERTY:Ice::Ice,ICE_RUNTIME_DLLS>>
+      $<TARGET_FILE_DIR:writer>
     COMMAND_EXPAND_LISTS
   )
   ice_copy_pdbs(writer)

--- a/cpp/DataStorm/stock/CMakeLists.txt
+++ b/cpp/DataStorm/stock/CMakeLists.txt
@@ -13,9 +13,10 @@ slice2cpp_generate(reader)
 target_link_libraries(reader PRIVATE Ice::Ice Ice::DataStorm)
 if(WIN32)
   add_custom_command(TARGET reader POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:reader>
+    COMMAND ${CMAKE_COMMAND} -E copy
       $<TARGET_RUNTIME_DLLS:reader>
       $<GENEX_EVAL:$<TARGET_PROPERTY:Ice::Ice,ICE_RUNTIME_DLLS>>
+      $<TARGET_FILE_DIR:reader>
     COMMAND_EXPAND_LISTS
   )
   ice_copy_pdbs(reader)
@@ -26,9 +27,10 @@ slice2cpp_generate(writer)
 target_link_libraries(writer PRIVATE Ice::Ice Ice::DataStorm)
 if(WIN32)
   add_custom_command(TARGET writer POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:writer>
+    COMMAND ${CMAKE_COMMAND} -E copy
       $<TARGET_RUNTIME_DLLS:writer>
       $<GENEX_EVAL:$<TARGET_PROPERTY:Ice::Ice,ICE_RUNTIME_DLLS>>
+      $<TARGET_FILE_DIR:writer>
     COMMAND_EXPAND_LISTS
   )
   ice_copy_pdbs(writer)

--- a/cpp/Glacier2/callback/CMakeLists.txt
+++ b/cpp/Glacier2/callback/CMakeLists.txt
@@ -9,9 +9,10 @@ slice2cpp_generate(client)
 target_link_libraries(client PRIVATE Ice::Ice Ice::Glacier2)
 if(WIN32)
   add_custom_command(TARGET client POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:client>
+    COMMAND ${CMAKE_COMMAND} -E copy
       $<TARGET_RUNTIME_DLLS:client>
       $<GENEX_EVAL:$<TARGET_PROPERTY:Ice::Ice,ICE_RUNTIME_DLLS>>
+      $<TARGET_FILE_DIR:client>
     COMMAND_EXPAND_LISTS
   )
   ice_copy_pdbs(client)
@@ -22,9 +23,10 @@ slice2cpp_generate(server)
 target_link_libraries(server PRIVATE Ice::Ice)
 if(WIN32)
   add_custom_command(TARGET server POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:server>
+    COMMAND ${CMAKE_COMMAND} -E copy
       $<TARGET_RUNTIME_DLLS:server>
       $<GENEX_EVAL:$<TARGET_PROPERTY:Ice::Ice,ICE_RUNTIME_DLLS>>
+      $<TARGET_FILE_DIR:server>
     COMMAND_EXPAND_LISTS
   )
   ice_copy_pdbs(server)

--- a/cpp/Glacier2/greeter/CMakeLists.txt
+++ b/cpp/Glacier2/greeter/CMakeLists.txt
@@ -9,9 +9,10 @@ slice2cpp_generate(client)
 target_link_libraries(client PRIVATE Ice::Ice Ice::Glacier2)
 if(WIN32)
   add_custom_command(TARGET client POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:client>
+    COMMAND ${CMAKE_COMMAND} -E copy
       $<TARGET_RUNTIME_DLLS:client>
       $<GENEX_EVAL:$<TARGET_PROPERTY:Ice::Ice,ICE_RUNTIME_DLLS>>
+      $<TARGET_FILE_DIR:client>
     COMMAND_EXPAND_LISTS
   )
   ice_copy_pdbs(client)
@@ -22,9 +23,10 @@ slice2cpp_generate(server)
 target_link_libraries(server PRIVATE Ice::Ice)
 if(WIN32)
   add_custom_command(TARGET server POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:server>
+    COMMAND ${CMAKE_COMMAND} -E copy
       $<TARGET_RUNTIME_DLLS:server>
       $<GENEX_EVAL:$<TARGET_PROPERTY:Ice::Ice,ICE_RUNTIME_DLLS>>
+      $<TARGET_FILE_DIR:server>
     COMMAND_EXPAND_LISTS
   )
   ice_copy_pdbs(server)

--- a/cpp/Glacier2/session/CMakeLists.txt
+++ b/cpp/Glacier2/session/CMakeLists.txt
@@ -10,9 +10,10 @@ slice2cpp_generate(client)
 target_link_libraries(client PRIVATE Ice::Ice Ice::Glacier2)
 if(WIN32)
   add_custom_command(TARGET client POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:client>
+    COMMAND ${CMAKE_COMMAND} -E copy
       $<TARGET_RUNTIME_DLLS:client>
       $<GENEX_EVAL:$<TARGET_PROPERTY:Ice::Ice,ICE_RUNTIME_DLLS>>
+      $<TARGET_FILE_DIR:client>
     COMMAND_EXPAND_LISTS
   )
   ice_copy_pdbs(client)
@@ -37,9 +38,10 @@ slice2cpp_generate(server)
 target_link_libraries(server PRIVATE Ice::Ice Ice::Glacier2)
 if(WIN32)
   add_custom_command(TARGET server POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:server>
+    COMMAND ${CMAKE_COMMAND} -E copy
       $<TARGET_RUNTIME_DLLS:server>
       $<GENEX_EVAL:$<TARGET_PROPERTY:Ice::Ice,ICE_RUNTIME_DLLS>>
+      $<TARGET_FILE_DIR:server>
     COMMAND_EXPAND_LISTS
   )
   ice_copy_pdbs(server)

--- a/cpp/Ice/bidir/CMakeLists.txt
+++ b/cpp/Ice/bidir/CMakeLists.txt
@@ -9,9 +9,10 @@ slice2cpp_generate(client)
 target_link_libraries(client PRIVATE Ice::Ice)
 if(WIN32)
   add_custom_command(TARGET client POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:client>
+    COMMAND ${CMAKE_COMMAND} -E copy
       $<TARGET_RUNTIME_DLLS:client>
       $<GENEX_EVAL:$<TARGET_PROPERTY:Ice::Ice,ICE_RUNTIME_DLLS>>
+      $<TARGET_FILE_DIR:client>
     COMMAND_EXPAND_LISTS
   )
   ice_copy_pdbs(client)
@@ -22,9 +23,10 @@ slice2cpp_generate(server)
 target_link_libraries(server PRIVATE Ice::Ice)
 if(WIN32)
   add_custom_command(TARGET server POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:server>
+    COMMAND ${CMAKE_COMMAND} -E copy
       $<TARGET_RUNTIME_DLLS:server>
       $<GENEX_EVAL:$<TARGET_PROPERTY:Ice::Ice,ICE_RUNTIME_DLLS>>
+      $<TARGET_FILE_DIR:server>
     COMMAND_EXPAND_LISTS
   )
   ice_copy_pdbs(server)

--- a/cpp/Ice/callback/CMakeLists.txt
+++ b/cpp/Ice/callback/CMakeLists.txt
@@ -9,9 +9,10 @@ slice2cpp_generate(client)
 target_link_libraries(client PRIVATE Ice::Ice)
 if(WIN32)
   add_custom_command(TARGET client POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:client>
+    COMMAND ${CMAKE_COMMAND} -E copy
       $<TARGET_RUNTIME_DLLS:client>
       $<GENEX_EVAL:$<TARGET_PROPERTY:Ice::Ice,ICE_RUNTIME_DLLS>>
+      $<TARGET_FILE_DIR:client>
     COMMAND_EXPAND_LISTS
   )
   ice_copy_pdbs(client)
@@ -22,9 +23,10 @@ slice2cpp_generate(server)
 target_link_libraries(server PRIVATE Ice::Ice)
 if(WIN32)
   add_custom_command(TARGET server POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:server>
+    COMMAND ${CMAKE_COMMAND} -E copy
       $<TARGET_RUNTIME_DLLS:server>
       $<GENEX_EVAL:$<TARGET_PROPERTY:Ice::Ice,ICE_RUNTIME_DLLS>>
+      $<TARGET_FILE_DIR:server>
     COMMAND_EXPAND_LISTS
   )
   ice_copy_pdbs(server)

--- a/cpp/Ice/cancellation/CMakeLists.txt
+++ b/cpp/Ice/cancellation/CMakeLists.txt
@@ -9,9 +9,10 @@ slice2cpp_generate(client)
 target_link_libraries(client PRIVATE Ice::Ice)
 if(WIN32)
   add_custom_command(TARGET client POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:client>
+    COMMAND ${CMAKE_COMMAND} -E copy
       $<TARGET_RUNTIME_DLLS:client>
       $<GENEX_EVAL:$<TARGET_PROPERTY:Ice::Ice,ICE_RUNTIME_DLLS>>
+      $<TARGET_FILE_DIR:client>
     COMMAND_EXPAND_LISTS
   )
   ice_copy_pdbs(client)
@@ -22,9 +23,10 @@ slice2cpp_generate(server)
 target_link_libraries(server PRIVATE Ice::Ice)
 if(WIN32)
   add_custom_command(TARGET server POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:server>
+    COMMAND ${CMAKE_COMMAND} -E copy
       $<TARGET_RUNTIME_DLLS:server>
       $<GENEX_EVAL:$<TARGET_PROPERTY:Ice::Ice,ICE_RUNTIME_DLLS>>
+      $<TARGET_FILE_DIR:server>
     COMMAND_EXPAND_LISTS
   )
   ice_copy_pdbs(server)

--- a/cpp/Ice/config/CMakeLists.txt
+++ b/cpp/Ice/config/CMakeLists.txt
@@ -9,9 +9,10 @@ slice2cpp_generate(client)
 target_link_libraries(client PRIVATE Ice::Ice)
 if(WIN32)
   add_custom_command(TARGET client POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:client>
+    COMMAND ${CMAKE_COMMAND} -E copy
       $<TARGET_RUNTIME_DLLS:client>
       $<GENEX_EVAL:$<TARGET_PROPERTY:Ice::Ice,ICE_RUNTIME_DLLS>>
+      $<TARGET_FILE_DIR:client>
     COMMAND_EXPAND_LISTS
   )
   ice_copy_pdbs(client)
@@ -22,9 +23,10 @@ slice2cpp_generate(server)
 target_link_libraries(server PRIVATE Ice::Ice)
 if(WIN32)
   add_custom_command(TARGET server POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:server>
+    COMMAND ${CMAKE_COMMAND} -E copy
       $<TARGET_RUNTIME_DLLS:server>
       $<GENEX_EVAL:$<TARGET_PROPERTY:Ice::Ice,ICE_RUNTIME_DLLS>>
+      $<TARGET_FILE_DIR:server>
     COMMAND_EXPAND_LISTS
   )
   ice_copy_pdbs(server)

--- a/cpp/Ice/context/CMakeLists.txt
+++ b/cpp/Ice/context/CMakeLists.txt
@@ -9,9 +9,10 @@ slice2cpp_generate(client)
 target_link_libraries(client PRIVATE Ice::Ice)
 if(WIN32)
   add_custom_command(TARGET client POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:client>
+    COMMAND ${CMAKE_COMMAND} -E copy
       $<TARGET_RUNTIME_DLLS:client>
       $<GENEX_EVAL:$<TARGET_PROPERTY:Ice::Ice,ICE_RUNTIME_DLLS>>
+      $<TARGET_FILE_DIR:client>
     COMMAND_EXPAND_LISTS
   )
   ice_copy_pdbs(client)
@@ -22,9 +23,10 @@ slice2cpp_generate(server)
 target_link_libraries(server PRIVATE Ice::Ice)
 if(WIN32)
   add_custom_command(TARGET server POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:server>
+    COMMAND ${CMAKE_COMMAND} -E copy
       $<TARGET_RUNTIME_DLLS:server>
       $<GENEX_EVAL:$<TARGET_PROPERTY:Ice::Ice,ICE_RUNTIME_DLLS>>
+      $<TARGET_FILE_DIR:server>
     COMMAND_EXPAND_LISTS
   )
   ice_copy_pdbs(server)

--- a/cpp/Ice/customError/CMakeLists.txt
+++ b/cpp/Ice/customError/CMakeLists.txt
@@ -9,9 +9,10 @@ slice2cpp_generate(client)
 target_link_libraries(client PRIVATE Ice::Ice)
 if(WIN32)
   add_custom_command(TARGET client POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:client>
+    COMMAND ${CMAKE_COMMAND} -E copy
       $<TARGET_RUNTIME_DLLS:client>
       $<GENEX_EVAL:$<TARGET_PROPERTY:Ice::Ice,ICE_RUNTIME_DLLS>>
+      $<TARGET_FILE_DIR:client>
     COMMAND_EXPAND_LISTS
   )
   ice_copy_pdbs(client)
@@ -22,9 +23,10 @@ slice2cpp_generate(server)
 target_link_libraries(server PRIVATE Ice::Ice)
 if(WIN32)
   add_custom_command(TARGET server POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:server>
+    COMMAND ${CMAKE_COMMAND} -E copy
       $<TARGET_RUNTIME_DLLS:server>
       $<GENEX_EVAL:$<TARGET_PROPERTY:Ice::Ice,ICE_RUNTIME_DLLS>>
+      $<TARGET_FILE_DIR:server>
     COMMAND_EXPAND_LISTS
   )
   ice_copy_pdbs(server)

--- a/cpp/Ice/forwarder/CMakeLists.txt
+++ b/cpp/Ice/forwarder/CMakeLists.txt
@@ -9,9 +9,10 @@ slice2cpp_generate(client)
 target_link_libraries(client PRIVATE Ice::Ice)
 if(WIN32)
   add_custom_command(TARGET client POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:client>
+    COMMAND ${CMAKE_COMMAND} -E copy
     $<TARGET_RUNTIME_DLLS:client>
     $<GENEX_EVAL:$<TARGET_PROPERTY:Ice::Ice,ICE_RUNTIME_DLLS>>
+    $<TARGET_FILE_DIR:client>
     COMMAND_EXPAND_LISTS
   )
   ice_copy_pdbs(client)
@@ -22,9 +23,10 @@ slice2cpp_generate(server)
 target_link_libraries(server PRIVATE Ice::Ice)
 if(WIN32)
   add_custom_command(TARGET server POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:server>
+    COMMAND ${CMAKE_COMMAND} -E copy
     $<TARGET_RUNTIME_DLLS:server>
     $<GENEX_EVAL:$<TARGET_PROPERTY:Ice::Ice,ICE_RUNTIME_DLLS>>
+    $<TARGET_FILE_DIR:server>
     COMMAND_EXPAND_LISTS
   )
   ice_copy_pdbs(server)
@@ -34,9 +36,10 @@ add_executable(forwardingserver Forwarder.cpp Forwarder.h ForwardingServer.cpp)
 target_link_libraries(forwardingserver PRIVATE Ice::Ice)
 if(WIN32)
   add_custom_command(TARGET forwardingserver POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:forwardingserver>
+    COMMAND ${CMAKE_COMMAND} -E copy
       $<TARGET_RUNTIME_DLLS:forwardingserver>
       $<GENEX_EVAL:$<TARGET_PROPERTY:Ice::Ice,ICE_RUNTIME_DLLS>>
+      $<TARGET_FILE_DIR:forwardingserver>
     COMMAND_EXPAND_LISTS
   )
   ice_copy_pdbs(forwardingserver)

--- a/cpp/Ice/greeter/CMakeLists.txt
+++ b/cpp/Ice/greeter/CMakeLists.txt
@@ -9,9 +9,10 @@ slice2cpp_generate(client)
 target_link_libraries(client PRIVATE Ice::Ice)
 if(WIN32)
   add_custom_command(TARGET client POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:client>
+    COMMAND ${CMAKE_COMMAND} -E copy
       $<TARGET_RUNTIME_DLLS:client>
       $<GENEX_EVAL:$<TARGET_PROPERTY:Ice::Ice,ICE_RUNTIME_DLLS>>
+      $<TARGET_FILE_DIR:client>
     COMMAND_EXPAND_LISTS
   )
   ice_copy_pdbs(client)
@@ -22,9 +23,10 @@ slice2cpp_generate(server)
 target_link_libraries(server PRIVATE Ice::Ice)
 if(WIN32)
   add_custom_command(TARGET server POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:server>
+    COMMAND ${CMAKE_COMMAND} -E copy
       $<TARGET_RUNTIME_DLLS:server>
       $<GENEX_EVAL:$<TARGET_PROPERTY:Ice::Ice,ICE_RUNTIME_DLLS>>
+      $<TARGET_FILE_DIR:server>
     COMMAND_EXPAND_LISTS
   )
   ice_copy_pdbs(server)
@@ -35,9 +37,10 @@ slice2cpp_generate(serveramd)
 target_link_libraries(serveramd PRIVATE Ice::Ice)
 if(WIN32)
   add_custom_command(TARGET serveramd POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:serveramd>
+    COMMAND ${CMAKE_COMMAND} -E copy
       $<TARGET_RUNTIME_DLLS:serveramd>
       $<GENEX_EVAL:$<TARGET_PROPERTY:Ice::Ice,ICE_RUNTIME_DLLS>>
+      $<TARGET_FILE_DIR:serveramd>
     COMMAND_EXPAND_LISTS
   )
   ice_copy_pdbs(serveramd)

--- a/cpp/Ice/inheritance/CMakeLists.txt
+++ b/cpp/Ice/inheritance/CMakeLists.txt
@@ -9,9 +9,10 @@ slice2cpp_generate(client)
 target_link_libraries(client PRIVATE Ice::Ice)
 if(WIN32)
   add_custom_command(TARGET client POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:client>
+    COMMAND ${CMAKE_COMMAND} -E copy
       $<TARGET_RUNTIME_DLLS:client>
       $<GENEX_EVAL:$<TARGET_PROPERTY:Ice::Ice,ICE_RUNTIME_DLLS>>
+      $<TARGET_FILE_DIR:client>
     COMMAND_EXPAND_LISTS
   )
   ice_copy_pdbs(client)
@@ -22,9 +23,10 @@ slice2cpp_generate(server)
 target_link_libraries(server PRIVATE Ice::Ice)
 if(WIN32)
   add_custom_command(TARGET server POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:server>
+    COMMAND ${CMAKE_COMMAND} -E copy
       $<TARGET_RUNTIME_DLLS:server>
       $<GENEX_EVAL:$<TARGET_PROPERTY:Ice::Ice,ICE_RUNTIME_DLLS>>
+      $<TARGET_FILE_DIR:server>
     COMMAND_EXPAND_LISTS
   )
   ice_copy_pdbs(server)

--- a/cpp/Ice/middleware/CMakeLists.txt
+++ b/cpp/Ice/middleware/CMakeLists.txt
@@ -9,9 +9,10 @@ slice2cpp_generate(client)
 target_link_libraries(client PRIVATE Ice::Ice)
 if(WIN32)
   add_custom_command(TARGET client POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:client>
+    COMMAND ${CMAKE_COMMAND} -E copy
     $<TARGET_RUNTIME_DLLS:client>
     $<GENEX_EVAL:$<TARGET_PROPERTY:Ice::Ice,ICE_RUNTIME_DLLS>>
+    $<TARGET_FILE_DIR:client>
     COMMAND_EXPAND_LISTS
   )
   ice_copy_pdbs(client)
@@ -26,9 +27,10 @@ slice2cpp_generate(server)
 target_link_libraries(server PRIVATE Ice::Ice)
 if(WIN32)
   add_custom_command(TARGET server POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:server>
+    COMMAND ${CMAKE_COMMAND} -E copy
     $<TARGET_RUNTIME_DLLS:server>
     $<GENEX_EVAL:$<TARGET_PROPERTY:Ice::Ice,ICE_RUNTIME_DLLS>>
+    $<TARGET_FILE_DIR:server>
     COMMAND_EXPAND_LISTS
   )
   ice_copy_pdbs(server)

--- a/cpp/Ice/optional/CMakeLists.txt
+++ b/cpp/Ice/optional/CMakeLists.txt
@@ -9,9 +9,10 @@ slice2cpp_generate(client1)
 target_link_libraries(client1 PRIVATE Ice::Ice)
 if(WIN32)
   add_custom_command(TARGET client1 POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:client1>
+    COMMAND ${CMAKE_COMMAND} -E copy
       $<TARGET_RUNTIME_DLLS:client1>
       $<GENEX_EVAL:$<TARGET_PROPERTY:Ice::Ice,ICE_RUNTIME_DLLS>>
+      $<TARGET_FILE_DIR:client1>
     COMMAND_EXPAND_LISTS
   )
   ice_copy_pdbs(client1)
@@ -22,9 +23,10 @@ slice2cpp_generate(client2)
 target_link_libraries(client2 PRIVATE Ice::Ice)
 if(WIN32)
   add_custom_command(TARGET client2 POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:client2>
+    COMMAND ${CMAKE_COMMAND} -E copy
       $<TARGET_RUNTIME_DLLS:client2>
       $<GENEX_EVAL:$<TARGET_PROPERTY:Ice::Ice,ICE_RUNTIME_DLLS>>
+      $<TARGET_FILE_DIR:client2>
     COMMAND_EXPAND_LISTS
   )
   ice_copy_pdbs(client2)
@@ -35,9 +37,10 @@ slice2cpp_generate(server1)
 target_link_libraries(server1 PRIVATE Ice::Ice)
 if(WIN32)
   add_custom_command(TARGET server1 POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:server1>
+    COMMAND ${CMAKE_COMMAND} -E copy
       $<TARGET_RUNTIME_DLLS:server1>
       $<GENEX_EVAL:$<TARGET_PROPERTY:Ice::Ice,ICE_RUNTIME_DLLS>>
+      $<TARGET_FILE_DIR:server1>
     COMMAND_EXPAND_LISTS
   )
   ice_copy_pdbs(server1)
@@ -48,9 +51,10 @@ slice2cpp_generate(server2)
 target_link_libraries(server2 PRIVATE Ice::Ice)
 if(WIN32)
   add_custom_command(TARGET server2 POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:server2>
+    COMMAND ${CMAKE_COMMAND} -E copy
       $<TARGET_RUNTIME_DLLS:server2>
       $<GENEX_EVAL:$<TARGET_PROPERTY:Ice::Ice,ICE_RUNTIME_DLLS>>
+      $<TARGET_FILE_DIR:server2>
     COMMAND_EXPAND_LISTS
   )
   ice_copy_pdbs(server2)

--- a/cpp/Ice/secure/CMakeLists.txt
+++ b/cpp/Ice/secure/CMakeLists.txt
@@ -19,9 +19,10 @@ slice2cpp_generate(client)
 target_link_libraries(client PRIVATE Ice::Ice)
 if(WIN32)
   add_custom_command(TARGET client POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:client>
+    COMMAND ${CMAKE_COMMAND} -E copy
     $<TARGET_RUNTIME_DLLS:client>
     $<GENEX_EVAL:$<TARGET_PROPERTY:Ice::Ice,ICE_RUNTIME_DLLS>>
+    $<TARGET_FILE_DIR:client>
     COMMAND_EXPAND_LISTS
   )
   ice_copy_pdbs(client)
@@ -50,9 +51,10 @@ slice2cpp_generate(server)
 target_link_libraries(server PRIVATE Ice::Ice)
 if(WIN32)
   add_custom_command(TARGET server POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:server>
+    COMMAND ${CMAKE_COMMAND} -E copy
     $<TARGET_RUNTIME_DLLS:server>
     $<GENEX_EVAL:$<TARGET_PROPERTY:Ice::Ice,ICE_RUNTIME_DLLS>>
+    $<TARGET_FILE_DIR:server>
     COMMAND_EXPAND_LISTS
   )
   ice_copy_pdbs(server)

--- a/cpp/IceBox/greeter/CMakeLists.txt
+++ b/cpp/IceBox/greeter/CMakeLists.txt
@@ -9,9 +9,10 @@ slice2cpp_generate(client)
 target_link_libraries(client PRIVATE Ice::Ice)
 if(WIN32)
   add_custom_command(TARGET client POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:client>
+    COMMAND ${CMAKE_COMMAND} -E copy
       $<TARGET_RUNTIME_DLLS:client>
       $<GENEX_EVAL:$<TARGET_PROPERTY:Ice::Ice,ICE_RUNTIME_DLLS>>
+      $<TARGET_FILE_DIR:client>
     COMMAND_EXPAND_LISTS
   )
   ice_copy_pdbs(client)
@@ -23,14 +24,16 @@ target_link_libraries(GreeterService PRIVATE Ice::Ice Ice::IceBox)
 if(WIN32)
   set_target_properties(GreeterService PROPERTIES DEBUG_POSTFIX "d")
   add_custom_command(TARGET GreeterService POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:GreeterService>
+    COMMAND ${CMAKE_COMMAND} -E copy
       $<TARGET_RUNTIME_DLLS:GreeterService>
       $<GENEX_EVAL:$<TARGET_PROPERTY:Ice::Ice,ICE_RUNTIME_DLLS>>
+      $<TARGET_FILE_DIR:GreeterService>
     COMMAND_EXPAND_LISTS
   )
   add_custom_command(TARGET GreeterService POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:GreeterService>
+    COMMAND ${CMAKE_COMMAND} -E copy
       $<TARGET_FILE:Ice::icebox_EXE>
+      $<TARGET_FILE_DIR:GreeterService>
   )
   ice_copy_pdbs(GreeterService)
 endif()

--- a/cpp/IceDiscovery/greeter/CMakeLists.txt
+++ b/cpp/IceDiscovery/greeter/CMakeLists.txt
@@ -9,9 +9,10 @@ slice2cpp_generate(client)
 target_link_libraries(client PRIVATE Ice::Ice Ice::IceDiscovery)
 if(WIN32)
   add_custom_command(TARGET client POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:client>
+    COMMAND ${CMAKE_COMMAND} -E copy
     $<TARGET_RUNTIME_DLLS:client>
     $<GENEX_EVAL:$<TARGET_PROPERTY:Ice::Ice,ICE_RUNTIME_DLLS>>
+    $<TARGET_FILE_DIR:client>
     COMMAND_EXPAND_LISTS
   )
   ice_copy_pdbs(client)
@@ -22,9 +23,10 @@ slice2cpp_generate(server)
 target_link_libraries(server PRIVATE Ice::Ice Ice::IceDiscovery)
 if(WIN32)
   add_custom_command(TARGET server POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:server>
+    COMMAND ${CMAKE_COMMAND} -E copy
     $<TARGET_RUNTIME_DLLS:server>
     $<GENEX_EVAL:$<TARGET_PROPERTY:Ice::Ice,ICE_RUNTIME_DLLS>>
+    $<TARGET_FILE_DIR:server>
     COMMAND_EXPAND_LISTS
   )
   ice_copy_pdbs(server)

--- a/cpp/IceDiscovery/replication/CMakeLists.txt
+++ b/cpp/IceDiscovery/replication/CMakeLists.txt
@@ -9,9 +9,10 @@ slice2cpp_generate(client)
 target_link_libraries(client PRIVATE Ice::Ice Ice::IceDiscovery)
 if(WIN32)
   add_custom_command(TARGET client POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:client>
+    COMMAND ${CMAKE_COMMAND} -E copy
       $<TARGET_RUNTIME_DLLS:client>
       $<GENEX_EVAL:$<TARGET_PROPERTY:Ice::Ice,ICE_RUNTIME_DLLS>>
+      $<TARGET_FILE_DIR:client>
     COMMAND_EXPAND_LISTS
   )
   ice_copy_pdbs(client)
@@ -22,9 +23,10 @@ slice2cpp_generate(server)
 target_link_libraries(server PRIVATE Ice::Ice Ice::IceDiscovery)
 if(WIN32)
   add_custom_command(TARGET server POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:server>
+    COMMAND ${CMAKE_COMMAND} -E copy
       $<TARGET_RUNTIME_DLLS:server>
       $<GENEX_EVAL:$<TARGET_PROPERTY:Ice::Ice,ICE_RUNTIME_DLLS>>
+      $<TARGET_FILE_DIR:server>
     COMMAND_EXPAND_LISTS
   )
   ice_copy_pdbs(server)

--- a/cpp/IceGrid/greeter/CMakeLists.txt
+++ b/cpp/IceGrid/greeter/CMakeLists.txt
@@ -9,9 +9,10 @@ slice2cpp_generate(client)
 target_link_libraries(client PRIVATE Ice::Ice)
 if(WIN32)
   add_custom_command(TARGET client POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:client>
+    COMMAND ${CMAKE_COMMAND} -E copy
       $<TARGET_RUNTIME_DLLS:client>
       $<GENEX_EVAL:$<TARGET_PROPERTY:Ice::Ice,ICE_RUNTIME_DLLS>>
+      $<TARGET_FILE_DIR:client>
     COMMAND_EXPAND_LISTS
   )
   ice_copy_pdbs(client)
@@ -22,9 +23,10 @@ slice2cpp_generate(server)
 target_link_libraries(server PRIVATE Ice::Ice)
 if(WIN32)
   add_custom_command(TARGET server POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:server>
+    COMMAND ${CMAKE_COMMAND} -E copy
       $<TARGET_RUNTIME_DLLS:server>
       $<GENEX_EVAL:$<TARGET_PROPERTY:Ice::Ice,ICE_RUNTIME_DLLS>>
+      $<TARGET_FILE_DIR:server>
     COMMAND_EXPAND_LISTS
   )
   ice_copy_pdbs(server)

--- a/cpp/IceGrid/icebox/CMakeLists.txt
+++ b/cpp/IceGrid/icebox/CMakeLists.txt
@@ -9,9 +9,10 @@ slice2cpp_generate(client)
 target_link_libraries(client PRIVATE Ice::Ice)
 if(WIN32)
   add_custom_command(TARGET client POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:client>
+    COMMAND ${CMAKE_COMMAND} -E copy
       $<TARGET_RUNTIME_DLLS:client>
       $<GENEX_EVAL:$<TARGET_PROPERTY:Ice::Ice,ICE_RUNTIME_DLLS>>
+      $<TARGET_FILE_DIR:client>
     COMMAND_EXPAND_LISTS
   )
   ice_copy_pdbs(client)
@@ -23,14 +24,16 @@ target_link_libraries(GreeterService PRIVATE Ice::Ice Ice::IceBox)
 if(WIN32)
   set_target_properties(GreeterService PROPERTIES DEBUG_POSTFIX "d")
   add_custom_command(TARGET GreeterService POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:GreeterService>
+    COMMAND ${CMAKE_COMMAND} -E copy
       $<TARGET_RUNTIME_DLLS:GreeterService>
       $<GENEX_EVAL:$<TARGET_PROPERTY:Ice::Ice,ICE_RUNTIME_DLLS>>
+      $<TARGET_FILE_DIR:GreeterService>
     COMMAND_EXPAND_LISTS
   )
   add_custom_command(TARGET GreeterService POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:GreeterService>
+    COMMAND ${CMAKE_COMMAND} -E copy
       $<TARGET_FILE:Ice::icebox_EXE>
+      $<TARGET_FILE_DIR:GreeterService>
   )
   ice_copy_pdbs(GreeterService)
 endif()

--- a/cpp/IceGrid/locatorDiscovery/CMakeLists.txt
+++ b/cpp/IceGrid/locatorDiscovery/CMakeLists.txt
@@ -9,9 +9,10 @@ slice2cpp_generate(client)
 target_link_libraries(client PRIVATE Ice::Ice Ice::IceLocatorDiscovery)
 if(WIN32)
   add_custom_command(TARGET client POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:client>
+    COMMAND ${CMAKE_COMMAND} -E copy
       $<TARGET_RUNTIME_DLLS:client>
       $<GENEX_EVAL:$<TARGET_PROPERTY:Ice::Ice,ICE_RUNTIME_DLLS>>
+      $<TARGET_FILE_DIR:client>
     COMMAND_EXPAND_LISTS
   )
   ice_copy_pdbs(client)

--- a/cpp/IceGrid/query/CMakeLists.txt
+++ b/cpp/IceGrid/query/CMakeLists.txt
@@ -9,9 +9,10 @@ slice2cpp_generate(client)
 target_link_libraries(client PRIVATE Ice::Ice Ice::IceGrid Ice::Glacier2)
 if(WIN32)
   add_custom_command(TARGET client POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:client>
+    COMMAND ${CMAKE_COMMAND} -E copy
       $<TARGET_RUNTIME_DLLS:client>
       $<GENEX_EVAL:$<TARGET_PROPERTY:Ice::Ice,ICE_RUNTIME_DLLS>>
+      $<TARGET_FILE_DIR:client>
     COMMAND_EXPAND_LISTS
   )
   ice_copy_pdbs(client)
@@ -22,9 +23,10 @@ slice2cpp_generate(server)
 target_link_libraries(server PRIVATE Ice::Ice)
 if(WIN32)
   add_custom_command(TARGET server POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:server>
+    COMMAND ${CMAKE_COMMAND} -E copy
       $<TARGET_RUNTIME_DLLS:server>
       $<GENEX_EVAL:$<TARGET_PROPERTY:Ice::Ice,ICE_RUNTIME_DLLS>>
+      $<TARGET_FILE_DIR:server>
     COMMAND_EXPAND_LISTS
   )
   ice_copy_pdbs(server)

--- a/cpp/IceStorm/weather/CMakeLists.txt
+++ b/cpp/IceStorm/weather/CMakeLists.txt
@@ -9,9 +9,10 @@ slice2cpp_generate(sensor)
 target_link_libraries(sensor PRIVATE Ice::Ice Ice::IceStorm)
 if(WIN32)
   add_custom_command(TARGET sensor POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:sensor>
+    COMMAND ${CMAKE_COMMAND} -E copy
       $<TARGET_RUNTIME_DLLS:sensor>
       $<GENEX_EVAL:$<TARGET_PROPERTY:Ice::Ice,ICE_RUNTIME_DLLS>>
+      $<TARGET_FILE_DIR:sensor>
     COMMAND_EXPAND_LISTS
   )
   ice_copy_pdbs(sensor)
@@ -22,9 +23,10 @@ slice2cpp_generate(station)
 target_link_libraries(station PRIVATE Ice::Ice Ice::IceStorm)
 if(WIN32)
   add_custom_command(TARGET station POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:station>
+    COMMAND ${CMAKE_COMMAND} -E copy
       $<TARGET_RUNTIME_DLLS:station>
       $<GENEX_EVAL:$<TARGET_PROPERTY:Ice::Ice,ICE_RUNTIME_DLLS>>
+      $<TARGET_FILE_DIR:station>
     COMMAND_EXPAND_LISTS
   )
   ice_copy_pdbs(station)


### PR DESCRIPTION
The C++ demos copy runtime DLLs on Windows with `cmake -E copy -t <dir> <files...>`, but the `-t` argument was only added in CMake 3.26. Since these projects declare a CMake 3.21 minimum, configuring with CMake 3.21 through 3.25 produces a post-build copy step that treats `-t` as a source file and fails.

This replaces every occurrence with the destination-last form (`cmake -E copy <files...> <dir>`), which works with all supported CMake versions. Found while reviewing zeroc-ice/ice#6430, where the same snippet in the documentation was corrected.