### PR TITLE
Add physical-device guidance to the Swift GreeterApp README

### DIFF
--- a/swift/Ice/GreeterApp/GreeterApp.xcodeproj/project.pbxproj
+++ b/swift/Ice/GreeterApp/GreeterApp.xcodeproj/project.pbxproj
@@ -278,6 +278,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSLocalNetworkUsageDescription = "This app connects to a Greeter server on your local network.";
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
@@ -318,6 +319,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSLocalNetworkUsageDescription = "This app connects to a Greeter server on your local network.";
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;

--- a/swift/Ice/GreeterApp/README.md
+++ b/swift/Ice/GreeterApp/README.md
@@ -15,3 +15,12 @@ The client is implemented using SwiftUI and can be run on **macOS**, the **iOS S
 > On the first build attempt, you may see the message:
 > _"Plugin “CompileSlice” from package “ice” must be enabled before it can be used."_
 > Click on the message in Xcode to enable the plugin.
+
+## Running on a physical iOS device
+
+On a physical iOS device, `localhost` refers to the device itself. In the Host field, enter the LAN address of the
+computer running the Greeter server (for example, `192.168.1.10`); the device and this computer must be on the same
+network.
+
+The first time the app connects, iOS asks for permission to find and connect to devices on your local network. Allow
+this request so the app can reach the Greeter server.

--- a/swift/Ice/GreeterApp/README.md
+++ b/swift/Ice/GreeterApp/README.md
@@ -18,9 +18,16 @@ The client is implemented using SwiftUI and can be run on **macOS**, the **iOS S
 
 ## Running on a physical iOS device
 
-On a physical iOS device, `localhost` refers to the device itself. In the Host field, enter the LAN address of the
-computer running the Greeter server (for example, `192.168.1.10`); the device and this computer must be on the same
-network.
+Before running on a physical device, connect it to your Mac, unlock it, and trust the Mac if prompted. Then add your
+Apple Account in **Xcode > Settings > Accounts** and select your team in the GreeterApp target's **Signing &
+Capabilities** tab — a free Personal Team is sufficient; Apple Developer Program membership is not required. If Xcode
+reports that `com.example.ice.GreeterApp` is not available, change the bundle identifier to a unique value.
+
+The device must run iOS 18.5 or later and have **Developer Mode** enabled (Settings > Privacy & Security > Developer
+Mode; enabling it restarts the device).
+
+On a physical iOS device, `localhost` refers to the device itself. In the Host field, enter the IP address of the
+computer running the Greeter server; the device and this computer must be on the same network.
 
 The first time the app connects, iOS asks for permission to find and connect to devices on your local network. Allow
 this request so the app can reach the Greeter server.


### PR DESCRIPTION
Fixes #850.

- README: new "Running on a physical iOS device" section — enter the LAN address of the computer running the Greeter server in the Host field, and allow the local-network permission prompt on first connect.
- Xcode project: set `INFOPLIST_KEY_NSLocalNetworkUsageDescription` in both target configurations so the generated Info.plist carries a proper local-network usage description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)