### PR TITLE
Mention the platform SSL APIs in the Secure demo READMEs

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -5,6 +5,7 @@
         "Blobject",
         "icegrid",
         "pyright",
+        "Schannel",
         "signum",
         "visitorcenter",
         "zeroc"

--- a/cpp/Ice/secure/README.md
+++ b/cpp/Ice/secure/README.md
@@ -1,14 +1,15 @@
 # Ice Secure
 
-This demo shows how to programmatically configure the ssl transport in Ice C++ client and server applications.
+This demo illustrates how to set up secure connections programmatically: the client and server call the platform's
+native SSL API directly and rely on the test certificates from the shared `certs` directory.
 
-It demonstrates how the ssl transport can be configured using the platform's native SSL API:
+| Platform | Native SSL API   |
+| -------- | ---------------- |
+| Linux    | OpenSSL          |
+| Windows  | Schannel         |
+| macOS    | Secure Transport |
 
-- **OpenSSL** on Linux
-- **Schannel** on Windows
-- **Secure Transport** on macOS
-
-Because each platform provides a different SSL API, we implement the configuration logic for each one in a separate C++
+Because each platform provides a different SSL API, we implement the SSL setup code for each one in a separate C++
 source file to keep the code organized and modular:
 
 | File                        | Description                                             |

--- a/cpp/Ice/secure/README.md
+++ b/cpp/Ice/secure/README.md
@@ -15,13 +15,13 @@ source file to keep the code organized and modular:
 | File                        | Description                                             |
 | --------------------------- | ------------------------------------------------------- |
 | `ClientRun.cpp`             | Shared client-side logic used by all platform variants. |
-| `ClientOpenSSL.cpp`         | OpenSSL client configuration for Linux.                 |
-| `ClientSchannel.cpp`        | Schannel client configuration for Windows.              |
-| `ClientSecureTransport.cpp` | Secure Transport client configuration for macOS.        |
+| `ClientOpenSSL.cpp`         | OpenSSL client setup for Linux.                         |
+| `ClientSchannel.cpp`        | Schannel client setup for Windows.                      |
+| `ClientSecureTransport.cpp` | Secure Transport client setup for macOS.                |
 | `ServerRun.cpp`             | Shared server-side logic used by all platform variants. |
-| `ServerOpenSSL.cpp`         | OpenSSL server configuration for Linux.                 |
-| `ServerSchannel.cpp`        | Schannel server configuration for Windows.              |
-| `ServerSecureTransport.cpp` | Secure Transport server configuration for macOS.        |
+| `ServerOpenSSL.cpp`         | OpenSSL server setup for Linux.                         |
+| `ServerSchannel.cpp`        | Schannel server setup for Windows.                      |
+| `ServerSecureTransport.cpp` | Secure Transport server setup for macOS.                |
 | `UtilSchannel.cpp`          | Schannel helper functions.                              |
 | `UtilSecureTransport.cpp`   | Secure Transport helper functions.                      |
 

--- a/csharp/Ice/Secure/README.md
+++ b/csharp/Ice/Secure/README.md
@@ -1,6 +1,7 @@
 # Ice Secure
 
-This demo illustrates how to programmatically configure client and server applications to use SSL secure connections.
+This demo illustrates how to set up secure connections programmatically: the client and server call the .NET SSL API
+directly and rely on the test certificates from the shared `certs` directory.
 
 ## Building the demo
 

--- a/java/Ice/secure/README.md
+++ b/java/Ice/secure/README.md
@@ -1,6 +1,7 @@
 # Ice Secure
 
-This demo illustrates how to programmatically configure client and server applications to use SSL secure connections.
+This demo illustrates how to set up secure connections programmatically: the client and server call the Java SSL API
+(JSSE) directly and rely on the test certificates from the shared `certs` directory.
 
 > [!NOTE]
 > On Windows, run all the commands below in Git Bash or PowerShell; they don't work in the cmd.exe Command Prompt.


### PR DESCRIPTION
Fixes #848.

The C#, Java, and C++ Secure READMEs now open with the same sentence pattern: the demo sets up secure connections programmatically — the client and server call the platform's SSL API (.NET / JSSE / native) directly and rely on the test certificates from the shared `certs` directory. Individual API type names stay out of the README; you see them when you read the code.

In the C++ README, the platform bullet list became a small Platform / Native SSL API table, and two occurrences of "configuration" were reworded to keep that term reserved for Ice configuration, which this demo deliberately doesn't use.

The issue's note about Java certificate paths being relative to the Gradle subproject working directories is obsolete: since #873, the build bundles the certificates into the application JARs as resources. The suggested C++ working-directory note was dropped as redundant — the README's commands already run from the demo directory.

Also adds "Schannel" to the cspell word list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)