### PR TITLE
Pin LF line endings for shell scripts in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,4 +7,5 @@
 
 # Set line endings: CRLF for Windows scripts, LF for Unix scripts
 *.bat text eol=crlf
+*.sh text eol=lf
 **/gradlew eol=lf


### PR DESCRIPTION
Adds `*.sh text eol=lf` to `.gitattributes` so Git-for-Windows checkouts with `core.autocrlf=true` don't bake CRLF into shell scripts such as `php/Ice/registeredCommunicator/entrypoint.sh`, which breaks the Docker container entrypoint.

Fixes #886.

🤖 Generated with [Claude Code](https://claude.com/claude-code)