### PR TITLE
Document Android prerequisites and physical-device usage in android-greeter

### DIFF
--- a/java/Ice/android-greeter/README.md
+++ b/java/Ice/android-greeter/README.md
@@ -4,6 +4,11 @@ This demo illustrates how to create an Ice client application using Kotlin and I
 
 The demo provides a simple Android client that can be used with any of the Greeter servers included in this repository.
 
+## Prerequisites
+
+- Android Studio
+- An Android emulator or physical Android device running Android 14 (API level 34) or later
+
 ## Getting Started
 
 First, start a Greeter server implemented in a language with server-side support (C++, C#, Java, Python, or Swift), for
@@ -13,5 +18,7 @@ Then, open Android Studio and import the `java/Ice/android-greeter` project.
 You can run the application on either an Android emulator or a physical Android device.
 
 > [!NOTE]
-> The default IP address `10.0.2.2` is used to communicate with the host machine when running in the Android emulator.
-> If your Greeter server is running on a different host, be sure to update the IP address in the app accordingly.
+> The Server IP Address field defaults to `10.0.2.2`, the address the Android emulator uses to reach the computer it
+> runs on. This address only works in the emulator: on a physical Android device, enter the LAN address of the
+> computer running the Greeter server (for example, `192.168.1.10`); the device and this computer must be on the same
+> network.

--- a/java/Ice/android-greeter/README.md
+++ b/java/Ice/android-greeter/README.md
@@ -19,6 +19,5 @@ You can run the application on either an Android emulator or a physical Android 
 
 > [!NOTE]
 > The Server IP Address field defaults to `10.0.2.2`, the address the Android emulator uses to reach the computer it
-> runs on. This address only works in the emulator: on a physical Android device, enter the LAN address of the
-> computer running the Greeter server (for example, `192.168.1.10`); the device and this computer must be on the same
-> network.
+> runs on. This address only works in the emulator: on a physical Android device, enter the IP address of the
+> computer running the Greeter server; the device and this computer must be on the same network.


### PR DESCRIPTION
Fixes #851.

- Adds a Prerequisites section: Android Studio, and an emulator or physical device running Android 14 (API level 34) or later, per `minSdk` in the Gradle file.
- Rewrites the `10.0.2.2` note: this default in the Server IP Address field is emulator-only; on a physical Android device, enter the LAN address of the computer running the Greeter server (same network required).

The "concrete matching server path" ask is already covered by the existing link to the Java Greeter server in Getting Started.

🤖 Generated with [Claude Code](https://claude.com/claude-code)