### PR TITLE
Fix int64 overflow in Time::toTimeStamp

### DIFF
--- a/cpp/common/Time.h
+++ b/cpp/common/Time.h
@@ -4,6 +4,7 @@
 #define TIME_H
 
 #include <chrono>
+#include <cstdint>
 #include <ctime>
 #include <stdexcept>
 #include <string>
@@ -45,9 +46,10 @@ namespace Time
     {
         const int daysBeforeEpoch = 719'162;
 
-        std::int64_t timeStampMicro = std::chrono::duration_cast<std::chrono::microseconds>(
-                                          timePoint.time_since_epoch() + daysBeforeEpoch * std::chrono::hours{24})
-                                          .count();
+        std::int64_t timeStampMicro =
+            (std::chrono::duration_cast<std::chrono::microseconds>(timePoint.time_since_epoch()) +
+             daysBeforeEpoch * std::chrono::hours{24})
+                .count();
 
         // The time stamp is in ticks, where each tick is 100 nanoseconds = 0.1 microsecond.
         return timeStampMicro * 10;


### PR DESCRIPTION
`Time::toTimeStamp` adds the 719,162-day offset to `time_since_epoch()` before converting to microseconds, so the addition is performed in `system_clock::duration` units. On libstdc++ (Linux), where this duration is nanoseconds, the offset alone is about 6.7× `INT64_MAX`: the arithmetic overflows and the encoder produces an incorrect timestamp. A same-platform round trip mostly hides this because `toTimePoint` wraps back, but a peer that doesn't overflow (macOS, Windows, or the C#/Java demos) decodes the wrapped value faithfully.

The fix converts to microseconds before adding the offset. Also adds the missing `<cstdint>` include.

Since `Time.h` is shared, this affects the DataStorm/customEncoding, Ice/callback, Ice/bidir, and Glacier2/callback demos. Found by @pepone while reviewing #881.

🤖 Generated with [Claude Code](https://claude.com/claude-code)